### PR TITLE
feat(scripts): report translation coverage, and open the project to more languages

### DIFF
--- a/.claude/skills/contributing/SKILL.md
+++ b/.claude/skills/contributing/SKILL.md
@@ -25,6 +25,64 @@ time and the contributor's:
 3. **Never commit a secret** — no key, token, password, or real phone number. If one is
    needed to run something, it goes in `.env`, which is ignored.
 
+## Translation — the first contribution, and the one that never runs out
+
+Do not send somebody new to a code issue. Send them here.
+
+The whole task is one loop, and it is the same loop every time:
+
+```
+run the script  →  pick what is missing  →  translate it  →  open a pull request
+       ↑                                                              │
+       └──────────────────────────────────────────────────────────────┘
+```
+
+```bash
+node scripts/check-locales.mjs               # every language, and where each stands
+node scripts/check-locales.mjs --locale fr   # one language: what is left, smallest first
+```
+
+The script measures everything against English, which is the source language. It prints
+the remaining files **smallest first**, and the smallest are 16 to 26 strings — about
+twenty minutes.
+
+```bash
+mkdir -p locales/fr
+cp locales/en/code.json locales/fr/
+# translate the values, leave the keys alone
+node scripts/check-locales.mjs --locale fr   # confirm the number moved
+```
+
+Then the normal flow from step 2: claim, branch, pull request. **One file per pull
+request.** A translator who has finished one runs the script again, takes the next file
+— or a different language entirely — and repeats. Nothing needs to be assigned again
+after the first time.
+
+This is why it never runs out: every language is 2,972 strings across 33 files, and any
+language anybody speaks is welcome. There is more of this work than there will ever be
+people to do it.
+
+**Four things that get a translation pull request sent back**, all easy to avoid:
+
+- **Copying all 33 files and translating one.** An untranslated copy of English looks
+  finished and ships English to somebody who asked for their own language. One file.
+- **Translating the keys.** Only the values on the right-hand side change.
+- **Translating `{placeholders}`.** `{count}` and `{name}` are filled at runtime, and a
+  translated placeholder breaks only on that language — so nobody catches it.
+- **Machine translation nobody read.** Translate the meaning. If it reads oddly to a
+  native speaker it is wrong, whatever the dictionary says. Only take a language you
+  actually speak.
+
+`locales/README.md` has the rest: the two tiers, why a partial language breaks nothing,
+and when a language gets registered.
+
+**After the first one is merged, anything on the board is open to them.** The
+translation is not a test to be passed — it is the smallest real thing in the project,
+and it is where the workflow gets learned on something that does not matter if it takes
+two attempts.
+
+---
+
 ## Step 1 — Find something to work on
 
 Work comes from the public board and nowhere else. Do not invent a task, and do not

--- a/locales/README.md
+++ b/locales/README.md
@@ -1,17 +1,82 @@
-# locales/ — en · de · ar
+# locales/
 
 Every user-facing string. **This is infrastructure, not content work.**
 
 Multi-language is in from day one because retrofitting it is expensive: it means
 touching every component that was built assuming English string lengths.
 
-| Locale | Notes |
-|---|---|
-| `en/` | Source language. Strings are written here first. |
-| `de/` | German. The primary market is Austria, so this is the realistic case, not a translation afterthought. |
-| `ar/` | Arabic. Requires full RTL. |
+**English is the source language.** A key exists because it exists in `en/`. Strings are
+written there first and every other locale is measured against it.
 
-## What this forces on the UI
+```bash
+node scripts/check-locales.mjs              # where every language stands
+node scripts/check-locales.mjs --locale fr  # one language, and what is left in it
+node scripts/check-locales.mjs --list       # every missing key
+```
+
+---
+
+## Two tiers, and the difference matters
+
+| Tier | Locales | What the project promises |
+|---|---|---|
+| **Committed** | `en` · `de` · `ar` | Kept current. A new English string blocks a release until these three have it. |
+| **Community** | everything else | Maintained by whoever turns up. Registered when complete, and allowed to fall behind without holding anything up. |
+
+The tiers exist so that adding a language costs the project nothing. A committed locale
+is a permanent obligation on every future change; a community locale is a contribution
+that stands on its own. Without the split, every new language would make English harder
+to change, and the honest response to "can we add twelve languages" would have to be no.
+
+`de` is committed because the primary market is Austria — the realistic case, not a
+translation afterthought. `ar` is committed because it is the RTL case, and RTL that is
+not exercised is RTL that is broken.
+
+---
+
+## Adding a language
+
+**One file at a time. Do not copy all 33.**
+
+```bash
+mkdir -p locales/fr
+cp locales/en/code.json locales/fr/
+# translate the values in that one file, then open a pull request
+```
+
+The smallest files are 16 to 26 strings — twenty minutes of work, and a complete
+contribution on its own. `check-locales.mjs` prints the remaining files smallest-first,
+so the next person can see what is left and take one.
+
+**Why not copy everything at once.** An untranslated copy of English is worse than a
+missing file: it looks finished, it ships English text to somebody who asked for their
+own language, and nothing flags it. A missing file is visible in one command. The script
+reports keys that are identical to English for the same reason.
+
+**A partial language breaks nothing.** It is not added to `LOCALES` in
+`web/lib/locales.ts` until `check-locales.mjs` reports it at 100%, so it is invisible to
+users until it is real. Wiring it up is a maintainer's job, not part of a translation
+pull request.
+
+### Translating well
+
+- **Translate the meaning, not the words.** If a literal translation reads oddly to a
+  native speaker, it is wrong, whatever the dictionary says.
+- **Leave `{placeholders}` exactly as they are.** `{count}` and `{name}` are filled at
+  runtime; a translated placeholder is a bug that only shows up on that language.
+- **Latin-script data is never translated** — phone numbers, API keys, timestamps, logs,
+  code. Only interface text.
+- **Product names stay** — Tel-Agent, WhatsApp, Telegram, SMS. If a key is identical to
+  English on purpose, that is fine; the script only asks you to check, it does not
+  demand a change.
+- **Keep it short.** These are buttons and labels. A translation twice the length of the
+  English breaks the layout it sits in.
+- **Match the register of the English.** It is direct and unfussy; it does not apologise
+  and it does not sell.
+
+---
+
+## What multi-language forces on the UI
 
 **German runs about 30% longer than English.** No fixed-width buttons or labels
 anywhere. Every layout must survive 1.4× string expansion without breaking.
@@ -23,13 +88,15 @@ the case to get right.
 
 **Dates, times and number formats follow the selected locale**, not the browser.
 
+---
+
 ## Rules
 
 - No string is hardcoded in a component. If it can be read by a user, it lives here.
 - Latin-script *data* is never translated — only interface text is.
-- More languages arrive through community pull requests. The three here are the ones
-  the project commits to keeping current.
-
-## Right now
-
-Empty. Files arrive with the UI at Milestone 4.
+- One file per screen per language, never one dictionary for everything: the screens are
+  client components, so a single file would ship the whole product's copy to the browser
+  on every route.
+- A key added to `en/` and forgotten in `de/` or `ar/` is a `tsc` error, not a blank
+  label at runtime — the German and Arabic dictionaries are passed where `typeof en` is
+  expected. Community locales are checked by the script instead.

--- a/scripts/check-locales.mjs
+++ b/scripts/check-locales.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Compares every locale in `locales/` against English and reports what is missing.
+ *
+ * English is the source language: a key exists because it exists in `en/`. A key
+ * present in another locale and absent from English is not a translation, it is a
+ * leftover, and it is reported too.
+ *
+ * No dependencies. Run it with:
+ *
+ *   node scripts/check-locales.mjs            # summary
+ *   node scripts/check-locales.mjs --list     # every missing key
+ *   node scripts/check-locales.mjs --locale fr
+ *
+ * Exits 1 if anything is missing, so it can be a CI check later.
+ */
+
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const LOCALES_DIR = join(ROOT, "locales");
+const SOURCE = "en";
+
+const args = process.argv.slice(2);
+const showAll = args.includes("--list");
+const onlyLocale = args[args.indexOf("--locale") + 1];
+
+/** Every leaf key in an object, as dotted paths. Arrays count as leaves. */
+function leaves(obj, prefix = "") {
+  const out = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      out.push(...leaves(value, path));
+    } else {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+function read(locale, file) {
+  const path = join(LOCALES_DIR, locale, file);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    console.error(`  ✗ ${locale}/${file} is not valid JSON — ${error.message}`);
+    process.exit(2);
+  }
+}
+
+const localeDirs = readdirSync(LOCALES_DIR, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
+
+if (!localeDirs.includes(SOURCE)) {
+  console.error(`No ${SOURCE}/ directory. English is the source language.`);
+  process.exit(2);
+}
+
+const sourceFiles = readdirSync(join(LOCALES_DIR, SOURCE)).filter((f) => f.endsWith(".json"));
+const targets = localeDirs.filter((l) => l !== SOURCE && (!onlyLocale || l === onlyLocale));
+
+if (onlyLocale && !targets.length) {
+  const smallest = readdirSync(join(LOCALES_DIR, SOURCE))
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => ({ f, n: leaves(JSON.parse(readFileSync(join(LOCALES_DIR, SOURCE, f), "utf8"))).length }))
+    .sort((a, b) => a.n - b.n)[0];
+
+  console.log(`\n  ${onlyLocale} does not exist yet. Start it with one file.\n`);
+  console.log(`    mkdir -p locales/${onlyLocale}`);
+  console.log(`    cp locales/${SOURCE}/${smallest.f} locales/${onlyLocale}/`);
+  console.log(`\n  Then translate the values in that one file — ${smallest.n} strings — and open a`);
+  console.log(`  pull request. Do not copy all ${sourceFiles.length} files: an untranslated copy of`);
+  console.log(`  English reads as finished work and is harder to find than a missing file.\n`);
+  console.log(`  A language is built one file at a time, by whoever turns up. It is only`);
+  console.log(`  registered in LOCALES (web/lib/locales.ts) once this reports 100%, so a`);
+  console.log(`  partial language breaks nothing and ships to nobody.\n`);
+  process.exit(1);
+}
+
+// English totals first — everything is measured against these.
+const sourceKeys = new Map();
+let sourceTotal = 0;
+for (const file of sourceFiles) {
+  const keys = leaves(read(SOURCE, file) ?? {});
+  sourceKeys.set(file, keys);
+  sourceTotal += keys.length;
+}
+
+console.log(`\n  Source: ${SOURCE} — ${sourceTotal} keys across ${sourceFiles.length} files\n`);
+
+let failed = false;
+
+for (const locale of targets) {
+  const missing = [];
+  const extra = [];
+  const untranslated = [];
+  const absentFiles = [];
+
+  for (const file of sourceFiles) {
+    const expected = sourceKeys.get(file);
+    const target = read(locale, file);
+
+    if (target === null) {
+      absentFiles.push(file);
+      missing.push(...expected.map((k) => `${file}:${k}`));
+      continue;
+    }
+
+    const actual = new Set(leaves(target));
+    for (const key of expected) {
+      if (!actual.has(key)) missing.push(`${file}:${key}`);
+    }
+    for (const key of actual) {
+      if (!expected.includes(key)) extra.push(`${file}:${key}`);
+    }
+
+    // Present, but identical to English — usually a copied file nobody translated.
+    const source = read(SOURCE, file);
+    for (const key of expected) {
+      if (!actual.has(key)) continue;
+      const a = key.split(".").reduce((o, k) => o?.[k], source);
+      const b = key.split(".").reduce((o, k) => o?.[k], target);
+      if (typeof a === "string" && a === b && a.trim() !== "") untranslated.push(`${file}:${key}`);
+    }
+  }
+
+  const done = sourceTotal - missing.length;
+  const percent = sourceTotal ? Math.round((done / sourceTotal) * 100) : 100;
+  const bar = "█".repeat(Math.round(percent / 5)).padEnd(20, "░");
+
+  console.log(`  ${locale.padEnd(6)} ${bar} ${String(percent).padStart(3)}%   ${done}/${sourceTotal}`);
+
+  // Per-file breakdown. This is the pick-list: one file is one contribution, so a
+  // contributor scans this and takes the smallest thing nobody has done.
+  if (missing.length) {
+    failed = true;
+    const perFile = sourceFiles
+      .map((file) => {
+        const total = sourceKeys.get(file).length;
+        const gone = missing.filter((m) => m.startsWith(`${file}:`)).length;
+        return { file, total, gone, absent: absentFiles.includes(file) };
+      })
+      .filter((row) => row.gone > 0)
+      .sort((a, b) => a.total - b.total);
+
+    console.log(`         ${missing.length} key(s) to translate, in ${perFile.length} file(s):\n`);
+    for (const row of perFile) {
+      const state = row.absent ? "not started" : `${row.total - row.gone}/${row.total} done`;
+      console.log(`           ${String(row.total).padStart(4)} keys  ${row.file.padEnd(22)} ${state}`);
+    }
+    console.log();
+
+    if (showAll) {
+      for (const key of missing) console.log(`           - ${key}`);
+      console.log();
+    } else {
+      console.log(`         Smallest first. Run with --list to see every key.\n`);
+    }
+  }
+  if (untranslated.length) {
+    console.log(`         ${untranslated.length} key(s) identical to English — check these are intentional`);
+    if (showAll) for (const key of untranslated) console.log(`           ~ ${key}`);
+  }
+  if (extra.length) {
+    failed = true;
+    console.log(`         ${extra.length} key(s) not in English — leftovers, remove them`);
+    if (showAll) for (const key of extra) console.log(`           + ${key}`);
+  }
+  console.log();
+}
+
+if (!failed) {
+  console.log(`  Nothing missing.\n`);
+}
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Adds `scripts/check-locales.mjs`, and turns translation into the entry point for new contributors.

## The script

Compares every locale against English — the source language — and reports what is missing, **per language and per file, smallest file first**.

```bash
node scripts/check-locales.mjs               # every language
node scripts/check-locales.mjs --locale fr   # one language, and what is left in it
node scripts/check-locales.mjs --list        # every missing key
```

No dependencies. Exits 1 when anything is missing, so it can become a CI check later.

It also catches two things a plain key-diff misses:

- **Keys present but identical to English** — the signature of a file that was copied and never translated. It reports rather than fails, because some really are meant to be identical: `Tel-Agent`, `SMS`, `WhatsApp`.
- **Keys absent from English** — leftovers, not translations.

**Current state:** 2,972 keys across 33 files. `ar` and `de` are both complete. `de` carries 111 keys identical to English and `ar` carries 32 — worth a look by someone who speaks them, but not necessarily wrong.

## Two tiers, which is the part that actually matters

| Tier | Locales | The promise |
|---|---|---|
| **Committed** | `en` · `de` · `ar` | Kept current. A new English string blocks a release until all three have it. |
| **Community** | everything else | Registered when complete, allowed to fall behind, holds nothing up. |

Without this split, every added language becomes a permanent obligation on every future change to English — and the honest answer to *"can we add twelve languages"* would have to be no. With it, the answer is yes, and adding one costs the project nothing.

## One file at a time, and why

A language is built one file at a time and is **not added to `LOCALES` until the script reports 100%**, so a partial language breaks nothing and ships to nobody.

`locales/README.md` says plainly why copying all 33 files is worse than leaving them missing: an untranslated copy of English looks finished, ships English to somebody who asked for their own language, and nothing flags it. A missing file is visible in one command.

## The skill

A first-time contributor is now sent here rather than to a code issue. The task is a loop — run the script, pick what is missing, translate it, open a pull request, repeat — and one file is one pull request. The smallest files are 16 to 26 strings, about twenty minutes.

It never runs out: 2,972 strings per language, and any language anybody speaks is welcome.

## Verification

```
$ node scripts/check-locales.mjs
  Source: en — 2972 keys across 33 files
  ar     ████████████████████ 100%   2972/2972
  de     ████████████████████ 100%   2972/2972
  Nothing missing.
$ echo $?
0

$ node scripts/check-locales.mjs --locale fr
  fr does not exist yet. Start it with one file.
  ...
$ echo $?
1
```

Also tested against a simulated partial locale: the per-file pick-list renders smallest-first and the percentage is correct. Invalid JSON exits 2 with the file named.

No dependency added. No competitor named, no secret.