### PR TITLE
fix(tests): guard the route-table walk, as its sibling already did

### DIFF
--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -185,4 +185,6 @@ def test_the_app_builds_without_leaving_the_probe_route(settings: Settings) -> N
     """A guard on the fixture above: the probe is added to its own app, not the shared one."""
     app: FastAPI = create_app(settings)
 
-    assert not any(route.path == "/concurrency-probe" for route in app.routes)  # type: ignore[attr-defined]
+    assert not any(
+        route.path == "/concurrency-probe" for route in app.routes if hasattr(route, "path")
+    )


### PR DESCRIPTION
`main` has been red since #59 landed. This turns it green.

## What broke

CI resolves `fastapi>=0.118` to **fastapi 0.141.1 / starlette 1.6.0**, which put `_IncludedRouter` objects into `app.routes` alongside the flattened routes. They carry no `.path`.

```
tests/test_request_id.py:188
AttributeError: '_IncludedRouter' object has no attribute 'path'
1 failed, 301 passed
```

The walk touched `.path` on every entry, so it raised before it could evaluate the condition.

## Why this is a test bug, not a dependency problem

`test_every_route_is_protected_unless_it_is_on_the_public_list` in `tests/test_auth.py` walks the same table and **already guards**:

```python
if hasattr(route, "path") and not route.path.startswith("/docs/")
```

One reader of the route table guarded, the other did not. This applies the same guard, so the two agree. The `# type: ignore[attr-defined]` goes with it — the guard is what the checker was asking for.

## The assertion is not weakened

Verified against the exact versions CI installs:

```
fastapi 0.141.1 | starlette 1.6.0

  Route            has path: True
  _IncludedRouter  has path: False
  APIRoute         has path: True

unguarded walk raises:            YES -> '_IncludedRouter' has no attribute 'path'
guarded walk raises:              no
guarded walk still sees @app.get: True
```

That last line is the one that matters. The probe is registered with a bare `@app.get("/concurrency-probe")`, never through a router, so a guarded walk still catches it if it ever leaks into the shared app. The guard removes the crash, not the test.

## Not addressed here, on purpose

`pyproject.toml` pins `fastapi>=0.118` with no upper bound, so a release can turn `main` red without anyone touching the repo — which is what happened. Whether this project wants reproducible dependency resolution is a real decision, separate from this fix, and I have raised it rather than deciding it in a bug fix.