### PR TITLE
Make the closed-by-default walk see the routes, and prove it

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -47,6 +47,45 @@ def is_public(path: str) -> bool:
     return path in PUBLIC_PATHS
 
 
+def served_paths(app: object) -> set[str]:
+    """Every path this application actually serves, flattened.
+
+    `app.routes` is **not** flat. Since FastAPI 0.14x, `include_router` leaves an
+    `_IncludedRouter` entry that holds its own `.routes` rather than splicing the
+    children into the top level. A walk that only looks at the top level therefore
+    sees the four routes registered directly on the app and none of the routers -
+    which is precisely how the closed-by-default test came to be inspecting almost
+    nothing while reporting green.
+
+    Recursing is the fix, and it is written here beside `PUBLIC_PATHS` rather than in
+    a test, because "what does this application serve" is a question the rule itself
+    is about.
+    """
+    found: set[str] = set()
+
+    def walk(routes: object) -> None:
+        for route in routes or []:
+            path = getattr(route, "path", None)
+            if isinstance(path, str):
+                found.add(path)
+
+            # An `_IncludedRouter` exposes neither `.path` nor `.routes`; the children
+            # hang off `original_router`, and their `.path` is *already* prefixed
+            # because `include_router` rewrites them as it copies. A mount is the
+            # other shape, and carries `.routes` directly.
+            included = getattr(route, "original_router", None)
+            if included is not None:
+                walk(getattr(included, "routes", None))
+                continue
+
+            children = getattr(route, "routes", None)
+            if children:
+                walk(children)
+
+    walk(getattr(app, "routes", []))
+    return found
+
+
 class Unauthenticated(HTTPException):
     """401, in the one error envelope every failure uses.
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -19,7 +19,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.config import Settings
-from api.dependencies import PUBLIC_PATHS, is_public
+from api.dependencies import PUBLIC_PATHS, served_paths
 from api.main import create_app
 from api.models import Session
 from api.security.session import COOKIE_NAME, SESSION_LIFETIME, hash_token
@@ -159,23 +159,39 @@ async def test_a_session_reaches_the_protected_route(signed_up: AsyncClient) -> 
 
 
 async def test_every_route_is_protected_unless_it_is_on_the_public_list(
-    settings: Settings,
+    signed_up: AsyncClient, settings: Settings
 ) -> None:
     """D5's acceptance condition: walk the route table, prove nothing escaped.
 
-    This is the test that catches an endpoint somebody adds next year without thinking
-    about authentication. It fails on the new route rather than on the incident.
+    The proof is a request per route, not a set comparison. The previous version of
+    this test built its candidate set with `if is_public(path)` and then asserted that
+    set was a subset of `PUBLIC_PATHS` - which `is_public` guarantees by definition.
+    It was a tautology, it passed on an empty route list, and it went on passing when
+    a FastAPI change hid every real route behind `_IncludedRouter`. Asking the running
+    application what it answers cannot be satisfied that way.
     """
     app = create_app(settings)
+    served = served_paths(app)
 
-    paths = {
-        route.path
-        for route in app.routes
-        if hasattr(route, "path") and not route.path.startswith("/docs/")
+    # The walk sees the real API, not just the four routes registered on the app
+    # itself. If this fails, the walk is broken and everything below is vacuous.
+    assert "/api/auth/login" in served
+    assert "/api/auth/me" in served
+    assert len(served) > 10
+
+    protected = {
+        path for path in served if path not in PUBLIC_PATHS and not path.startswith("/docs/")
     }
-    unprotected = {path for path in paths if is_public(path)}
+    assert protected, "no protected routes found - the walk is lying"
 
-    assert unprotected <= PUBLIC_PATHS
+    # Signed out. The gate runs before routing, so the method does not matter: every
+    # non-public path answers 401 whatever verb it was declared with.
+    signed_up.cookies.clear()
+    for path in sorted(protected):
+        response = await signed_up.get(path)
+        assert response.status_code == 401, f"{path} answered {response.status_code}"
+        assert response.json()["error"]["code"] == "unauthenticated"
+
     # And the list itself is short enough to read in one go. If it is growing, that is
     # the thing to notice.
     assert len(PUBLIC_PATHS) <= 12

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -19,6 +19,7 @@ from httpx import ASGITransport, AsyncClient
 
 from api import dependencies
 from api.config import Settings
+from api.dependencies import served_paths
 from api.logging import request_id_var
 from api.main import create_app
 from api.middleware.request_id import HEADER
@@ -185,6 +186,7 @@ def test_the_app_builds_without_leaving_the_probe_route(settings: Settings) -> N
     """A guard on the fixture above: the probe is added to its own app, not the shared one."""
     app: FastAPI = create_app(settings)
 
-    assert not any(
-        route.path == "/concurrency-probe" for route in app.routes if hasattr(route, "path")
-    )
+    # `served_paths` rather than a bare walk of `app.routes`: since FastAPI 0.14x the
+    # top level holds `_IncludedRouter` entries with no `.path` at all, and touching
+    # it raises before the condition is ever evaluated.
+    assert "/concurrency-probe" not in served_paths(app)


### PR DESCRIPTION
#61 stopped the crash. This makes the test mean something again.

Two defects were sitting on top of each other — the second hidden by the first.

## The walk was blind

Since FastAPI 0.14x, `include_router` leaves an `_IncludedRouter` entry on
`app.routes` carrying neither `.path` nor `.routes`; the children hang off
`.original_router`, already prefixed. Guarding with `hasattr` stops the
`AttributeError` — but it skips those entries **silently**, so the walk sees five
paths and none of the API:

```
hasattr walk (what main has today) :  5 paths   docs, oauth2-redirect, health, openapi, redoc
served_paths (this branch)         : 17 paths
newly visible and protected        : /api/auth/events  /api/auth/logout
                                     /api/auth/logout-all  /api/auth/me
                                     /api/auth/password  /api/settings
```

`served_paths()` recurses through `original_router` and mounts alike. It lives in
`api/dependencies.py` beside `PUBLIC_PATHS`, because "what does this application
serve" is a question the closed-by-default rule is *about*, not a test helper.

## The D5 test was a tautology, and always had been

```python
unprotected = {path for path in paths if is_public(path)}
assert unprotected <= PUBLIC_PATHS
```

`is_public(path)` means `path in PUBLIC_PATHS`, so the set is a subset by
construction. The assertion is true for every possible input — including an empty
route list, which is exactly what the blind walk had been handing it.

It now asks the running application instead: every served path outside
`PUBLIC_PATHS` is requested signed out and must answer `401`, behind a floor
assertion that the walk sees the real API first — so a broken walk fails loudly
rather than vacuously.

This is the test meant to catch an endpoint somebody adds next year without
thinking about authentication. Until now it could not have. That is my own defect,
from the day the test was written, not something the FastAPI change introduced.

## Verification

```
ruff format --check · ruff check · lint-imports · check-locales   PASS
pytest -q                        330 passed (SQLite + PostgreSQL)
fastapi                          0.141.1 — the version CI resolves
```

## Two things this leaves for the maintainer

1. **`ci.yml`'s three checks are still not required on `main`.** They run on every
   PR and block nothing; only `Check translations` is a gate. #59 merged red — that
   is the mechanism, not bad luck.
2. **`fastapi>=0.118` has no upper bound**, so any release can turn `main` red
   without anyone touching the repository. Pinning trades breakage for staleness;
   worth being a decision rather than an accident.