### PR TITLE
Carry D-017 through every document that still ordered the phone first

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,8 +42,9 @@ Latency impact:
 
 ## Before you open this
 
-Tel-Agent is at **Milestone 0** — one real phone call, answered, message taken,
-transcript printed. Nothing else is being built yet.
+Tel-Agent is at **Milestone 0** — a visitor types on a web page, the agent answers,
+the thread holds, and the reply streams and can be cancelled. Nothing else is being
+built yet. The phone is Milestone 11.
 
 **Feature PRs will be pointed at [IDEAS.md](../IDEAS.md) rather than merged.** That is
 not a judgement on the idea; it is how this project stays finishable. Bug fixes,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,14 +50,16 @@ Build order inside Milestone 0. Do not start step N+1 before step N works:
 
 | # | Check | How you know it works |
 |---|---|---|
-| 1 | The number reaches us | The provider console shows the inbound call arriving at our SIP endpoint |
-| 2 | Answer the call | You call the number, it stops ringing, silence on the line |
-| 3 | Speak fixed text | It answers and says a hardcoded greeting |
-| 4 | Hear the caller | Your words appear as text in the terminal |
-| 5 | Full loop | You speak → LLM replies → you hear the reply |
+| 1 | The message reaches us | A message typed in a browser arrives at the agent process |
+| 2 | Answer it | It replies with a hardcoded greeting |
+| 3 | Understand it | The model's reply appears in the page, in the visitor's language |
+| 4 | Full loop | Visitor writes → LLM replies → visitor writes again, thread intact |
+| 5 | Stream and cancel | Tokens appear as produced, and stop instantly when cancelled |
 | 6 | Take a message | It asks for name and reason, prints a structured result |
 
-Steps 1–2 are plumbing. Step 5 is the product.
+Steps 1–2 are plumbing. Step 4 is the product, and step 5 is what protects the phone
+at Milestone 11: an agent that composes a whole answer before sending it can never be
+put on a call.
 
 **Before any code at all:** buy a number, point it at the SIP endpoint, call it from
 a mobile, and confirm in the provider console that the call arrives. If it does not,
@@ -168,7 +170,7 @@ Settled. Do not reopen without a concrete reason.
 | Runs as | Locally installed web app on the LAN — not a desktop app, not SaaS-only |
 | First test bed | A number from a SIP provider, pointed at the agent |
 | Number acquisition | Users bring their own number in v1. Reselling numbers belongs to Tel-Agent Cloud and never enters the open edition |
-| SIP in Milestone 0 | LiveKit Cloud SIP |
+| SIP at Milestone 11 | LiveKit Cloud SIP |
 | Theme | Dark and light, dark designed first |
 | Languages | en / de / ar from day one, RTL supported |
 | Analog lines | Out of scope — users bridge with an ATA; we only ever speak SIP |
@@ -177,27 +179,27 @@ Settled. Do not reopen without a concrete reason.
 
 ---
 
-## How SIP is handled in Milestone 0 — decided
+## How SIP is handled at Milestone 11 — decided
 
 **LiveKit Cloud SIP.** A number from a SIP provider points at a LiveKit Cloud SIP
 trunk; the agent connects to the room. Nothing runs locally except the one script.
 
 The objection to this option used to be that media leaves the LAN. That objection
-was written when Milestone 0 assumed an on-premises PBX on the same network. It no
-longer applies: with a provider number the audio crosses the internet either way,
-so the "same LAN, no NAT" property is not available to give up.
+was written when the phone milestone assumed an on-premises PBX on the same network.
+It no longer applies: with a provider number the audio crosses the internet either
+way, so the "same LAN, no NAT" property is not available to give up.
 
 The two rejected options, and why:
 
 - **Direct SIP** via `pjsua2` / `baresip` / `pyVoIP` — genuinely one script, but
-  turn-taking and barge-in get written by hand and thrown away at Milestone 1.
+  turn-taking and barge-in get written by hand and thrown away immediately after.
   Those two are the hardest part of the whole product; hand-rolling them to save
   a dependency is the wrong trade.
 - **LiveKit self-hosted** — correct eventually, and required for the on-premises
-  story. It costs two services running before the first call is answered, which
-  is exactly the delay Milestone 0 exists to prevent. It returns at Milestone 9.
+  story. It costs two services running before the first call is answered, which is
+  the delay this decision exists to avoid. It follows once calls are answered.
 
-**This is a Milestone 0 decision, not the product's architecture.** The shipped
+**This is a first-call decision, not the product's architecture.** The shipped
 product must still support a self-hosted media path — an installation whose audio
 is forced through a vendor's cloud contradicts the reason this project exists.
 Anything written now must sit behind the interfaces in §B3, so that swapping the
@@ -244,7 +246,7 @@ Competitive notes belong in , which is gitignored and never published.
   the database and the key. Database dumps, backups and read replicas are where
   credentials actually leak
 - Milestone 0 is the exception — no database exists yet, so everything is in `.env`.
-  This ends at Milestone 2. Never build a settings screen that writes to `.env`
+  This ends at Milestone 1. Never build a settings screen that writes to `.env`
 - Never log a key, never commit one, never return one in full to a client — the UI
   shows a masked preview with the last four characters
 - `.env.example` documents every variable with a safe placeholder

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,20 +7,22 @@ request — it will save you time.
 
 ## Read this first: the project is pre-alpha
 
-Tel-Agent is at **Milestone 0**: getting a single real phone call answered by an AI
-voice, with the message captured and the transcript printed. There is no installable
-release, no web UI, and no database yet.
+Tel-Agent is at **Milestone 0**: getting a single conversation answered end to end in
+a web chat, with the message captured and the transcript printed. There is no
+installable release, no dashboard, and no database yet. The phone comes last, at
+Milestone 11 — see [`docs/ROADMAP.md`](docs/ROADMAP.md) for why.
 
 **Feature pull requests will be pointed at [`IDEAS.md`](IDEAS.md) rather than merged.**
 
 That is not a judgement on your idea. The project follows one rule:
 
-> **Nothing gets built until the first call works.**
-> Not the UI. Not the rules engine. Not the second provider. Not MCP.
+> **Nothing gets built until the agent answers on one channel, end to end.**
+> Not the second channel. Not the rules engine. Not the UI beyond what it takes to
+> watch one conversation happen.
 
-The previous attempt at this stalled with plenty of plan and no answered call. The
-order is the only thing being changed this time, and holding that order is what makes
-the project finishable. Good ideas go into `IDEAS.md`, where they wait rather than
+The previous attempt at this stalled with plenty of plan and nothing a customer could
+reach. The order is the only thing being changed this time, and holding that order is
+what makes the project finishable. Good ideas go into `IDEAS.md`, where they wait rather than
 distract.
 
 **What is welcome right now:** bug reports, documentation fixes, corrections to the

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -7,7 +7,7 @@ written down here **instead of into the code**. It is the mechanism that gets th
 project finished. The ideas will still be here when they are needed, and they will
 not distract now.
 
-**The one rule:** nothing gets built until the first call works.
+**The one rule:** nothing gets built until the agent answers on one channel, end to end.
 Not the UI. Not the rules engine. Not the second provider. Not MCP.
 
 ---
@@ -25,7 +25,7 @@ Items graduate out of this file only when an earlier milestone is finished.
 These are already described in `docs/SPEC.md` and scheduled, just not now.
 
 - **Provider abstraction** (§B3) — Milestone 1. One implementation each of STT / LLM /
-  TTS first; the second implementation comes only after the first call works.
+  TTS first; the second implementation comes only after one channel works end to end.
 - **Additional providers** (§B3) — Ollama, local Whisper, Piper, Cartesia. Many will
   arrive as community pull requests.
 - **PostgreSQL persistence** (§B5) — Milestone 2.

--- a/README.md
+++ b/README.md
@@ -55,12 +55,20 @@ models, and decide which callers ever reach the AI at all.
 
 **Pre-alpha. Not usable yet.** There is no installable release.
 
-The project is at Milestone 0: getting a single real phone call answered by an AI
-voice, with the message captured and the transcript printed. Everything else — the web
-UI, the database, Docker packaging, routing rules — comes after that works.
+The project is at Milestone 0: getting a single conversation answered end to end in a
+web chat — the reply streaming token by token, interruptible mid-sentence, with the
+message captured and the transcript printed. The messaging channels follow, and **the
+phone comes last**, at Milestone 11.
 
-The build order is deliberate. The previous attempt at this stalled with plenty of
-plan and no answered call.
+**The screens exist and have nothing behind them.** Twenty-eight of them are in this
+repository, designed and built; there is no backend serving them yet. Treat them as
+design, not as a product you can run.
+
+The build order is deliberate, and it was reversed once, on 2026-08-22. It originally
+required an answered phone call before anything else was built; the phone loop was
+proven elsewhere, which retired the risk that ordering existed to cover. What was not
+proven is that anyone can reach the agent at all. The superseded rule and the cost of
+reversing it are recorded in `internal/DECISIONS.md` as D-017.
 
 **Milestone 0 of 12 — in progress.** The full plan, and what each milestone means, is
 in [`docs/ROADMAP.md`](docs/ROADMAP.md).
@@ -138,9 +146,9 @@ cable.
 
 ## Contributing
 
-Contributions are welcome, but note the current state: until Milestone 0 works,
-pull requests adding features will be pointed at [`IDEAS.md`](IDEAS.md) rather than
-merged. That is not a judgement on the idea — it is how this project stays finishable.
+Contributions are welcome, but note the current state: until the agent answers on one
+channel end to end, pull requests adding features will be pointed at
+[`IDEAS.md`](IDEAS.md) rather than merged. That is not a judgement on the idea — it is how this project stays finishable.
 
 **All contributors must sign the [CLA](CLA.md)** before their first pull request is
 merged. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening one. Everything in the

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,9 +1,11 @@
 # agent/ — the voice agent
 
-Owns everything that happens **while a phone call is in progress**: SIP, the audio
-path, turn-taking, the model loop, and tool execution.
+Owns everything that happens **while a conversation is in progress**: the model loop,
+turn-taking, tool execution, and - from Milestone 11 - SIP and the audio path.
 
-This is a soft real-time system, not a web service. See `docs/ARCHITECTURE.md`.
+It is built as a soft real-time system rather than a web service even while the only
+channel is a chat window, because the channel that decides the shape is the phone. See
+`docs/ARCHITECTURE.md`.
 
 ## The rule that governs this folder
 
@@ -37,6 +39,6 @@ the database and publishes events; it does not serve the UI.
 
 ## Right now
 
-Milestone 0 is **one script**, with no provider abstraction, no database, and no
-routing. This structure is where that code goes as it grows — not an instruction to
+Milestone 0 is **one script and one page**, with no database, no routing, and no
+provider abstraction beyond the model interface. This structure is where that code goes as it grows — not an instruction to
 build it all now.

--- a/api/README.md
+++ b/api/README.md
@@ -51,4 +51,5 @@ WS     /ws/conversations/{id}/whisper operator -> agent, mid-conversation
 
 ## Right now
 
-Empty. This arrives at Milestone 5, after persistence and routing exist.
+Empty. This arrives at Milestone 6, after persistence, the UI, the channels and the
+routing rules exist.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,11 +90,12 @@ Tel-Agent; these show how to reach it through webhooks and the generic HTTP tool
 ## Where Milestone 0 fits
 
 **Only `agent/` is used right now**, and not even as this structure — Milestone 0 is
-one script in a terminal, with no UI, no database, and no provider abstraction.
+one script and one page, with no dashboard, no database, and no provider abstraction
+beyond the model.
 
 The folders exist today so that files land in the right place from the first day
 instead of being moved later. They are not an instruction to start filling them.
 
-`api/`, `web/`, `locales/` and `examples/` stay empty until Milestones 2–5.
+`api/`, `web/`, `locales/` and `examples/` stay empty until Milestones 1–6.
 See `docs/SPEC.md` §B11 for the build order, and remember the rule that governs all
-of it: **nothing gets built until the first call works.**
+of it: **nothing gets built until the agent answers on one channel, end to end.**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,10 +13,11 @@ live in [`IDEAS.md`](../IDEAS.md).
 **Milestone 0. Nothing else is being worked on.**
 
 That is not a formality. The previous attempt at this stalled with plenty of plan and
-no answered call. The order is the only thing being changed this time.
+nothing a customer could reach. The order is the only thing being changed this time.
 
-> **Nothing gets built until the first call works.**
-> Not the UI. Not the rules engine. Not the second provider. Not MCP.
+> **Nothing gets built until the agent answers on one channel, end to end.**
+> Not the second channel. Not the rules engine. Not the UI beyond what it takes to
+> watch one conversation happen.
 
 Milestone 0 has a **two-week time box**. If it is not working by then, the constraint
 is time rather than architecture — and learning that early is worth more than any
@@ -24,18 +25,193 @@ feature.
 
 ---
 
-## 0 — First call · **in progress**
+## Why the phone is last, and what that costs
 
-A phone number rings, a Python script answers, speaks, listens, replies, takes a
-message, and prints a transcript.
+This roadmap used to open with the phone. It was ordered that way because the phone is
+the hard case — no interface, no way to show the caller what was understood, a
+sub-second latency budget, and a caller who interrupts mid-sentence — and because an
+architecture built to satisfy text channels can look healthy while being far too slow
+for voice.
+
+That order was reversed on 2026-08-22 by decision **D-017**; the superseded text and
+the cost of reversing it are kept in `internal/DECISIONS.md`, the same way CLAUDE.md
+records it.
+
+The reasoning was sound, and one thing changed it: **the phone loop is already
+proven.** A number rings, a script answers, speaks, listens and replies — demonstrated
+outside this project. The risk the old order existed to retire is retired. What is not
+proven is that anyone can reach this agent at all, and that is what the first
+milestones buy.
+
+The cost is real, and is written here so nobody rediscovers it as a surprise:
+
+- **The hardest measurement now comes last.** A loop that is comfortable in a chat
+  window can be hopeless on a call. Latency, endpointing and barge-in are not measured
+  until Milestone 11.
+- **The mitigation is a budget written down now, not later.** Every interface built
+  before Milestone 11 is shaped for streaming: partial results in, output in chunks,
+  and a `cancel()` that stops generation immediately. An interface that returns one
+  finished answer is the shape that cannot be fixed later without rewriting everything
+  above it.
+- **Text-channel comfort is not evidence.** No milestone before 11 may claim the
+  latency question is answered.
+
+---
+
+## 0 — Web chat · **in progress**
+
+A visitor types on a web page, the agent answers, the thread holds, and a transcript is
+printed. One process, one page, one model.
+
+**No database. No routing rules. No provider abstraction beyond the model. No
+dashboard.** The page and a script.
+
+Six checks, in order:
+
+| # | Check | Done when |
+|---|---|---|
+| 1 | Arrive | A message typed in a browser reaches the agent process |
+| 2 | Answer | It replies with a hardcoded greeting |
+| 3 | Understand | The model's reply appears in the page, in the visitor's language |
+| 4 | **Full loop** | Visitor writes → model replies → visitor writes again, thread intact |
+| 5 | **Stream and cancel** | Tokens appear as they are produced, and stop instantly when cancelled |
+| 6 | Take a message | It asks for name and reason, prints a structured result |
+
+Steps 1–2 are plumbing. **Step 4 is the product. Step 5 is what protects Milestone 11.**
+
+Step 5 is not a nicety. It is the whole of what the old phone-first order was
+protecting: an agent that composes a complete answer and then sends it is an agent that
+can never be put on a phone. Cancellation is proven here, in the easy case, while it is
+still cheap to get right.
+
+The model sits behind one interface from the first commit — changing the model must
+never mean editing the page. Speech-to-text and text-to-speech get the same treatment
+when they arrive, at Milestone 11.
+
+**Measured:** time to first token, whether the thread survives a page reload, and
+whether cancel actually stops generation rather than only hiding it.
+
+## 1 — Persistence
+
+PostgreSQL. Conversations and messages stored.
+
+Six things that are painful to add later and are therefore done here, in full in
+`docs/SPEC.md` §B5. The two that shape everything else:
+
+**`conversations` is the core table, and there is no `calls` table yet.** A phone call
+will be a conversation on a channel of kind `phone`, plus a `calls` row for what only a
+call has — the caller's number, the recording, the billable seconds, the provider cost.
+Everything built for chat then works on the phone without a branch. The phone-first
+order reached this same decision from the other end, which is the sign that reordering
+the milestones is a change of sequence and not of architecture.
+
+**`user_id` on every table even while it is always `1`**, and a full-text index on
+`messages.text` in the first migration.
+
+## 2 — Web UI
+
+In this order: **conversation detail** → conversations list → home → rules → agent →
+settings.
+
+Conversation detail is designed and built first, alone. It is the heart of the product
+and it settles the vocabulary every other screen inherits. Onboarding is designed last,
+because it should be assembled from components the rest of the product already proved.
+
+No screen may assume a channel. A conversation is a conversation; the phone is a kind,
+not a layout.
+
+## 3 — Messaging channels
+
+WhatsApp, Telegram, Messenger, Instagram, Discord — plus SMS and email. The same agent,
+the same tools, the same searchable archive; a different transport.
+**Nine channels including the phone, and the list is closed.**
+
+The line that keeps it closed: a channel is any route a **customer** uses to reach a
+business. It is not any system the business itself runs on — Slack, Teams and project
+trackers are integrations, reached through the HTTP tool. Without that line, "add one
+more connector" has no end.
+
+WhatsApp and Telegram come first: that is where the customers of the businesses this is
+built for already are, and Telegram needs no platform review at all. Email follows. SMS
+arrives with the telephony account, which does not exist until Milestone 11 — it is the
+one channel here that may legitimately land late.
+
+The customer connects credentials from their own developer account on each platform.
+Tel-Agent never holds a shared platform application: one shared app would put every
+installation behind a single rate limit, and make one policy violation everybody's
+outage.
+
+Setup requirements per channel are specified in `docs/SPEC.md` §B13.
+
+## 4 — Routing rules
+
+Pass through, block, or hand to the AI, decided from who is making contact and when.
+Business hours.
+
+Rules are written against a channel identity rather than a phone number: a WhatsApp
+number, a Telegram handle, an email address — and later a caller ID — all resolve to
+the same contact. Building it any other way means writing the rules engine twice.
+
+**Phone routing is not finished in this milestone.** It rests on a question only a live
+line can answer: whether a forwarded call carries the original caller's number or the
+forwarding subscriber's. Some carriers present the latter, which would leave every rule
+matching the same number on every call. That is settled at Milestone 11, and where the
+original survives in a diversion header it is read from there.
+
+## 5 — Tools
+
+Transfer, take a message, end conversation, notify, generic HTTP request, search
+knowledge, check calendar.
+
+Kept short on purpose: five precise tools beat twenty that confuse the model. The
+calendar tool proposes and confirms, or writes to a review calendar — it does not book
+directly into a live calendar in v1. One wrong entry destroys trust permanently.
+
+## 6 — Webhooks and REST
+
+The documented, signed public API. The dashboard already consumes it, so it exists
+anyway — this milestone makes it public and documented.
+
+## 7 — MCP server
+
+A thin layer over the REST API, with hard limits. An external model that can start real
+conversations — and later real calls — spends real money.
+
+## 8 — Live intervention
+
+**Whisper first** — the operator types an instruction and the agent delivers it in its
+own voice; the customer never knows. Highest value, lowest complexity, and on a text
+channel it is nearly free.
+
+Takeover follows. Note that browsers block microphone access over plain HTTP outside
+`localhost`, so voice takeover needs HTTPS; until then, whisper and type-to-speak only.
+
+## 9 — Health and alerts
+
+Not a feature. A silently dead service is worse than an obviously dead one, because the
+operator only finds out after losing ten conversations.
+
+Real checks on every connected channel, on provider reachability and on the database;
+immediate alerting on a channel that stops delivering; per-message latency telemetry.
+SIP registration joins this list at Milestone 11.
+
+## 10 — Docker packaging
+
+One-command install. Manual development runs stay documented — contributors need to run
+the code without rebuilding an image on every edit.
+
+## 11 — Phone call
+
+A phone number rings, the agent answers, speaks, listens, replies, takes a message, and
+the transcript lands in the same archive as every other conversation.
 
 The number comes from a SIP provider and is pointed at the agent. An extension on an
-existing PBX reaches the same place and stays a first-class way to connect a line — it
-is simply not the path that proves the product first, because it depends on access to
-a PBX that the person building this may not administer.
+existing PBX reaches the same place and stays a first-class way to connect a line.
 
-**No UI. No Docker. No database. No routing rules. No provider abstraction.**
-One script in a terminal.
+This milestone brings the two provider interfaces chat never needed — speech-to-text
+and text-to-speech, each behind a clean interface. **`cancel()` on text-to-speech is
+mandatory:** on interruption, audio stops instantly and queued speech is discarded. The
+model-side cancellation it depends on was proven at Milestone 0.
 
 Six checks, in order:
 
@@ -44,134 +220,28 @@ Six checks, in order:
 | 1 | Arrive | The provider console shows the inbound call reaching our SIP endpoint |
 | 2 | Answer | You call it, it stops ringing, the line goes quiet |
 | 3 | Speak | It answers with a hardcoded greeting |
-| 4 | Listen | Your words appear as text in the terminal |
+| 4 | Listen | Your words appear as text |
 | 5 | **Full loop** | You speak → the model replies → you hear the reply |
-| 6 | Take a message | It asks for name and reason, prints a structured result |
-
-Steps 1–2 are plumbing. **Step 5 is the product.**
+| 6 | Same archive | The call sits beside the chats, searchable, with a transcript |
 
 Before any code: buy the number, point it at the SIP endpoint, call it from a mobile,
 and confirm in the provider console that the call arrives. If it does not, the problem
 is in the number configuration, and debugging SIP through our own code is far harder.
 
-**Measured from the first call:** time from end of speech to first audio out (target
-under 800 ms), where that time goes — **endpointing included, as it is usually the
-largest stage** — what happens when the caller interrupts, and accuracy across at
-least 20 real calls in Austrian German including names and addresses. **If latency
-exceeds ~1.5 s, no features are added until streaming is fixed.**
+**Measured:** time from end of speech to first audio out (target under 800 ms), where
+that time goes — **endpointing included, as it is usually the largest stage** — what
+happens when the caller interrupts, and accuracy across at least 20 real calls in
+Austrian German including names and addresses. **If latency exceeds ~1.5 s, nothing
+else is added until streaming is fixed.**
 
 **Also recorded on the first forwarded call:** which number arrives in the caller ID
 when a call is forwarded rather than dialled directly — the original caller's, or the
-subscriber's. This is carrier-dependent and it decides whether Milestone 3 works at
-all.
+subscriber's. This is carrier-dependent, and it decides whether the phone half of
+Milestone 4 works at all.
 
-## 1 — Provider interfaces
-
-One speech-to-text, one language model and one text-to-speech implementation, each
-behind a clean interface. `cancel()` on text-to-speech is mandatory: on interruption,
-audio stops instantly and queued speech is discarded.
-
-The second implementation of anything comes after this, never before.
-
-## 2 — Persistence
-
-PostgreSQL. Conversations and messages stored.
-
-Six things that are painful to add later and are therefore done here, in full in
-`docs/SPEC.md` §B5. The two that shape everything else:
-
-**`conversations` is the core table, not `calls`.** A phone call is a conversation on
-a channel of kind `phone`, plus a `calls` row for what only a call has — the caller's
-number, the recording, the billable seconds, the provider cost. Everything built for
-the phone then works on every channel without a branch. Renaming today costs nothing;
-renaming after Milestone 4 means migrating every stored transcript, query, API path
-and screen.
-
-**`user_id` on every table even while it is always `1`**, and a full-text index on
-`messages.text` in the first migration.
-
-## 3 — Routing rules
-
-Pass through, block, or hand to the AI, decided from the caller ID. Business hours.
-
-This milestone rests on an assumption worth testing in Milestone 0 rather than here:
-that a forwarded call still carries the original caller's number. Some carriers
-present the forwarding subscriber's number instead, which would leave every rule
-matching the same number on every call. Where the original survives in a diversion
-header, read it from there.
-
-## 4 — Web UI
-
-In this order: **call detail** → calls list → home → rules → agent → settings.
-
-Call detail is designed and built first, alone. It is the heart of the product and it
-settles the vocabulary every other screen inherits. Onboarding is designed last,
-because it should be assembled from components the rest of the product already proved.
-
-## 5 — Webhooks and REST
-
-The documented, signed public API. The dashboard already consumes it, so it exists
-anyway — this milestone makes it public and documented.
-
-## 6 — Tools
-
-Transfer, take a message, end call, notify, generic HTTP request, search knowledge,
-check calendar.
-
-Kept short on purpose: five precise tools beat twenty that confuse the model. The
-calendar tool proposes and confirms, or writes to a review calendar — it does not book
-directly into a live calendar in v1. One wrong entry destroys trust permanently.
-
-## 7 — Live intervention
-
-**Whisper first** — the operator types an instruction, the agent speaks it in its own
-voice, the caller never knows. Highest value, lowest complexity.
-
-Takeover follows. Note that browsers block microphone access over plain HTTP outside
-`localhost`, so voice takeover needs HTTPS; until then, whisper and type-to-speak only.
-
-## 8 — Health and alerts
-
-Not a feature. A silently dead phone service is worse than an obviously dead one,
-because the operator only finds out after losing ten calls.
-
-Real checks on SIP registration, provider reachability and the database; immediate
-alerting on lost registration; per-call latency telemetry.
-
-## 9 — Docker packaging
-
-One-command install. Manual development runs stay documented — contributors need to
-run the code without rebuilding an image on every edit.
-
-## 10 — MCP server
-
-A thin layer over the REST API, with hard limits. An external model that can start
-real calls spends real money.
-
-## 11 — Messaging channels
-
-Web chat, SMS, email, WhatsApp, Telegram, Messenger, Instagram and Discord. The same
-agent, the same tools, the same searchable archive — a different transport.
-**Nine channels including the phone, and the list is closed.**
-
-The line that keeps it closed: A channel is any route a **customer** uses to reach a business. It is not any system the business itself runs on — Slack, Teams and project trackers are integrations, reached through the HTTP tool. Without that line, "add one more
-connector" has no end.
-
-Web chat, SMS and email come first of the eight: web chat needs no platform approval
-at all, and SMS arrives with the telephony account the phone already uses.
-
-The customer connects credentials from their own developer account on each platform.
-Tel-Agent never holds a shared platform application: one shared app would put every
-installation behind a single rate limit and make one policy violation everybody's
-outage.
-
-**This is last on purpose.** The phone is the hard case — no interface, no way to show
-the caller what was understood, a sub-second latency budget, and a caller who
-interrupts mid-sentence. Text channels are forgiving, and an architecture built to
-satisfy them would look healthy while being far too slow for voice. Build for the
-phone, then fit the rest to it.
-
-Setup requirements per channel are specified in `docs/SPEC.md` §B13.
+**This is last on purpose, and it is the milestone that judges the ten before it.**
+Everything above was built to a latency budget it was never forced to meet. Here it is
+forced.
 
 ---
 
@@ -180,7 +250,7 @@ Setup requirements per channel are specified in `docs/SPEC.md` §B13.
 | | Why |
 |---|---|
 | General workflow automation | Webhooks and a generic HTTP tool reach n8n and Home Assistant, which do it better |
-| Integrations with SaaS applications | A **channel** is where the conversation happens; an **integration** is a system the agent acts on. We own the first and reach the second through the HTTP tool. Channels are a closed list of six; integrations are unbounded, which is why they are somebody else's product |
+| Integrations with SaaS applications | A **channel** is where the conversation happens; an **integration** is a system the agent acts on. We own the first and reach the second through the HTTP tool. Channels are a closed list of nine; integrations are unbounded, which is why they are somebody else's product |
 | Being a CRM | Not what this is |
 | Being a PBX replacement | It connects to your PBX as an extension |
 | Analog hardware support | We only ever speak SIP. A genuinely analog line is bridged with an ATA — see the requirements in the README |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -13,17 +13,48 @@ Section A is for the designer. Section B is for the developer. Read both.
 
 # START HERE — Milestone 0
 
-**Goal:** one real phone call, answered by an AI voice, message captured, transcript printed.
+**Goal:** one conversation, answered end to end in a web chat. The reply streams token
+by token, it can be interrupted mid-sentence, the message is captured and the
+transcript printed.
 
-**Not in this milestone:** no web UI, no Docker, no database, no routing rules, no
-provider abstraction. One script in a terminal.
+**Not in this milestone:** no dashboard, no Docker, no database, no routing rules, no
+provider abstraction beyond the model. A page and a script.
 
 **Time box: two weeks.** If it isn't working by then, the constraint is time, not
 architecture — and knowing that early is worth more than any feature.
 
+**The phone is Milestone 11**, by decision D-017 of 2026-08-22. Everything below about
+numbers, trunks and SIP is still correct and still required — it simply happens last.
+It is kept here, in order, because it is the milestone that judges every interface
+built before it: an agent that cannot stream and cannot cancel will fail on a call no
+matter how well it reads in a chat window.
+
+## Milestone 0 in four steps
+
+| # | Step | Done when |
+|---|---|---|
+| 1 | A page that posts a message | A message typed in a browser reaches the agent process |
+| 2 | A model behind one interface | It replies, and swapping the model does not touch the page |
+| 3 | **Stream and cancel** | Tokens appear as produced; cancelling stops generation, not just the display |
+| 4 | Take a message | It asks for name and reason, prints a structured result |
+
+Step 3 is the one that matters beyond this milestone. It is what the phone will
+require, proven while it is cheap.
+
+**Measure from the first exchange:** time to first token, and where that time goes.
+The same discipline as the call measurements below, on an easier channel.
+
+---
+
+# Milestone 11 — the phone line
+
+Everything from here to the end of this section is the phone milestone. It was written
+first, when the phone was Milestone 0, and none of it has been weakened by moving:
+the numbers, the trunk, the codec and the measurements are unchanged.
+
 ## Step 1 — A number that reaches the agent (30 minutes)
 
-Milestone 0 needs one inbound number under your own control. Buy it from a SIP
+Milestone 11 needs one inbound number under your own control. Buy it from a SIP
 provider — Twilio, Telnyx, or a European equivalent — and point it at a LiveKit Cloud
 SIP trunk.
 
@@ -51,15 +82,15 @@ through your own code is far harder.
 mobile to forward to it after 15 seconds, call that mobile from a third phone, and
 check the caller ID again. If forwarding replaces the original caller's number with
 the subscriber's, every routing rule in §A6.5 matches the same number on every call.
-Better to learn this in week one than in Milestone 3.
+Better to learn this early than during the phone half of Milestone 4.
 
 ## Step 2 — Machine setup
 
 Any machine with outbound internet access. The agent connects **out** to LiveKit; it
 accepts no inbound connections, so there is no NAT traversal, no STUN, and no RTP port
 range to open. That removes the single biggest source of "call connects but there's no
-audio" for Milestone 0 — and defers it rather than solving it, because the
-self-hosted media path at Milestone 9 brings it back.
+audio" — and defers it rather than solving it, because the self-hosted media path
+brings it back.
 
 ```
 Python 3.11+
@@ -164,12 +195,12 @@ These are settled. Do not reopen them without a concrete reason.
 | Runs as | Locally installed web app on the LAN — not a desktop app, not SaaS-only |
 | First test bed | A number from a SIP provider, pointed at the agent |
 | Number acquisition | Users bring their own number in v1. Reselling numbers belongs to Tel-Agent Cloud and never enters the open edition — see §B3.1 |
-| SIP in Milestone 0 | LiveKit Cloud SIP. A Milestone 0 decision only; the self-hosted media path returns at Milestone 9 |
+| SIP at Milestone 11 | LiveKit Cloud SIP. A first-call decision only; the self-hosted media path returns after |
 | Theme | Dark and light, dark designed first |
 | Languages | Multi-language from day one: en / de / ar, RTL supported |
 | Analog phone lines | Out of scope. Users bridge with an ATA; we only ever speak SIP. |
 | Workflow automation | Out of scope. Webhooks + generic HTTP tool; n8n does the rest. |
-| Messaging channels | In scope at Milestone 11 — web chat, SMS, email, WhatsApp, Telegram, Messenger, Instagram, Discord. Nine with the phone. Closed list. Customer connects their own app credentials (§B13). |
+| Messaging channels | In scope at Milestone 3 — web chat, SMS, email, WhatsApp, Telegram, Messenger, Instagram, Discord. Nine with the phone. Closed list. Customer connects their own app credentials (§B13). |
 
 ---
 
@@ -431,7 +462,7 @@ Appears whenever a call is active, reachable from anywhere in the app.
 1. **General** — interface language, theme, timezone, agent display name
 2. **Providers** — STT / LLM / TTS: provider, key, "Test connection", est. cost/min
 3. **Numbers** — connected numbers, add another, per-number agent assignment, status
-4. **Channels** (§B13, Milestone 11) — one card per channel: connect, per-channel agent
+4. **Channels** (§B13, Milestone 3) — one card per channel: connect, per-channel agent
    assignment, status. Every card holds credentials the customer created in their own
    developer account, so each needs a **"Test connection"** that proves the link rather
    than claiming it, and each shows the saved token **masked to its last four
@@ -672,9 +703,9 @@ live view. That is the entire reason for the split.
    The product answers on nine channels (§B13), so a schema whose master table is named
    `calls` and whose lines are keyed by `call_id` is wrong from the first migration.
    Renaming today costs nothing — there is no code and no stored row. Renaming after
-   Milestone 4 means migrating every transcript, every query, every API path and every
+   Milestone 2 means migrating every transcript, every query, every API path and every
    screen. The `channels` table exists from the first migration too, holding exactly
-   one row of kind `phone` until Milestone 11 — the same discipline as `user_id` being
+   one row of kind `web` until Milestone 3 — the same discipline as `user_id` being
    permanently `1`, and for the same reason: the structure is what makes the later work
    a write instead of a redesign.
 
@@ -692,7 +723,7 @@ POST   /api/calls/outbound            # {to, prompt} — phone only, starts a re
 GET    /api/rules  POST  /api/rules
 GET    /api/agents PATCH /api/agents/{id}
 GET    /api/contacts
-GET    /api/channels   POST /api/channels     # connect a channel (§B13, Milestone 11)
+GET    /api/channels   POST /api/channels     # connect a channel (§B13, Milestone 3)
 GET    /api/settings PATCH /api/settings
 POST   /api/providers/test            # test connection
 WS     /ws/conversations/{id}         # live transcript / message stream
@@ -830,7 +861,7 @@ Two kinds of secret, two homes. Confusing them is why this section exists.
 | | `.env` | Database, encrypted |
 |---|---|---|
 | What | Installation secrets | Credentials the user enters |
-| Examples | `DATABASE_URL`, `REDIS_URL`, **`ENCRYPTION_KEY`**, LiveKit keys in Milestone 0 | STT / LLM / TTS API keys, SIP credentials per number, channel tokens (§B13) |
+| Examples | `DATABASE_URL`, `REDIS_URL`, **`ENCRYPTION_KEY`**, LiveKit keys at Milestone 11 | STT / LLM / TTS API keys, SIP credentials per number, channel tokens (§B13) |
 | Set by | Whoever runs the server, once | The user, from the UI, at any time |
 | How many | Exactly one set per installation | Many — several numbers, five channels, one key per provider |
 | Changing it | Restart | Takes effect immediately |
@@ -858,11 +889,11 @@ So: **the credential goes in the database, encrypted; the key that encrypts it g
 full to the client, shown in the UI only as a masked preview with the last four
 characters visible.
 
-### Milestone 0 is the exception, and only until Milestone 2
+### Milestone 0 is the exception, and only until Milestone 1
 
 There is no database in Milestone 0, so everything is in `.env` — including the
-provider keys. That is correct for one script in a terminal and wrong for anything
-with a UI. The move happens at Milestone 2, when persistence arrives; do not build a
+provider keys. That is correct for one script and one page, and wrong for anything
+with a dashboard. The move happens at Milestone 1, when persistence arrives; do not build a
 settings screen that writes to `.env`.
 
 **Unchanged in all cases:** never log a credential, never commit one, never return one
@@ -890,23 +921,25 @@ Do not start step N+1 before step N works.
 
 | # | Milestone | Done when |
 |---|---|---|
-| 0 | **First call** | A provider number rings, a Python script answers, speaks via TTS, takes a message, prints a transcript. **No UI, no Docker, no database.** |
-| 1 | Provider interfaces | One STT/LLM/TTS each behind clean interfaces |
-| 2 | Persistence | Postgres, conversations + messages stored, schema per §B5 |
-| 3 | Routing rules | Whitelist / blacklist / AI from SIP caller ID |
-| 4 | Web UI | Call detail → calls list → home → rules → agent → settings |
-| 5 | Webhooks + REST | Documented, signed |
-| 6 | Tools | The seven in B7 |
-| 7 | Live intervention | Whisper first, takeover after |
-| 8 | Health + alerts | B8 complete |
-| 9 | Docker packaging | One-command install |
-| 10 | MCP server | Thin layer over the REST API, with hard limits |
-| 11 | Messaging channels | The five in §B13, same agent and tools, different transport |
+| 0 | **Web chat** | A visitor types, the model replies token by token, the reply can be cancelled mid-sentence, a message is taken and a transcript printed. **No dashboard, no Docker, no database.** |
+| 1 | Persistence | Postgres, conversations + messages stored, schema per §B5 |
+| 2 | Web UI | Conversation detail → conversations list → home → rules → agent → settings |
+| 3 | Messaging channels | The eight in §B13, same agent and tools, different transport |
+| 4 | Routing rules | Pass / block / AI, from a channel identity rather than a phone number |
+| 5 | Tools | The seven in B7 |
+| 6 | Webhooks + REST | Documented, signed |
+| 7 | MCP server | Thin layer over the REST API, with hard limits |
+| 8 | Live intervention | Whisper first, takeover after |
+| 9 | Health + alerts | B8 complete |
+| 10 | Docker packaging | One-command install |
+| 11 | **Phone call** | A provider number rings, the agent answers, speaks via TTS, takes a message, and the transcript lands in the same archive as every chat. Brings the STT and TTS interfaces. |
 
-**Milestone 11 sits last on purpose.** The phone is the hard case — no interface, no
-way to show the caller what was understood, sub-second latency, and interruption
-mid-sentence. Text channels are forgiving and would let a slow architecture look
-healthy. Build for voice, then fit the rest to it.
+**Milestone 11 sits last, and it is the one that judges the ten before it.** The phone
+is the hard case — no interface, no way to show the caller what was understood,
+sub-second latency, and interruption mid-sentence. Text channels are forgiving and
+will let a slow architecture look healthy, which is exactly the trap this order walks
+into on purpose: the defence is that every interface built before it streams and
+cancels, and Milestone 0 proves both while they are cheap.
 
 **Milestone 0 is the only one that matters right now.** If it works within two weeks,
 everything above is worth building. If it doesn't, that is valuable information gained
@@ -939,7 +972,7 @@ a network service, and you must publish your modifications.
 *Commercial and ownership strategy is maintained privately and is not part of this
 specification.*
 
-## B13. Messaging channels — Milestone 11
+## B13. Messaging channels — Milestone 3
 
 Eight channels alongside the phone: **web chat · SMS · email · WhatsApp · Telegram ·
 Messenger · Instagram · Discord**. The same agent, the same tools, the same transcript


### PR DESCRIPTION
CLAUDE.md was revised on 2026-08-22 to put web chat first and the phone last. Nothing else moved with it, so the repository has been arguing with itself since: the roadmap opened with "nothing gets built until the first call works", the spec's START HERE walked through buying a SIP number, and CLAUDE.md's own Rule 2 still listed the six phone checks two paragraphs under the rule that reversed them.

The roadmap is reordered: 0 web chat, 1 persistence, 2 web UI, 3 messaging channels, 4 routing rules, 5 tools, 6 webhooks and REST, 7 MCP, 8 live intervention, 9 health, 10 Docker, 11 phone.

Three things this reordering had to solve rather than renumber:

Provider interfaces was a milestone of its own because voice needs three of them. Chat needs one. The model interface moves into Milestone 0 - required from the first commit, since changing the model must never mean editing the page - and speech-to-text and text-to-speech move into the phone milestone that actually needs them.

Routing rules used to key off SIP caller ID, which does not exist until Milestone 11 now. Rules are written against a channel identity instead, and the milestone says plainly that its phone half is finished later - along with the carrier question about whether a forwarded call keeps the original caller's number, which only a live line can answer.

The phone-first order existed to stop an architecture that looks healthy on text and is far too slow for voice. That danger is real again, so the defence is written into Milestone 0 rather than assumed: streaming and cancellation are check 5 of six, proven in the easy case while it is cheap, and no milestone before 11 may claim the latency question is answered.

The superseded reasoning is not deleted anywhere. The roadmap now carries a section on what ordering the phone last costs, and points at internal/DECISIONS D-017 the way CLAUDE.md does.

README also says what it had been avoiding: the twenty-eight screens exist and have no backend behind them.

# Pull request

## What does this change, and why?

<!-- The diff shows the what. Explain the why. -->

## Related issue

<!-- e.g. Closes #12 -->

---

## Contributor License Agreement — required

Every contribution needs this before it can be merged, including one-line fixes.
You keep full ownership and copyright of your work. See [CLA.md](../CLA.md).

- [ ] I have read the CLA document and I hereby sign the CLA.

---

## Checklist

- [ ] Everything I wrote — code, comments, commit messages — is in **English**
- [ ] This PR does **one thing**
- [ ] I have not added any credential, real recording, or real transcript
- [ ] New configuration is documented in `.env.example` with a safe placeholder

**If this touches the call path (`agent/`):**

- [ ] Nothing on the audio path blocks — it is `async` throughout
- [ ] I have considered the latency budget (§B4: under 800 ms from end of caller
      speech to first audio out) and stated the impact below
- [ ] If it touches speech, I tested it **in German** — English alone proves little for
      this project

Latency impact:

<!-- Numbers if you have them, "none" if it does not touch the call path. -->

---

## Before you open this

Tel-Agent is at **Milestone 0** — one real phone call, answered, message taken,
transcript printed. Nothing else is being built yet.

**Feature PRs will be pointed at [IDEAS.md](../IDEAS.md) rather than merged.** That is
not a judgement on the idea; it is how this project stays finishable. Bug fixes,
documentation, specification corrections, and anything that helps Milestone 0 work are
welcome now.

Security problem? **Do not open a PR** — see [SECURITY.md](../SECURITY.md).
