### PR TITLE
deps: bound FastAPI, and declare Starlette in its own right

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,14 @@ license = { text = "AGPL-3.0-or-later" }
 authors = [{ name = "Dpro GmbH" }]
 
 dependencies = [
-    "fastapi>=0.118",
+    # Upper bounds because FastAPI is pre-1.0: the minor position is the breaking one.
+    # Starlette 1.6 put `_IncludedRouter` objects in `app.routes` and turned main red
+    # with nothing in this repository having changed. Starlette is listed in its own
+    # right, not left to arrive through FastAPI: api/errors.py and four middlewares
+    # import it directly, and FastAPI asks only for `starlette>=0.46.0`, so capping
+    # FastAPI alone would leave the same door open.
+    "fastapi>=0.118,<0.142",
+    "starlette>=0.46,<2",
     "pydantic>=2.9",
     "pydantic-settings>=2.6",
     "uvicorn[standard]>=0.32",


### PR DESCRIPTION
`main` went red this morning without anybody touching the repository. This is why.

## What happened

```
pyproject.toml:  fastapi>=0.118          <- no ceiling
CI resolved:     fastapi 0.141.1, starlette 1.6.0
result:          _IncludedRouter in app.routes, AttributeError, 1 failed
```

FastAPI is pre-1.0, so the **minor** position is the breaking one. An open upper bound makes every FastAPI release a live, unreviewed change to this project.

## Capping FastAPI alone would not have closed it

```
$ fastapi 0.141.1 declares:
    starlette>=0.46.0        <- no upper bound either
```

A pinned FastAPI still lets the next Starlette major walk in the same way — and Starlette is the package that actually changed behaviour here.

So Starlette is now listed directly. It should have been regardless:

```
api/errors.py                    from starlette.exceptions import ...
api/middleware/auth.py           from starlette.middleware.base import ...
api/middleware/csrf.py           from starlette.types import ...
api/middleware/request_id.py     from starlette.middleware.base import ...
api/middleware/ws_auth.py        from starlette.types import ...
```

Six files import it. It was a direct dependency that happened to arrive as a transitive one — the kind that works until the day it doesn't.

## Nothing moves today

Resolved with the new bounds, from a clean environment:

```
fastapi        0.141.1     <- same as CI installs now
starlette      1.6.0       <- same as CI installs now
```

The bounds prevent the next surprise; they do not change the current one.

## Not done here, on purpose

The other ten runtime dependencies — pydantic, sqlalchemy, alembic, uvicorn, asyncpg, cryptography, argon2-cffi and the rest — are all still `>=` with no ceiling and carry exactly the same exposure. FastAPI is not special, it just went first.

Bounding them is a real decision with a real cost (bounds go stale and need tending), and it deserves to be made deliberately rather than smuggled into a bug-driven PR. Worth its own issue.