### PR TITLE
ci(locales): check placeholders on every locale, and run both checks in CI

### DIFF
--- a/.github/workflows/locales.yml
+++ b/.github/workflows/locales.yml
@@ -1,0 +1,45 @@
+# Every user-facing string is contributed by whoever turns up, in a language most
+# reviewers here do not read. These two scripts are what a reviewer cannot do by eye:
+# they check the shape of a translation against English, and they say nothing about
+# whether the words are any good.
+name: Locales
+
+on:
+  pull_request:
+    paths:
+      - "locales/**"
+      - "scripts/check-locales.mjs"
+      - "scripts/check-placeholders.mjs"
+      - ".github/workflows/locales.yml"
+  push:
+    branches: [main]
+    paths:
+      - "locales/**"
+      - "scripts/check-locales.mjs"
+      - "scripts/check-placeholders.mjs"
+      - ".github/workflows/locales.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check translations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # Gates every locale: a dropped or invented {placeholder} is a bug in a string
+      # that already shipped, not a language that is merely behind.
+      - name: Placeholders match English
+        run: node scripts/check-placeholders.mjs
+
+      # Gates en / de / ar only, by design — a community locale is allowed to be
+      # incomplete. `always()` so one run reports both problems instead of two.
+      - name: Committed locales are complete
+        if: always()
+        run: node scripts/check-locales.mjs

--- a/locales/README.md
+++ b/locales/README.md
@@ -12,12 +12,21 @@ written there first and every other locale is measured against it.
 node scripts/check-locales.mjs                     # where every language stands
 node scripts/check-locales.mjs --locale fr         # one language, file by file
 node scripts/check-locales.mjs --locale fr --list  # every missing key in it
+
+node scripts/check-placeholders.mjs                # every {placeholder} matches English
+node scripts/check-placeholders.mjs --locale fr    # one language
 ```
 
 Only the committed locales gate anything: the script exits 1 when `de` or `ar` is
 missing a key and 0 when a community language is behind. Use `--list` with `--locale`
 — on its own it prints every missing key in every language, which is tens of thousands
 of lines once the wanted languages are sitting there empty.
+
+**`check-placeholders.mjs` gates every locale, community ones included.** Being
+unfinished is allowed; a `{host}` that was dropped or misspelled in a string that
+already shipped is a bug, and it is invisible to a coverage count and to a reviewer who
+does not read the language. Translate the words around the braces and copy the braces
+across untouched.
 
 ---
 

--- a/scripts/check-placeholders.mjs
+++ b/scripts/check-placeholders.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Checks that every translated string carries the same placeholders as its English
+ * original.
+ *
+ * A placeholder is a `{name}` the application fills in at render time. Drop one and
+ * the value it stood for is never shown — the user reads "No response from ." and the
+ * host they needed is gone. Invent one and it renders literally, `{hsot}` and all.
+ * Neither breaks the build, neither shows up in a coverage count, and both survive a
+ * reviewer who does not read the language.
+ *
+ * This is deliberately not part of check-locales.mjs. That script measures how much of
+ * English a locale has reached, and it lets a community language sit at 40% because
+ * being unfinished is allowed. A broken placeholder is not slow progress, it is a bug
+ * in a string that already shipped, so this gates every locale in the tree.
+ *
+ * Keys the locale has not translated yet are not this script's business — a key that
+ * is absent cannot have the wrong placeholders, and check-locales.mjs already counts
+ * it. Only keys present in both are compared.
+ *
+ * Placeholders are compared as sets, not as counts. Word order moves between languages
+ * and a translation may reasonably mention a value once where English mentions it
+ * twice; what matters is that nothing is dropped and nothing is invented.
+ *
+ * No dependencies. Run it with:
+ *
+ *   node scripts/check-placeholders.mjs
+ *   node scripts/check-placeholders.mjs --locale es
+ */
+
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const LOCALES_DIR = join(ROOT, "locales");
+const SOURCE = "en";
+
+/** `{host}`, `{count}` — a single identifier in braces, which is all this project uses. */
+const PLACEHOLDER = /\{([a-zA-Z0-9_]+)\}/g;
+
+const args = process.argv.slice(2);
+const onlyLocale = args.includes("--locale") ? args[args.indexOf("--locale") + 1] : undefined;
+
+/** Every leaf key in an object, as dotted paths. Arrays count as leaves. */
+function leaves(obj, prefix = "") {
+  const out = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      out.push(...leaves(value, path));
+    } else {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+function read(locale, file) {
+  const path = join(LOCALES_DIR, locale, file);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    console.error(`  ✗ ${locale}/${file} is not valid JSON — ${error.message}`);
+    process.exit(2);
+  }
+}
+
+function at(obj, key) {
+  return key.split(".").reduce((o, k) => o?.[k], obj);
+}
+
+function placeholders(value) {
+  return typeof value === "string" ? new Set(value.match(PLACEHOLDER) ?? []) : new Set();
+}
+
+const localeDirs = readdirSync(LOCALES_DIR, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
+
+if (!localeDirs.includes(SOURCE)) {
+  console.error(`No ${SOURCE}/ directory. English is the source language.`);
+  process.exit(2);
+}
+
+const sourceFiles = readdirSync(join(LOCALES_DIR, SOURCE)).filter((f) => f.endsWith(".json"));
+const targets = localeDirs.filter((l) => l !== SOURCE && (!onlyLocale || l === onlyLocale));
+
+if (onlyLocale && !targets.length) {
+  console.error(`No locales/${onlyLocale}/ directory.`);
+  process.exit(2);
+}
+
+console.log(`\n  Comparing placeholders against ${SOURCE}/\n`);
+
+let failed = false;
+let checked = 0;
+
+for (const locale of targets) {
+  const problems = [];
+
+  for (const file of sourceFiles) {
+    const target = read(locale, file);
+    if (target === null) continue;
+
+    const source = read(SOURCE, file);
+
+    for (const key of leaves(source ?? {})) {
+      const translated = at(target, key);
+      // Absent here means untranslated, which check-locales.mjs reports.
+      if (typeof translated !== "string") continue;
+
+      checked += 1;
+      const expected = placeholders(at(source, key));
+      const actual = placeholders(translated);
+
+      const dropped = [...expected].filter((p) => !actual.has(p));
+      const invented = [...actual].filter((p) => !expected.has(p));
+
+      if (dropped.length || invented.length) {
+        problems.push({ file, key, dropped, invented });
+      }
+    }
+  }
+
+  if (problems.length) {
+    failed = true;
+    console.log(`  ✗ ${locale} — ${problems.length} string(s) with the wrong placeholders\n`);
+    for (const { file, key, dropped, invented } of problems) {
+      console.log(`      ${file}:${key}`);
+      if (dropped.length) console.log(`        dropped:  ${dropped.join(" ")}`);
+      if (invented.length) console.log(`        invented: ${invented.join(" ")}`);
+    }
+    console.log();
+  }
+}
+
+if (!failed) {
+  console.log(`  ${checked} translated string(s) across ${targets.length} locale(s). Placeholders all match.\n`);
+} else {
+  console.log(`  A dropped placeholder loses the value it stood for; an invented one renders`);
+  console.log(`  as literal text. Copy the braces from ${SOURCE}/ exactly — only the words`);
+  console.log(`  around them get translated.\n`);
+}
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Translations arrive from contributors writing languages most reviewers here do not read. `check-locales.mjs` already measures key coverage. Nothing checked the braces *inside* the strings.

A `{host}` that gets dropped or misspelled costs the user the value it stood for — they read `No response from .` — and it passes a coverage count, and it looks fine to anyone skimming the diff.

## What this adds

**`scripts/check-placeholders.mjs`** — compares the placeholder set of every translated string against its English original. Dependency-free, same shape and conventions as `check-locales.mjs`.

```
node scripts/check-placeholders.mjs
node scripts/check-placeholders.mjs --locale es
```

**`.github/workflows/locales.yml`** — runs both scripts on any change under `locales/` or to either script. `if: always()` on the second step so one run reports every problem instead of two round-trips.

## The two scripts gate different things

| | `check-locales.mjs` | `check-placeholders.mjs` |
|---|---|---|
| Measures | how much of English a locale has | whether translated strings are well-formed |
| Fails for | `en` / `de` / `ar` only | **every locale** |

Coverage and correctness are different rules. A community locale is allowed to be unfinished; it is not allowed to ship a broken string.

## Verification

Passes on the current tree — 6002 translated strings across 32 locales, all placeholders matching.

Deliberately breaking `es/code.json` two ways is caught and exits 1:

```
  ✗ es — 2 string(s) with the wrong placeholders

      code.json:sent_to
        dropped:  {address}
        invented: {addres}
      code.json:offline_body
        dropped:  {host}
```

The workflow's own checks on this PR are the rest of the proof.