### PR TITLE
The extension contract, with the core inside it

### DIFF
--- a/api/extensions/__init__.py
+++ b/api/extensions/__init__.py
@@ -1,0 +1,7 @@
+"""The extension contract — D-031.
+
+The core registers itself through it: `agent_core`, `database` and `web_chat` are
+official applications, not privileged code paths. That is the decision's own wording,
+and it is what keeps the contract honest — a contract only its authors are exempt from
+is a contract that drifts from what extensions actually need.
+"""

--- a/api/extensions/builtin/__init__.py
+++ b/api/extensions/builtin/__init__.py
@@ -1,0 +1,10 @@
+"""Official extensions that ship with the core."""
+
+# Loaded in this order at startup. Order matters only where one listener wants to run
+# before another on the same event; today none do, and the list is explicit so that
+# when one does, the answer is a line here rather than an import-time accident.
+BUILTIN = (
+    "api.extensions.builtin.agent_core",
+    "api.extensions.builtin.database",
+    "api.extensions.builtin.web_chat",
+)

--- a/api/extensions/builtin/agent_core.py
+++ b/api/extensions/builtin/agent_core.py
@@ -1,0 +1,32 @@
+"""The conversation engine, declared as the application the catalogue already lists.
+
+It subscribes to nothing yet: the loop that will react to `message.received` arrives
+with Epic F. The manifest exists now so the catalogue is truthful from the first boot
+and so the core is subject to the same validation as anything else.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from api.extensions.registry import Context
+
+
+MANIFEST = {
+    "slug": "agent_core",
+    "name": "Agent core",
+    "version": "0.1.0",
+    "origin": "official",
+    "category": "system",
+    "description": "Understands what a customer wants and decides what to say back.",
+    "scopes": [
+        "conversations.read",
+        "conversations.write",
+        "messages.read",
+        "messages.write",
+    ],
+    "hooks": [],
+}
+
+
+def register(context: "Context") -> None:
+    """Nothing to subscribe yet. Epic F attaches the loop to `message.received`."""

--- a/api/extensions/builtin/database.py
+++ b/api/extensions/builtin/database.py
@@ -1,0 +1,22 @@
+"""Storage, declared as a system application because the catalogue lists it as one."""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from api.extensions.registry import Context
+
+
+MANIFEST = {
+    "slug": "database",
+    "name": "Database",
+    "version": "0.1.0",
+    "origin": "official",
+    "category": "system",
+    "description": "Stores conversations, transcripts and settings.",
+    "scopes": ["conversations.read", "messages.read"],
+    "hooks": [],
+}
+
+
+def register(context: "Context") -> None:
+    """Storage is not event-driven; it is what the events are written into."""

--- a/api/extensions/builtin/web_chat.py
+++ b/api/extensions/builtin/web_chat.py
@@ -1,0 +1,44 @@
+"""Web chat — the first official application built on the contract.
+
+D-027 records this as the mitigation for building the foundations before the chat: the
+contract is proven by use rather than by inspection. The manifest and its subscription
+land now; the handler body is Epic F's work, and it is deliberately a no-op rather than
+absent, so the wiring is exercised from the first boot.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from api.extensions.registry import Context
+
+
+import logging
+
+logger = logging.getLogger("api.extensions.web_chat")
+
+MANIFEST = {
+    "slug": "web_chat",
+    "name": "Web chat",
+    "version": "0.1.0",
+    "origin": "official",
+    "category": "channels",
+    "description": "A chat bubble on your own site. No account anywhere.",
+    "scopes": ["conversations.write", "messages.read", "messages.write"],
+    "hooks": ["message.received"],
+    "ui_slots": ["conversation.detail"],
+}
+
+
+def register(context: "Context") -> None:
+    context.on("message.received", _on_message)
+
+
+async def _on_message(**payload: Any) -> None:
+    """Epic F replaces this with the streaming loop.
+
+    It logs rather than passing silently: a subscription that does nothing and says
+    nothing is indistinguishable from one that was never registered.
+    """
+    logger.debug(
+        "web_chat saw a message", extra={"conversation_id": payload.get("conversation_id")}
+    )

--- a/api/extensions/hooks.py
+++ b/api/extensions/hooks.py
@@ -1,0 +1,119 @@
+"""The event bus extensions listen on.
+
+The core emits; extensions react. The core never imports an extension, and an extension
+never calls into a route — the event name is the whole of the coupling between them,
+which is what lets a channel be written by somebody we will never meet.
+
+**A failing hook must not break what emitted the event.** A message arrives, is stored,
+and the arrival is announced; if a Telegram extension throws while reacting, the message
+is still stored. The alternative — letting the exception travel back up — makes every
+extension a way to break the core, which in an in-process design would be the whole
+product's stability handed to whoever wrote the worst plugin.
+
+So `emit` isolates each listener: the failure is logged with the extension's slug, and
+the remaining listeners still run. What it deliberately does **not** do is retry or
+queue: a hook is a reaction, and a reaction that must not be lost belongs in the jobs
+table where it can be retried with a record, not in a fire-and-forget bus.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger("api.extensions")
+
+# Events the core promises to emit. Closed on purpose: a listener subscribing to a
+# name nobody emits is a silence that looks like a bug for a very long time, so
+# subscribing to an unknown event is refused at registration.
+EVENTS = (
+    "conversation.started",
+    "conversation.ended",
+    "message.received",
+    "message.sent",
+    "channel.connected",
+    "channel.failed",
+    "notification.raised",
+    "app.installed",
+    "app.enabled",
+    "app.disabled",
+)
+
+
+class UnknownEvent(ValueError):
+    """A listener asked for an event the core does not emit."""
+
+    def __init__(self, event: str) -> None:
+        super().__init__(
+            f"{event!r} is not an event this core emits. Known events: {list(EVENTS)}. "
+            "Add it to EVENTS in api/extensions/hooks.py and emit it, or subscribe to "
+            "one that exists - a listener on a name nobody emits is silence, not a bug "
+            "anybody will find."
+        )
+
+
+@dataclass
+class Listener:
+    slug: str
+    event: str
+    handler: Callable[..., Any]
+
+
+@dataclass
+class HookBus:
+    """Listeners, grouped by event.
+
+    An instance rather than a module global: tests build one per case, and a future
+    per-workspace bus is then a change of ownership rather than a rewrite.
+    """
+
+    listeners: dict[str, list[Listener]] = field(default_factory=dict)
+
+    def subscribe(self, slug: str, event: str, handler: Callable[..., Any]) -> None:
+        if event not in EVENTS:
+            raise UnknownEvent(event)
+        self.listeners.setdefault(event, []).append(Listener(slug, event, handler))
+
+    def unsubscribe_all(self, slug: str) -> int:
+        """Remove every listener an extension registered — disabling it, in effect."""
+        removed = 0
+        for event, entries in self.listeners.items():
+            keep = [entry for entry in entries if entry.slug != slug]
+            removed += len(entries) - len(keep)
+            self.listeners[event] = keep
+        return removed
+
+    def listeners_for(self, event: str) -> list[Listener]:
+        return list(self.listeners.get(event, []))
+
+    async def emit(self, event: str, **payload: Any) -> int:
+        """Announce something happened. Returns how many listeners ran without raising.
+
+        Listeners run in registration order, one after another rather than gathered:
+        two extensions reacting to the same message often both want the database
+        session in the payload, and a session is not safe to use concurrently.
+        """
+        if event not in EVENTS:
+            raise UnknownEvent(event)
+
+        succeeded = 0
+        for listener in self.listeners.get(event, []):
+            try:
+                result = listener.handler(**payload)
+                if inspect.isawaitable(result):
+                    await result
+                succeeded += 1
+            except asyncio.CancelledError:
+                # Cancellation is the caller going away, not the listener failing.
+                # Swallowing it here would keep a dying request alive.
+                raise
+            except Exception:
+                logger.exception(
+                    "extension hook failed",
+                    extra={"app": listener.slug, "event": event},
+                )
+        return succeeded

--- a/api/extensions/manifest.py
+++ b/api/extensions/manifest.py
@@ -1,0 +1,165 @@
+"""What an extension declares about itself — the contract of D-031.
+
+A manifest is the whole of what the core knows before any of an extension's code runs.
+It is validated on load and stored in `apps.manifest`, so the catalogue screen can list
+something the installation has never executed.
+
+**Extensions run in this process** (decided for v1). That buys simplicity and speed and
+costs isolation: a module that raises at import takes the server with it, and one that
+blocks the event loop stalls every request. The engine's job is therefore to fail
+*narrowly* — a bad extension must be refused at load, and a bad hook must not take down
+the thing that emitted the event. Where that is impossible, it is said plainly rather
+than papered over.
+
+`scopes` is the honest part of that trade. In this process an extension can import
+whatever it likes; declaring a scope does not physically prevent anything. What it does
+is make the claim explicit and reviewable: the catalogue shows what an extension asked
+for, installing is a decision made against that list, and an extension that reaches
+beyond it is committing a visible breach rather than an invisible one. That is worth
+having now, and it is what a future out-of-process runtime would enforce for real.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+# Categories the `apps` screen already groups by.
+CATEGORIES = (
+    "system",
+    "channels",
+    "calendars",
+    "tools",
+    "notifications",
+    "pbx",
+    "sip",
+    "health",
+    "property",
+    "hospitality",
+    "accounting",
+    "beauty",
+    "analytics",
+)
+
+# What an extension may ask for. Deliberately coarse: a long list of fine-grained
+# permissions nobody reads is worse than a short one somebody does.
+SCOPES = (
+    "conversations.read",
+    "conversations.write",
+    "messages.read",
+    "messages.write",
+    "channels.manage",
+    "contacts.read",
+    "contacts.write",
+    "settings.read",
+    "settings.write",
+    "notifications.raise",
+    "http.outbound",
+)
+
+_SLUG = re.compile(r"^[a-z][a-z0-9_]{1,63}$")
+_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+class InvalidManifest(ValueError):
+    """The manifest is malformed. Raised at load, never at request time."""
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """One extension's declaration."""
+
+    slug: str
+    name: str
+    version: str
+    origin: str
+    category: str
+    description: str = ""
+    scopes: tuple[str, ...] = ()
+    # Event names this extension subscribes to. Declared as well as registered, so the
+    # catalogue can say what an extension reacts to without importing it.
+    hooks: tuple[str, ...] = ()
+    # Where its own tables live, if it has any. A namespace rather than free rein:
+    # `telegram_` prefixes its tables, so an extension can never migrate a core table
+    # and two extensions cannot collide on a name.
+    migration_prefix: str | None = None
+    ui_slots: tuple[str, ...] = ()
+
+    def as_json(self) -> dict[str, Any]:
+        """The shape stored in `apps.manifest`."""
+        return {
+            "slug": self.slug,
+            "name": self.name,
+            "version": self.version,
+            "origin": self.origin,
+            "category": self.category,
+            "description": self.description,
+            "scopes": list(self.scopes),
+            "hooks": list(self.hooks),
+            "migration_prefix": self.migration_prefix,
+            "ui_slots": list(self.ui_slots),
+        }
+
+
+def parse(raw: dict[str, Any]) -> Manifest:
+    """Validate a declaration and return it, or raise `InvalidManifest`.
+
+    Every failure names the field and what was expected. A manifest is usually written
+    by somebody who is not us, and "invalid manifest" as the whole message is a message
+    that costs an hour.
+    """
+    from api.models.extensions import ORIGINS
+
+    def need(key: str) -> Any:
+        if key not in raw or raw[key] in (None, ""):
+            raise InvalidManifest(f"manifest is missing {key!r}")
+        return raw[key]
+
+    slug = str(need("slug"))
+    if not _SLUG.match(slug):
+        raise InvalidManifest(
+            f"slug {slug!r} must be lowercase letters, digits and underscores, "
+            "starting with a letter (2-64 characters)"
+        )
+
+    version = str(need("version"))
+    if not _VERSION.match(version):
+        raise InvalidManifest(f"version {version!r} must look like 1.2.3")
+
+    origin = str(need("origin"))
+    if origin not in ORIGINS:
+        raise InvalidManifest(f"origin {origin!r} must be one of {list(ORIGINS)}")
+
+    category = str(need("category"))
+    if category not in CATEGORIES:
+        raise InvalidManifest(f"category {category!r} must be one of {list(CATEGORIES)}")
+
+    scopes = tuple(raw.get("scopes") or ())
+    unknown = [scope for scope in scopes if scope not in SCOPES]
+    if unknown:
+        raise InvalidManifest(
+            f"unknown scope(s) {unknown}: an extension may only ask for {list(SCOPES)}"
+        )
+
+    prefix = raw.get("migration_prefix")
+    if prefix is not None:
+        prefix = str(prefix)
+        if not prefix.endswith("_") or not _SLUG.match(prefix.rstrip("_")):
+            raise InvalidManifest(
+                f"migration_prefix {prefix!r} must be a slug ending in an underscore, "
+                "so an extension's tables can never be mistaken for a core table"
+            )
+
+    return Manifest(
+        slug=slug,
+        name=str(need("name")),
+        version=version,
+        origin=origin,
+        category=category,
+        description=str(raw.get("description") or ""),
+        scopes=scopes,
+        hooks=tuple(raw.get("hooks") or ()),
+        migration_prefix=prefix,
+        ui_slots=tuple(raw.get("ui_slots") or ()),
+    )

--- a/api/extensions/registry.py
+++ b/api/extensions/registry.py
@@ -1,0 +1,183 @@
+"""Loading extensions, and keeping a bad one from taking the server with it.
+
+An extension is a Python module exposing two names:
+
+    MANIFEST = {...}                 # the declaration, validated by manifest.parse
+    def register(context): ...       # called once at load; subscribes to hooks
+
+`register` receives a `Context` and nothing else. It is the only handle an extension is
+given, so what an extension can do *conveniently* is visible in one place — and in an
+in-process design, convenience is most of what governs behaviour, since nothing stops a
+determined module from importing whatever it likes.
+
+**Loading is the one place a bad extension is cheap to survive.** A module that raises
+on import, or whose manifest is malformed, or whose `register` throws, is recorded as
+failed and skipped; the others still load and the server still starts. That is the whole
+mitigation the in-process decision leaves available at load time, and it is applied
+without exception — including to official extensions, because "ours cannot be broken"
+is how a broken one ships.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from api.extensions.hooks import HookBus
+from api.extensions.manifest import InvalidManifest, Manifest, parse
+
+logger = logging.getLogger("api.extensions")
+
+
+@dataclass
+class Context:
+    """What an extension is handed at registration.
+
+    `on` is the subscription function, already bound to the extension's slug so a
+    listener is always attributable to whoever registered it — an anonymous failing
+    hook is a failure nobody can switch off.
+    """
+
+    slug: str
+    manifest: Manifest
+    bus: HookBus
+
+    def on(self, event: str, handler: Any) -> None:
+        self.bus.subscribe(self.slug, event, handler)
+
+    def may(self, scope: str) -> bool:
+        """Did this extension declare the scope it is about to use?
+
+        Advisory in this runtime, and the docstring on `manifest.py` says why. Code that
+        checks it is code that keeps working unchanged when the boundary becomes real.
+        """
+        return scope in self.manifest.scopes
+
+
+@dataclass
+class Loaded:
+    manifest: Manifest
+    module: Any
+
+
+@dataclass
+class Failed:
+    slug: str
+    reason: str
+
+
+@dataclass
+class Registry:
+    """Everything this process has loaded, and everything it refused."""
+
+    bus: HookBus = field(default_factory=HookBus)
+    loaded: dict[str, Loaded] = field(default_factory=dict)
+    failed: list[Failed] = field(default_factory=list)
+
+    def load(self, module_path: str) -> Loaded | None:
+        """Import one extension and register it. Returns None if it was refused.
+
+        Nothing here raises. The caller is application startup, and a startup that dies
+        because one community extension has a typo is a product that cannot be extended
+        by anybody but us.
+        """
+        try:
+            module = importlib.import_module(module_path)
+        except Exception as error:
+            return self._refuse(module_path, f"import failed: {error!r}")
+
+        raw = getattr(module, "MANIFEST", None)
+        if not isinstance(raw, dict):
+            return self._refuse(module_path, "no MANIFEST dict")
+
+        try:
+            manifest = parse(raw)
+        except InvalidManifest as error:
+            return self._refuse(module_path, str(error))
+
+        if manifest.slug in self.loaded:
+            return self._refuse(
+                manifest.slug,
+                f"slug already loaded from {self.loaded[manifest.slug].module.__name__}",
+            )
+
+        register = getattr(module, "register", None)
+        if not callable(register):
+            return self._refuse(manifest.slug, "no register() function")
+
+        # Declared hooks and actual subscriptions are cross-checked below, so a
+        # manifest that lies about what it listens to is caught rather than believed.
+        try:
+            register(Context(slug=manifest.slug, manifest=manifest, bus=self.bus))
+        except Exception as error:
+            self.bus.unsubscribe_all(manifest.slug)
+            return self._refuse(manifest.slug, f"register() raised: {error!r}")
+
+        subscribed = {
+            listener.event
+            for event in self.bus.listeners
+            for listener in self.bus.listeners_for(event)
+            if listener.slug == manifest.slug
+        }
+        undeclared = subscribed - set(manifest.hooks)
+        if undeclared:
+            self.bus.unsubscribe_all(manifest.slug)
+            return self._refuse(
+                manifest.slug,
+                f"subscribed to undeclared event(s) {sorted(undeclared)} - the manifest "
+                "is what the catalogue shows, so it has to be true",
+            )
+
+        entry = Loaded(manifest=manifest, module=module)
+        self.loaded[manifest.slug] = entry
+        logger.info(
+            "extension loaded",
+            extra={
+                "app": manifest.slug,
+                "version": manifest.version,
+                "origin": manifest.origin,
+                "hooks": list(manifest.hooks),
+            },
+        )
+        return entry
+
+    def disable(self, slug: str) -> bool:
+        """Stop an extension reacting, without restarting the process."""
+        if slug not in self.loaded:
+            return False
+        self.bus.unsubscribe_all(slug)
+        del self.loaded[slug]
+        logger.info("extension disabled", extra={"app": slug})
+        return True
+
+    def _refuse(self, slug: str, reason: str) -> None:
+        self.failed.append(Failed(slug=slug, reason=reason))
+        logger.error("extension refused", extra={"app": slug, "reason": reason})
+        return None
+
+
+async def sync_catalogue(db: Any, registry: Registry) -> int:
+    """Write what is loaded into the `apps` table so the catalogue can list it.
+
+    The table is the record; the registry is this process's live view of it. Keeping
+    them in step here means the catalogue screen shows what is actually running rather
+    than what was installed at some point in the past.
+    """
+    from sqlalchemy import select
+
+    from api.models import App
+
+    written = 0
+    for slug, entry in registry.loaded.items():
+        row = await db.scalar(select(App).where(App.slug == slug))
+        if row is None:
+            row = App(slug=slug)
+            db.add(row)
+        row.origin = entry.manifest.origin
+        row.version = entry.manifest.version
+        row.manifest = entry.manifest.as_json()
+        written += 1
+    await db.commit()
+    return written

--- a/api/main.py
+++ b/api/main.py
@@ -28,6 +28,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.config import Settings, get_settings
 from api.db import check_database, create_engine, create_sessionmaker
 from api.errors import ErrorResponse, install_error_handlers
+from api.extensions.builtin import BUILTIN
+from api.extensions.registry import Registry, sync_catalogue
 from api.jobs import builtin as builtin_jobs
 from api.jobs.runner import ensure_schedule
 from api.jobs.runner import loop as job_loop
@@ -114,6 +116,23 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # deploy: the smallest installation is one machine and somebody who does not run a
     # process manager. Without it the housekeeping tasks have no caller at all, which
     # is the state this codebase was in until P2.
+    # Extensions load after the database and before the first request, so no request
+    # ever sees a half-loaded registry. A refusal is recorded and startup continues:
+    # in an in-process design one broken extension must not stop the server answering.
+    registry = Registry()
+    for module_path in BUILTIN:
+        registry.load(module_path)
+    app.state.extensions = registry
+
+    try:
+        async with app.state.sessionmaker() as db:
+            await sync_catalogue(db, registry)
+    except Exception:
+        # The catalogue mirrors what is running; it is not a precondition for running.
+        # An unmigrated database must still start the server, or `alembic upgrade head`
+        # could never be run against it.
+        logging.getLogger("api.extensions").exception("could not sync the app catalogue")
+
     worker: asyncio.Task | None = None
     if settings.jobs_enabled:
         try:

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,333 @@
+"""The extension contract — P5, implementing D-031.
+
+Extensions run in this process (the v1 decision), so the tests that matter most are the
+ones about *containment*: a broken extension must be refused at load, and a broken hook
+must not take down whatever emitted the event. Everything else here is the contract
+being honest — a manifest that lies is caught, and the core is held to the same rules.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.extensions.builtin import BUILTIN
+from api.extensions.hooks import EVENTS, HookBus, UnknownEvent
+from api.extensions.manifest import InvalidManifest, parse
+from api.extensions.registry import Registry, sync_catalogue
+from api.models import App
+
+GOOD = {
+    "slug": "telegram",
+    "name": "Telegram",
+    "version": "1.2.0",
+    "origin": "community",
+    "category": "channels",
+    "scopes": ["messages.write"],
+    "hooks": ["message.received"],
+    "migration_prefix": "telegram_",
+}
+
+
+def _module(name: str, manifest: dict | None, register=None) -> str:
+    """Install a throwaway extension module and return its import path."""
+    module = types.ModuleType(name)
+    if manifest is not None:
+        module.MANIFEST = manifest
+    if register is not None:
+        module.register = register
+    sys.modules[name] = module
+    return name
+
+
+@pytest.fixture(autouse=True)
+def _clean_modules():
+    before = set(sys.modules)
+    yield
+    for name in set(sys.modules) - before:
+        sys.modules.pop(name, None)
+
+
+# --- The manifest ------------------------------------------------------------
+
+
+def test_a_good_manifest_parses() -> None:
+    manifest = parse(GOOD)
+
+    assert manifest.slug == "telegram"
+    assert manifest.scopes == ("messages.write",)
+    assert manifest.migration_prefix == "telegram_"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("slug", "Telegram", "lowercase"),
+        ("slug", "9live", "lowercase"),
+        ("version", "1.2", "1.2.3"),
+        ("origin", "vendor", "origin"),
+        ("category", "misc", "category"),
+    ],
+)
+def test_a_malformed_manifest_names_the_field(field: str, value: str, expected: str) -> None:
+    """A manifest is usually written by somebody who is not us. "Invalid manifest" as
+    the whole message costs an hour."""
+    with pytest.raises(InvalidManifest) as error:
+        parse({**GOOD, field: value})
+
+    assert expected in str(error.value)
+
+
+def test_an_undeclarable_scope_is_refused() -> None:
+    with pytest.raises(InvalidManifest) as error:
+        parse({**GOOD, "scopes": ["messages.write", "database.drop"]})
+
+    assert "database.drop" in str(error.value)
+
+
+def test_a_migration_prefix_must_be_a_prefix() -> None:
+    """So an extension's tables can never be mistaken for a core table."""
+    with pytest.raises(InvalidManifest):
+        parse({**GOOD, "migration_prefix": "messages"})
+
+
+# --- Loading, and refusing ---------------------------------------------------
+
+
+def test_a_working_extension_loads_and_subscribes() -> None:
+    seen: list[str] = []
+
+    def register(context) -> None:
+        context.on("message.received", lambda **kw: seen.append(kw["text"]))
+
+    registry = Registry()
+    entry = registry.load(_module("ext_ok", GOOD, register))
+
+    assert entry is not None
+    assert registry.failed == []
+    assert [listener.slug for listener in registry.bus.listeners_for("message.received")] == [
+        "telegram"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("name", "manifest", "register", "reason"),
+    [
+        ("ext_no_manifest", None, lambda context: None, "no MANIFEST"),
+        # A slug alone: it fails on the slug pattern before any missing field is
+        # reached, which is the message a manifest author actually needs.
+        ("ext_bad_slug", {"slug": "x"}, lambda context: None, "lowercase"),
+        ("ext_missing_field", {"slug": "telegram"}, lambda context: None, "missing"),
+        ("ext_no_register", GOOD, None, "no register()"),
+    ],
+)
+def test_a_broken_extension_is_refused_not_raised(
+    name: str, manifest: dict | None, register, reason: str
+) -> None:
+    """Startup must survive it. A server that dies because one community extension has
+    a typo is a product only we can extend."""
+    registry = Registry()
+
+    assert registry.load(_module(name, manifest, register)) is None
+    assert len(registry.failed) == 1
+    assert reason in registry.failed[0].reason
+
+
+def test_an_extension_that_throws_at_import_is_refused() -> None:
+    registry = Registry()
+
+    # A module path that does not exist stands in for one that raises on import: both
+    # arrive here as an exception from importlib.
+    assert registry.load("api.extensions.builtin.does_not_exist") is None
+    assert "import failed" in registry.failed[0].reason
+
+
+def test_a_register_that_raises_leaves_no_listeners_behind() -> None:
+    """Half a registration is worse than none: the extension is not loaded, but its
+    listeners would still fire."""
+
+    def register(context) -> None:
+        context.on("message.received", lambda **kw: None)
+        raise RuntimeError("boom")
+
+    registry = Registry()
+    registry.load(_module("ext_throws", GOOD, register))
+
+    assert registry.loaded == {}
+    assert registry.bus.listeners_for("message.received") == []
+
+
+def test_a_manifest_that_lies_about_its_hooks_is_refused() -> None:
+    """The manifest is what the catalogue shows, so it has to be true."""
+
+    def register(context) -> None:
+        context.on("conversation.started", lambda **kw: None)
+
+    registry = Registry()
+    registry.load(_module("ext_liar", GOOD, register))  # declares message.received only
+
+    assert registry.loaded == {}
+    assert "undeclared" in registry.failed[0].reason
+    assert registry.bus.listeners_for("conversation.started") == []
+
+
+def test_two_extensions_cannot_claim_one_slug() -> None:
+    registry = Registry()
+    registry.load(_module("ext_first", GOOD, lambda context: None))
+    registry.load(_module("ext_second", GOOD, lambda context: None))
+
+    assert len(registry.loaded) == 1
+    assert "already loaded" in registry.failed[0].reason
+
+
+# --- Containment: the point of the in-process trade ---------------------------
+
+
+async def test_a_failing_hook_does_not_break_the_emitter() -> None:
+    """A message arrives, is stored, and the arrival is announced. If an extension
+    throws while reacting, the message is still stored."""
+    bus = HookBus()
+    ran: list[str] = []
+
+    def explodes(**payload):
+        raise RuntimeError("this extension is broken")
+
+    def works(**payload):
+        ran.append("second")
+
+    bus.subscribe("broken", "message.received", explodes)
+    bus.subscribe("fine", "message.received", works)
+
+    succeeded = await bus.emit("message.received", text="hallo")
+
+    assert succeeded == 1  # the working one still ran
+    assert ran == ["second"]  # and it ran despite going second
+
+
+async def test_both_sync_and_async_listeners_run() -> None:
+    bus = HookBus()
+    ran: list[str] = []
+
+    async def slow(**payload):
+        ran.append("async")
+
+    bus.subscribe("a", "message.received", lambda **kw: ran.append("sync"))
+    bus.subscribe("b", "message.received", slow)
+
+    assert await bus.emit("message.received") == 2
+    assert ran == ["sync", "async"]
+
+
+async def test_cancellation_is_not_swallowed() -> None:
+    """Cancellation is the caller going away, not the listener failing. Catching it
+    here would keep a dying request alive."""
+    import asyncio
+
+    bus = HookBus()
+
+    async def cancelled(**payload):
+        raise asyncio.CancelledError
+
+    bus.subscribe("x", "message.received", cancelled)
+
+    with pytest.raises(asyncio.CancelledError):
+        await bus.emit("message.received")
+
+
+def test_subscribing_to_an_unknown_event_is_refused() -> None:
+    """A listener on a name nobody emits is silence, not a bug anybody finds."""
+    bus = HookBus()
+
+    with pytest.raises(UnknownEvent) as error:
+        bus.subscribe("x", "message.recieved", lambda **kw: None)
+
+    assert "message.recieved" in str(error.value)
+
+
+def test_disabling_stops_an_extension_reacting(monkeypatch) -> None:
+    registry = Registry()
+    registry.load(
+        _module(
+            "ext_live", GOOD, lambda context: context.on("message.received", lambda **kw: None)
+        )
+    )
+
+    assert registry.disable("telegram") is True
+    assert registry.bus.listeners_for("message.received") == []
+    assert registry.disable("telegram") is False  # already gone
+
+
+# --- The core holds itself to the contract -----------------------------------
+
+
+def test_the_built_in_extensions_all_load() -> None:
+    """D-031: agent_core, database and web_chat are official applications, not
+    privileged code paths - so they are parsed and validated like anything else."""
+    registry = Registry()
+    for path in BUILTIN:
+        registry.load(path)
+
+    assert sorted(registry.loaded) == ["agent_core", "database", "web_chat"]
+    assert registry.failed == []
+
+
+def test_web_chat_subscribes_to_incoming_messages() -> None:
+    """D-027's mitigation: the contract is proven by use, not by inspection. Web chat
+    is the first official application on it."""
+    registry = Registry()
+    for path in BUILTIN:
+        registry.load(path)
+
+    assert [entry.slug for entry in registry.bus.listeners_for("message.received")] == [
+        "web_chat"
+    ]
+
+
+def test_every_declared_hook_is_an_event_the_core_emits() -> None:
+    """A built-in that subscribes to a name the core never emits would be dead code
+    that looks alive."""
+    registry = Registry()
+    for path in BUILTIN:
+        registry.load(path)
+
+    for entry in registry.loaded.values():
+        for hook in entry.manifest.hooks:
+            assert hook in EVENTS, f"{entry.manifest.slug} declares unknown {hook!r}"
+
+
+# --- The catalogue ------------------------------------------------------------
+
+
+async def test_the_catalogue_records_what_is_loaded(migrated: AsyncSession) -> None:
+    """The screen lists what is actually running, not what was installed once."""
+    registry = Registry()
+    for path in BUILTIN:
+        registry.load(path)
+
+    written = await sync_catalogue(migrated, registry)
+
+    assert written == 3
+    rows = {row.slug: row for row in (await migrated.execute(select(App))).scalars()}
+    assert sorted(rows) == ["agent_core", "database", "web_chat"]
+    assert rows["web_chat"].origin == "official"
+    assert rows["web_chat"].manifest["hooks"] == ["message.received"]
+
+
+async def test_syncing_twice_updates_rather_than_duplicates(
+    migrated: AsyncSession,
+) -> None:
+    """Every restart runs this. A second row per app per boot would be a table that
+    grows with uptime."""
+    registry = Registry()
+    for path in BUILTIN:
+        registry.load(path)
+
+    await sync_catalogue(migrated, registry)
+    await sync_catalogue(migrated, registry)
+
+    rows = (await migrated.execute(select(App))).scalars().all()
+    assert len(rows) == 3


### PR DESCRIPTION
The `apps` and `app_installs` tables have existed since C1 with nothing to fill them.
This is the engine D-031 describes: a manifest, a loader, a hook bus — and the three
official applications the catalogue already lists registering through **the same
contract as anybody else**. `agent_core`, `database` and `web_chat` are rows, not
privileged code paths. That is the decision's own wording, and it is what keeps the
contract honest: one only its authors are exempt from drifts from what extensions
actually need.

## The in-process trade, and what the engine does about it

Extensions run in this process. That buys simplicity and speed; it costs isolation. So
the engine's entire job is to **fail narrowly**:

| what breaks | what happens |
|---|---|
| module will not import · no `MANIFEST` · no `register()` · `register()` raises | recorded as refused, skipped, **startup continues** |
| `register()` throws *after* subscribing | its listeners are removed first — half a registration is worse than none |
| a hook raises while reacting | logged with the slug; the emitter is unaffected and the remaining listeners still run |
| a hook is cancelled | `CancelledError` propagates — that is the caller going away, not the listener failing |

A server that dies because one community extension has a typo is a product only we can
extend.

## Two places the contract refuses to be lied to

**Subscribing to an event the core does not emit is refused at registration.** A
listener on a name nobody emits is silence, and silence is not a bug anybody finds.

**An extension that subscribes to something its manifest does not declare is
unloaded.** The manifest is what the catalogue shows, so it has to be true.

## Where the honesty is, about scopes

`scopes` is advisory in this runtime and the docstring says so plainly. In-process,
nothing physically stops a module importing whatever it likes. What the declaration
buys is that the ask is **visible and reviewable** — the catalogue shows what an
extension wanted, installing is a decision made against that list, and a breach is
visible rather than invisible. It is also enforceable unchanged if the boundary ever
becomes a real one.

## web_chat is deliberately a no-op, not absent

It subscribes to `message.received` with a handler Epic F replaces. Keeping the wiring
live from the first boot is the mitigation **D-027** recorded for building the
foundations before the chat: the contract is proven by use, not by inspection.

## Verification

On a real application boot, not a unit fixture:

```
loaded at startup  : ['agent_core', 'database', 'web_chat']
refused            : []
catalogue rows     : agent_core/official/0.1.0 · database/… · web_chat/…
emitted message.received → listeners that ran: 1

ruff format --check · ruff check · lint-imports · check-locales   PASS
pytest -q                        397 passed (SQLite + PostgreSQL)
```