### PR TITLE
docs: add issue templates, AGENTS.md, and Cursor rules

### DIFF
--- a/.cursor/rules/locales.mdc
+++ b/.cursor/rules/locales.mdc
@@ -1,0 +1,17 @@
+---
+description: Translation and locale file rules
+globs: locales/**/*.json
+alwaysApply: false
+---
+
+# locales/
+
+- English (`locales/en/`) is the source of truth. Measure coverage with:
+  `node scripts/check-locales.mjs` or `--locale <code>`.
+- **One file per pull request.** Do not copy all 33 files and translate one.
+- Translate **values only**. Never change keys.
+- Leave `{placeholders}` unchanged (`{count}`, `{name}`, …).
+- Only translate languages you speak. Unreviewed machine translation is worse than missing.
+- Product names stay as-is (Tel-Agent, WhatsApp, SMS, …).
+- Partial community locales are fine; only `en` / `de` / `ar` block releases.
+- First-time contributors: follow `docs/ONBOARDING.md`.

--- a/.cursor/rules/python-agent-api.mdc
+++ b/.cursor/rules/python-agent-api.mdc
@@ -1,0 +1,24 @@
+---
+description: Python conventions for agent/ and api/
+globs: "{agent,api}/**/*.py"
+alwaysApply: false
+---
+
+# Python — agent/ and api/
+
+- Python 3.11+, type hints on every public function.
+- Format: `ruff format`. Lint: `ruff check`. Prefer `async`/`await` on any path that can sit near media or live sessions.
+- Config from environment variables only. Document new vars in `.env.example` with safe placeholders.
+- Never log API keys or return them in full to a client (mask; last four chars only in UI).
+
+## agent/
+
+- Soft real-time: blocking calls on the media / session path are bugs.
+- Stream: start TTS (or token output) before the full LLM reply exists.
+- TTS `cancel()` is required for barge-in; discard queued speech.
+- If latency is bad, fix streaming before adding features.
+
+## api/
+
+- No media, codecs, or RTP. Read transcripts the agent wrote.
+- Enforce authz here; the browser is not the security boundary.

--- a/.cursor/rules/tel-agent-core.mdc
+++ b/.cursor/rules/tel-agent-core.mdc
@@ -1,0 +1,21 @@
+---
+description: Core Tel-Agent rules for every Cursor session
+alwaysApply: true
+---
+
+# Tel-Agent — always
+
+- Read `CLAUDE.md` and `AGENTS.md` before substantive edits. Spec wins on conflict: `docs/SPEC.md`.
+- **English only** in code, comments, commits, PRs, issues.
+- **Never name a competitor** in any public artefact. Check before commit.
+- **Never commit secrets**, real recordings, or real transcripts.
+- Work comes from a claimed GitHub issue. Stay inside it; park extras in `IDEAS.md`.
+- Milestone 0 = web chat stream + cancel + stored conversation. Phone is last.
+- Conversation layer must satisfy voice constraints (stream, barge-in/cancel, latency) even on text channels.
+- Do not invent features outside the issue or current milestone.
+
+## Architecture at a glance
+
+- `web/` → `api/` only. Never call `agent/` from the browser.
+- `api/` never touches audio. `agent/` never serves the dashboard.
+- `agent/` ↔ `api/` communicate via DB / Redis, not HTTP to each other.

--- a/.cursor/rules/web-frontend.mdc
+++ b/.cursor/rules/web-frontend.mdc
@@ -1,0 +1,15 @@
+---
+description: Next.js dashboard conventions under web/
+globs: web/**/*.{ts,tsx,css}
+alwaysApply: false
+---
+
+# web/ — dashboard
+
+- Talk **only** to `api/`. No direct agent calls.
+- No business rule that the API does not also enforce.
+- Layouts must survive ~1.4× string growth (German). No fixed-width labels that clip.
+- Arabic: full RTL for chrome; keep phone numbers, timestamps, IDs, logs, code LTR.
+- Dark theme designed first; light is a real second pass, not a naive invert.
+- Every screen needs empty, loading (skeletons), error, success, and offline states.
+- User-facing copy comes from `locales/`, not hardcoded English in components.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,11 +5,11 @@ contact_links:
     about: >-
       Never report a security problem in a public issue. Use private vulnerability
       reporting, or email info@dpro.at with SECURITY in the subject.
-  - name: Feature idea
+  - name: Park an idea in IDEAS.md
     url: https://github.com/Dpro-at/Tel-Agent/blob/main/IDEAS.md
     about: >-
-      The project is at Milestone 0 and nothing beyond it is being built yet. Ideas are
-      parked in IDEAS.md until the first call works. Open a discussion to suggest one.
+      Beyond Milestone 0? Open a discussion or a Feature request issue — maintainers
+      park out-of-order work in IDEAS.md until the current milestone is done.
   - name: Read the specification first
     url: https://github.com/Dpro-at/Tel-Agent/blob/main/docs/SPEC.md
     about: Most questions about what Tel-Agent does and does not do are answered there.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,81 @@
+name: Feature request
+description: Propose something Tel-Agent does not do yet
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Tel-Agent is at **Milestone 0** — web chat answered end to end, streaming,
+        cancellable. The phone is Milestone 11. Work outside that order is parked
+        in [IDEAS.md](https://github.com/Dpro-at/Tel-Agent/blob/main/IDEAS.md)
+        rather than built.
+
+        Use this form to describe the idea clearly. If it is beyond the current
+        milestone, expect it to be recorded in `IDEAS.md` instead of scheduled.
+
+        **Never include an API key, a SIP password, a real recording, or a real
+        transcript.** Security problem? See [SECURITY.md](https://github.com/Dpro-at/Tel-Agent/blob/main/SECURITY.md).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Who hits this, and what goes wrong today without it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What should Tel-Agent do?
+      description: The behaviour you want. Prefer outcomes over implementation.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: channel
+    attributes:
+      label: Which channel or area?
+      options:
+        - web chat
+        - phone / SIP
+        - messaging (SMS, email, WhatsApp, Telegram, …)
+        - dashboard (web/)
+        - api
+        - agent tooling
+        - documentation
+        - not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: milestone_fit
+    attributes:
+      label: Does this help Milestone 0?
+      description: >-
+        Milestone 0 is a visitor typing in web chat, an LLM replying token by
+        token, cancel mid-sentence, conversation stored and searchable.
+      options:
+        - Yes — it is required for Milestone 0
+        - No — park it in IDEAS.md
+        - Unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, or why a webhook / HTTP tool is not enough.
+
+  - type: checkboxes
+    id: reminders
+    attributes:
+      label: Before filing
+      options:
+        - label: I checked IDEAS.md and docs/SPEC.md so this is not already recorded
+          required: true
+        - label: Everything in this issue is written in English
+          required: true
+        - label: No competitor is named anywhere in this issue
+          required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -71,11 +71,11 @@ body:
       label: Level
       description: How hard is this for a contributor who does not know the codebase yet?
       options:
-        - level: first-issue
-        - level: easy
-        - level: medium
-        - level: hard
-        - level: maintainer
+        - "level: first-issue"
+        - "level: easy"
+        - "level: medium"
+        - "level: hard"
+        - "level: maintainer"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,107 @@
+name: Task
+description: A scoped piece of work with Why / Do / Done when / Verify
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for board work. Every field below is what reviewers and
+        contributors expect. Leave **Needs** empty if nothing blocks this task.
+
+        **Never include an API key, a SIP password, a real recording, or a real
+        transcript.**
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: Why this task exists. The reason, not the solution.
+      placeholder: A boundary is cheap now and a refactor later.
+    validations:
+      required: true
+
+  - type: textarea
+    id: do
+    attributes:
+      label: Do
+      description: What to build or change. Concrete and bounded.
+      placeholder: |
+        - Write the rule in docs/ARCHITECTURE.md
+        - Enforce it with an import-linter contract
+    validations:
+      required: true
+
+  - type: textarea
+    id: done_when
+    attributes:
+      label: Done when
+      description: The acceptance test. Someone who never saw the branch can check this.
+      placeholder: An import that crosses the line fails CI.
+    validations:
+      required: true
+
+  - type: textarea
+    id: verify
+    attributes:
+      label: Verify
+      description: Exact commands a reviewer will run. Paste real commands, not "run the tests".
+      placeholder: |
+        ruff check .
+        npm --prefix web run lint
+    validations:
+      required: true
+
+  - type: textarea
+    id: needs
+    attributes:
+      label: Needs
+      description: Issues that must be closed before this one is Ready. Leave blank if none.
+      placeholder: Needs #16 (CI must exist before the contract can fail in CI)
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Files
+      description: Paths that are expected to change, if known.
+      placeholder: docs/ARCHITECTURE.md, .importlinter
+
+  - type: dropdown
+    id: level
+    attributes:
+      label: Level
+      description: How hard is this for a contributor who does not know the codebase yet?
+      options:
+        - level: first-issue
+        - level: easy
+        - level: medium
+        - level: hard
+        - level: maintainer
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - agent
+        - api
+        - web
+        - locales
+        - documentation
+        - tooling / CI
+        - cross-cutting
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: reminders
+    attributes:
+      label: Before filing
+      options:
+        - label: Everything in this issue is written in English
+          required: true
+        - label: No competitor is named anywhere in this issue
+          required: true
+        - label: This is one task, not a bundle of unrelated work
+          required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ For the human contributor path (fork → claim → branch → PR), follow
 5. **Milestone 0 first:** web chat streams and cancels; conversation is stored. Messaging
    channels next. **Phone is last (Milestone 11).** Write the conversation layer to voice
    constraints from day one (streaming, cancel, latency).
-6. **Everything streams.** Target &lt;800 ms end-of-speech → first audio. Never wait for a
+6. **Everything streams.** Target <800 ms end-of-speech → first audio. Never wait for a
    full LLM reply before starting TTS. `cancel()` on TTS is mandatory.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md — guidance for AI coding agents
+
+You are working in **Tel-Agent**, an AGPL-3.0 self-hosted AI phone and messaging
+assistant by Dpro GmbH (Vienna). This file is the short entry point for any coding
+agent (Cursor, Codex, Copilot, and similar).
+
+**The full working contract is [`CLAUDE.md`](CLAUDE.md).** Read it before changing
+code. When `docs/SPEC.md` and any other document disagree, the specification wins.
+
+For the human contributor path (fork → claim → branch → PR), follow
+[`.claude/skills/contributing/SKILL.md`](.claude/skills/contributing/SKILL.md).
+
+---
+
+## Non-negotiable
+
+1. **English only** in code, comments, commits, PRs, and issues. UI strings live in
+   `locales/` (`en` / `de` / `ar`).
+2. **Never name a competitor** anywhere public — irreversible once pushed.
+3. **Never commit secrets** — keys go in `.env` (ignored) or encrypted DB columns later.
+4. **Stay inside the issue.** Extra ideas go in `IDEAS.md` or a new issue, not this branch.
+5. **Milestone 0 first:** web chat streams and cancels; conversation is stored. Messaging
+   channels next. **Phone is last (Milestone 11).** Write the conversation layer to voice
+   constraints from day one (streaming, cancel, latency).
+6. **Everything streams.** Target &lt;800 ms end-of-speech → first audio. Never wait for a
+   full LLM reply before starting TTS. `cancel()` on TTS is mandatory.
+
+---
+
+## Repository layout
+
+| Path | Role |
+|---|---|
+| `agent/` | Soft real-time conversation / call path (Python). Never serves the dashboard. |
+| `api/` | FastAPI REST + WebSocket. Never touches audio. |
+| `web/` | Next.js dashboard. Talks **only** to `api/`. |
+| `locales/` | UI strings. One translated file per PR for first contributions. |
+| `docs/SPEC.md` | Single source of truth for product behaviour |
+| `docs/ARCHITECTURE.md` | What may import / talk to what |
+| `IDEAS.md` | Parking lot for anything outside current milestone |
+
+`agent/` and `api/` do not call each other — the database (and Redis for live events)
+is the boundary. See `docs/ARCHITECTURE.md`.
+
+---
+
+## Verify before you open a PR
+
+Run the issue's **Verify** commands first, then the gate for what you touched:
+
+```bash
+# Python (when agent/ or api/ exist and are in scope)
+ruff check . && ruff format --check . && mypy . && pytest
+
+# web/
+npm --prefix web run lint
+npx --prefix web tsc --noEmit
+npm --prefix web run build
+
+# locales (translation PRs)
+node scripts/check-locales.mjs --locale <code>
+```
+
+Hand-check: no secrets, no competitor names, English only, one concern per PR.
+
+Commits: Conventional Commits, English, imperative (`feat(api): …`, `docs: …`).
+Branches: `feat/`, `fix/`, `docs/`, `chore/`, `refactor/`, `test/`.
+
+---
+
+## Cursor-specific rules
+
+Scoped project rules live in [`.cursor/rules/`](.cursor/rules/). They refine this file
+for `web/`, Python paths, and `locales/` — they do not replace `CLAUDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,8 @@ Competitive notes belong in , which is gitignored and never published.
 | `IDEAS.md` | Parking lot for everything not in v1 |
 | `CLA.md` | Contributor License Agreement |
 | `.env.example` | Every environment variable, documented |
+| `AGENTS.md` | Short entry for any coding agent; this file remains the full working contract |
+| `.cursor/rules/` | Cursor-scoped rules that refine `AGENTS.md` for `web/`, Python paths, and `locales/` |
 | `.claude/skills/contributing/` | The contributor workflow as a skill — clone to fork to merged pull request. It ships with the repository, so an agent working inside a clone already has it. |
 | `internal/` | **Gitignored here, and does not exist in this repository.** The working notes live in a private repository instead; the ignore entry is kept as a guard so the folder cannot reappear here by accident. Never put a credential anywhere, in either repository. |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,10 @@ slowly as its harder half.
 
 ### If you work with an AI coding agent
 
-The repository ships the whole workflow as a skill at
+The repository ships [`AGENTS.md`](AGENTS.md) for any coding agent, Cursor rules under
+[`.cursor/rules/`](.cursor/rules/), and the whole workflow as a skill at
 [`.claude/skills/contributing/`](.claude/skills/contributing/SKILL.md). An agent working
-inside your clone picks it up automatically, so it already knows the branch naming, the
+inside your clone picks these up automatically, so it already knows the branch naming, the
 verification gate, and the rules below — you do not have to explain them.
 
 Most issues also carry a ready-to-paste prompt and a rough time estimate in a comment.
@@ -184,6 +185,7 @@ English, imperative mood. Explain *why* in the body when the change is not obvio
 | [`docs/SPEC.md`](docs/SPEC.md) | The complete specification — the single source of truth |
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | How `agent/`, `api/` and `web/` are separated, and which may talk to which |
 | [`CLAUDE.md`](CLAUDE.md) | The development rules, including the build order |
+| [`AGENTS.md`](AGENTS.md) | Short entry for AI coding agents (points at `CLAUDE.md`) |
 | [`IDEAS.md`](IDEAS.md) | Everything deferred, and why |
 
 When the specification and any other document disagree, the specification wins — and


### PR DESCRIPTION
## Summary
- Completes #12: `task.yml` (Why / Do / Done when / Verify) and `feature_request.yml`, plus a small `config.yml` contact-link update. Bug report and PR templates were already present.
- Adds `AGENTS.md` as a short cross-tool entry for coding agents, with Cursor-scoped rules under `.cursor/rules/`, pointing at `CLAUDE.md` as the full working contract.
- Links the new agent files from `CLAUDE.md` and `CONTRIBUTING.md`.

## Test plan
- [ ] On GitHub after merge (or from this fork): **New issue** shows Bug report, Feature request, and Task in the chooser
- [ ] Opening a Task issue requires Why / Do / Done when / Verify
- [ ] Opening a Feature request asks about Milestone 0 fit and points at IDEAS.md for out-of-order work
- [ ] Opening a PR still pre-fills `.github/PULL_REQUEST_TEMPLATE.md`
- [ ] Confirm no secrets or competitor names in the diff

Closes #12


Made with [Cursor](https://cursor.com)