### PR TITLE
feat(locales): translate code.json into Italian

### DIFF
--- a/locales/it/code.json
+++ b/locales/it/code.json
@@ -1,0 +1,18 @@
+{
+  "title": "Inserisci il codice",
+  "sent_to": "Un codice di sei cifre è stato inviato a {address}. È valido per dieci minuti.",
+  "digit_label": "Cifra {position} di {total}",
+  "submit": "Continua",
+  "submit_offline": "Server irraggiungibile",
+  "wrong_code": "Il codice non corrisponde. Rimangono {attempts} tentativi prima che sia necessario richiedere un nuovo codice.",
+  "expired_title": "Questo codice è scaduto",
+  "expired_body": "I codici sono validi per dieci minuti. Richiedine uno nuovo: quello vecchio non funzionerà, anche se riesci a trovarlo.",
+  "expires_in": "Scade tra {time}",
+  "resend": "Invia un nuovo codice",
+  "resend_prompt_expired": "Non c'è più nulla da aspettare",
+  "back": "Torna all'accesso",
+  "self_hosted": "Ospitato autonomamente · nulla lascia questa macchina",
+  "offline_title": "Questo browser non riesce a raggiungere il tuo server Tel-Agent",
+  "offline_body": "Nessuna risposta da {host}. Le tue chiamate non sono interessate se la macchina è ancora in esecuzione: si tratta di un problema di rete tra te e la macchina. Verifica di essere connesso alla rete aziendale o alla VPN.",
+  "offline_retry": "Riprova connessione"
+}


### PR DESCRIPTION
# Pull request

## What does this change, and why?

Translated `code.json` into Italian to add the Italian locale.

## Related issue

Refs #40

---

## Contributor License Agreement — required

Every contribution needs this before it can be merged, including one-line fixes.
You keep full ownership and copyright of your work. See [CLA.md](../CLA.md).

- [x] I have read the CLA document and I hereby sign the CLA.

---

## Checklist

- [ ] Everything I wrote — code, comments, commit messages — is in **English**
- [x] This PR does **one thing**
- [ ] I have not added any credential, real recording, or real transcript
- [ ] New configuration is documented in `.env.example` with a safe placeholder

**If this touches the call path (`agent/`):**

- [ ] Nothing on the audio path blocks — it is `async` throughout
- [ ] I have considered the latency budget (§B4: under 800 ms from end of caller
      speech to first audio out) and stated the impact below
- [ ] If it touches speech, I tested it **in German** — English alone proves little for
      this project

Latency impact:

none

---

## Before you open this

Tel-Agent is at **Milestone 0** — a visitor types on a web page, the agent answers,
the thread holds, and the reply streams and can be cancelled. Nothing else is being
built yet. The phone is Milestone 11.

**Feature PRs will be pointed at [IDEAS.md](../IDEAS.md) rather than merged.** That is
not a judgement on the idea; it is how this project stays finishable. Bug fixes,
documentation, specification corrections, and anything that helps Milestone 0 work are
welcome now.

Security problem? **Do not open a PR** — see [SECURITY.md](../SECURITY.md).