### PR TITLE
P6 — the recent log behind the health screen

### DIFF
--- a/api/logging.py
+++ b/api/logging.py
@@ -19,9 +19,14 @@ import sys
 from contextvars import ContextVar
 from typing import Any
 
+from api.syslog import RecentLogHandler
+
 # Identifies the handler this module installs, so that reconfiguring replaces it rather
 # than removing every handler anybody else attached.
 _HANDLER_NAME = "telagent.json"
+# The in-memory ring the health screen reads. Named like the JSON handler so
+# `configure_logging` can replace its own without touching anybody else's.
+_RECENT_HANDLER_NAME = "telagent.recent"
 
 # Set by the request-id middleware, read by the log filter. A ContextVar rather than a
 # global because concurrent requests share the process: a global would let one request's
@@ -118,6 +123,18 @@ class SecretRedactionFilter(logging.Filter):
                     setattr(record, key, _scrub(value))
 
         if isinstance(record.msg, str) and record.msg:
+            if record.args:
+                # Interpolate before redacting, not after. `token: %s` with the
+                # credential in `args` would otherwise have its placeholder replaced
+                # while the argument stayed behind, and `getMessage()` then raises
+                # "not all arguments converted" - which drops the line entirely. The
+                # secret is in the argument anyway, so redacting the format string
+                # alone would have missed it.
+                try:
+                    record.msg = record.getMessage()
+                except Exception:  # pragma: no cover - a malformed call site
+                    return True
+                record.args = None
             record.msg = self._redact_inline(record.msg)
         return True
 
@@ -191,6 +208,15 @@ def configure_logging(level: str = "INFO") -> None:
     handler.addFilter(SecretRedactionFilter())
     handler.set_name(_HANDLER_NAME)
 
+    # The same records the JSON handler formats also land in a bounded ring, so the
+    # health screen can show them. Added after the redaction filter, so a line on the
+    # screen has already been through it - the panel cannot show a secret the log file
+    # would not have shown.
+    recent = RecentLogHandler()
+    recent.set_name(_RECENT_HANDLER_NAME)
+    recent.addFilter(RequestIdFilter())
+    recent.addFilter(SecretRedactionFilter())
+
     root = logging.getLogger()
     # Replace only *our* handler, never the whole list.
     #
@@ -198,9 +224,11 @@ def configure_logging(level: str = "INFO") -> None:
     # twice, and it silently removes anything else that attached one - an error
     # reporter, a journal handler, or the test framework's capture. Building an
     # application would then disable logging for whatever set it up first.
-    for existing in [h for h in root.handlers if h.get_name() == _HANDLER_NAME]:
+    ours = (_HANDLER_NAME, _RECENT_HANDLER_NAME)
+    for existing in [h for h in root.handlers if h.get_name() in ours]:
         root.removeHandler(existing)
     root.addHandler(handler)
+    root.addHandler(recent)
     root.setLevel(level)
 
     # uvicorn's access log duplicates the access line the middleware writes, without a
@@ -210,3 +238,16 @@ def configure_logging(level: str = "INFO") -> None:
     for name in ("uvicorn", "uvicorn.error"):
         logging.getLogger(name).handlers = []
         logging.getLogger(name).propagate = True
+
+
+def recent_log_handler() -> RecentLogHandler | None:
+    """The ring installed by `configure_logging`, if there is one.
+
+    Looked up rather than held in a module global: two applications built in one
+    process (which the test suite does constantly) would otherwise share one ring and
+    show each other's lines.
+    """
+    for handler in logging.getLogger().handlers:
+        if handler.get_name() == _RECENT_HANDLER_NAME and isinstance(handler, RecentLogHandler):
+            return handler
+    return None

--- a/api/main.py
+++ b/api/main.py
@@ -40,6 +40,7 @@ from api.routes import auth as auth_routes
 from api.routes import notifications as notification_routes
 from api.routes import recovery as recovery_routes
 from api.routes import settings as settings_routes
+from api.routes import system as system_routes
 
 TAGS_METADATA = [
     {
@@ -225,6 +226,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.include_router(auth_routes.router)
     app.include_router(notification_routes.router)
+    app.include_router(system_routes.router)
     app.include_router(settings_routes.router)
     app.include_router(recovery_routes.router)
 

--- a/api/routes/system.py
+++ b/api/routes/system.py
@@ -1,0 +1,74 @@
+"""The health screen's own endpoints — P6.
+
+`/health` stays where it is and stays public: a monitor cannot sign in, and an
+unreachable health check is a dead monitor. What lands here is the part of the screen
+that shows *why* something is red — the recent log — and that is a different thing
+with a different audience.
+
+**The log needs `admin`, not `viewer`.** Every other read in this product is scoped to
+a workspace; a log line is not. It carries hostnames, provider names, file paths, the
+shape of the internals, and the mistakes of whoever is operating the machine. On an
+installation a whole small business shares, the receptionist who may read every
+transcript has no reason to read the SMTP handshake — and giving it to them is how an
+internal detail leaves the building in a screenshot.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel
+
+from api.logging import recent_log_handler
+from api.security.permissions import WorkspaceContext, require_admin
+from api.syslog import CAPACITY
+
+router = APIRouter(prefix="/api/system", tags=["system"])
+
+
+class LogEntry(BaseModel):
+    time: str
+    level: str
+    service: str
+    message: str
+    request_id: str | None
+
+
+class LogPage(BaseModel):
+    entries: list[LogEntry]
+    # Said out loud rather than left for somebody to discover: this is a ring in
+    # memory, it holds at most `capacity` lines, and a restart empties it.
+    capacity: int
+    retained: int
+
+
+@router.get(
+    "/log",
+    summary="Recent log lines, for the health screen",
+    response_model=LogPage,
+)
+async def recent_log(
+    context: Annotated[WorkspaceContext, require_admin],
+    level: Annotated[str, Query(pattern="^(all|errors|warnings|calls)$")] = "all",
+    limit: Annotated[int, Query(ge=1, le=CAPACITY)] = 100,
+) -> LogPage:
+    """The four filters the screen draws: all, errors, warnings, calls.
+
+    `warnings` includes errors, because the chip means "at least this serious" — what
+    somebody clicking it wants. A version showing warnings alone would hide the errors
+    underneath them, which is the opposite of the question being asked.
+    """
+    handler = recent_log_handler()
+    if handler is None:
+        # Logging was configured by something other than `configure_logging` - a test
+        # harness, or an embedding host. Empty is the honest answer; inventing lines
+        # would be worse than showing none.
+        return LogPage(entries=[], capacity=CAPACITY, retained=0)
+
+    entries = handler.recent(level=level, limit=limit)
+    return LogPage(
+        entries=[LogEntry(**entry.as_json()) for entry in entries],
+        capacity=CAPACITY,
+        retained=len(handler.entries),
+    )

--- a/api/syslog.py
+++ b/api/syslog.py
@@ -1,0 +1,124 @@
+"""The recent log, kept so the health screen can show it — P6.
+
+Logs already go to stdout as JSON. That is right for anything collecting them, and
+useless to the one person this product is built for: somebody running Tel-Agent on a
+machine in their own office, who has a browser and no journal viewer. §B8's health
+screen has had a Log panel drawn since the beginning with nothing behind it.
+
+**A bounded ring in memory, not a table.** Three reasons, in order of weight:
+
+* Writing every log line to the database means the act of logging can itself fail, and
+  a logger that raises inside an error handler turns one incident into two.
+* A log table grows without limit and is the first thing to fill a small installation's
+  disk — the same machine that holds the transcripts.
+* What this panel is for is the last few minutes: *why is SMTP red right now*. History
+  beyond that is what `auth_events` (deliberately durable) and stdout are for.
+
+The cost is stated rather than hidden: **a restart empties it.** For a panel answering
+"what is wrong at this moment" that is acceptable, and for anything else this is the
+wrong source.
+
+Everything here is fed by the same handler that formats the JSON, so a line reaching
+the screen has already passed through `SecretRedactionFilter`. The panel cannot show a
+secret that the log file would not have shown.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+# Roughly the last few minutes of a busy installation, and a few hours of a quiet one.
+# Bounded so memory is a constant an operator can reason about rather than a leak.
+CAPACITY = 500
+
+# The four filters the health screen draws, in its own words: All, Errors, Warnings,
+# Calls. "Calls" is not a level - it is the services that carry a conversation.
+CALL_SERVICES = frozenset({"agent", "tools", "sip", "stt", "tts"})
+
+
+@dataclass(frozen=True)
+class Entry:
+    """One line, in the shape the screen already renders."""
+
+    time: str
+    level: str
+    service: str
+    message: str
+    request_id: str | None
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "time": self.time,
+            "level": self.level,
+            "service": self.service,
+            "message": self.message,
+            "request_id": self.request_id,
+        }
+
+
+def _service_of(logger_name: str) -> str:
+    """`api.access` -> `access`, `api.security.session` -> `security`.
+
+    The screen shows one short word per line, so the second segment is taken rather
+    than the full dotted path: `api.security.session` in a narrow column pushes the
+    message off the end, which is the part somebody is actually reading.
+    """
+    parts = logger_name.split(".")
+    if len(parts) >= 2 and parts[0] in ("api", "agent"):
+        return parts[1]
+    return parts[0]
+
+
+class RecentLogHandler(logging.Handler):
+    """Keeps the last `CAPACITY` records, and never lets that break logging.
+
+    `emit` is called from inside other people's error paths. A handler that raises
+    there would replace a real failure with a confusing one, so everything is caught -
+    the standard library's own contract for handlers, honoured deliberately.
+    """
+
+    def __init__(self, capacity: int = CAPACITY) -> None:
+        super().__init__()
+        self.entries: deque[Entry] = deque(maxlen=capacity)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self.entries.append(
+                Entry(
+                    time=dt.datetime.fromtimestamp(record.created, dt.UTC).isoformat(),
+                    level=record.levelname.lower(),
+                    service=_service_of(record.name),
+                    # `getMessage` applies the % arguments; the redaction filter has
+                    # already run on the handler chain by this point.
+                    message=record.getMessage()[:500],
+                    request_id=getattr(record, "request_id", None),
+                )
+            )
+        except Exception:  # pragma: no cover - defensive, per the handler contract
+            self.handleError(record)
+
+    def recent(self, *, level: str = "all", limit: int = 100) -> list[Entry]:
+        """Newest first, filtered the way the screen's four chips filter.
+
+        `warnings` includes errors on purpose: the chip means "everything at least this
+        serious", which is what somebody clicking it wants to see. A version that
+        showed warnings *only* would hide the errors underneath them.
+        """
+        entries = list(self.entries)
+        entries.reverse()
+
+        if level == "errors":
+            entries = [e for e in entries if e.level in ("error", "critical")]
+        elif level == "warnings":
+            entries = [e for e in entries if e.level in ("warning", "error", "critical")]
+        elif level == "calls":
+            entries = [e for e in entries if e.service in CALL_SERVICES]
+
+        return entries[:limit]
+
+    def clear(self) -> None:
+        self.entries.clear()

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -249,6 +249,32 @@ def test_secret_named_fields_are_redacted_from_records() -> None:
     assert "[redacted]" in line
 
 
+def test_a_secret_passed_as_an_argument_is_redacted_and_still_formats() -> None:
+    """`log.warning("token: %s", value)` - the ordinary way to write it.
+
+    Redacting the format string alone replaced the `%s` while the credential stayed in
+    `record.args`, and `getMessage()` then raised "not all arguments converted" - which
+    silently dropped the whole line instead of writing a redacted one.
+    """
+    from api.logging import JsonFormatter, SecretRedactionFilter
+
+    record = logging.LogRecord(
+        "api.test",
+        logging.WARNING,
+        __file__,
+        1,
+        "could not connect with token: %s",
+        (SECRET_VALUE,),
+        None,
+    )
+
+    SecretRedactionFilter().filter(record)
+    line = JsonFormatter().format(record)
+
+    assert SECRET_VALUE not in line
+    assert "[redacted]" in line
+
+
 async def test_a_posted_credential_appears_nowhere_in_captured_logs(
     migrated: AsyncSession,
     configured_key: bytes,

--- a/tests/test_syslog.py
+++ b/tests/test_syslog.py
@@ -1,0 +1,270 @@
+"""The recent log behind the health screen — P6.
+
+The Log panel has been drawn since the beginning with nothing behind it. This is what
+fills it, and the tests that matter are the ones about what it must *not* do: leak a
+secret, outgrow its bound, reach somebody who should not read it, or pretend to be a
+durable record when it is a ring in memory.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.config import Settings
+from api.logging import configure_logging, recent_log_handler
+from api.main import create_app
+from api.models import Membership, User, Workspace
+from api.security.password import hash_password
+from api.syslog import CAPACITY, Entry, RecentLogHandler
+
+PASSWORD = "a sentence i can actually remember"  # noqa: S105
+CREDENTIAL = "9999999999:AAH-telegram-bot-token"
+
+
+# --- The ring itself ---------------------------------------------------------
+
+
+def test_it_keeps_the_newest_and_drops_the_oldest() -> None:
+    """Bounded so memory is a constant an operator can reason about, not a leak."""
+    handler = RecentLogHandler(capacity=3)
+    for index in range(5):
+        handler.emit(
+            logging.LogRecord("api.agent", logging.INFO, "x.py", 1, f"line {index}", (), None)
+        )
+
+    assert [entry.message for entry in handler.recent()] == ["line 4", "line 3", "line 2"]
+
+
+def test_newest_first() -> None:
+    """The panel is read top-down by somebody asking what just happened."""
+    handler = RecentLogHandler()
+    for message in ("first", "second"):
+        handler.emit(logging.LogRecord("api.agent", logging.INFO, "x.py", 1, message, (), None))
+
+    assert [entry.message for entry in handler.recent()] == ["second", "first"]
+
+
+@pytest.mark.parametrize(
+    ("logger_name", "service"),
+    [
+        ("api.access", "access"),
+        ("api.security.session", "security"),
+        ("agent.session", "session"),
+        ("uvicorn.error", "uvicorn"),
+    ],
+)
+def test_the_service_column_is_one_short_word(logger_name: str, service: str) -> None:
+    """A dotted path in a narrow column pushes the message off the end - and the
+    message is the part somebody is actually reading."""
+    handler = RecentLogHandler()
+    handler.emit(logging.LogRecord(logger_name, logging.INFO, "x.py", 1, "hello", (), None))
+
+    assert handler.recent()[0].service == service
+
+
+def test_a_handler_that_cannot_format_does_not_raise() -> None:
+    """`emit` runs inside other people's error paths. Raising there would replace a
+    real failure with a confusing one."""
+    handler = RecentLogHandler()
+    record = logging.LogRecord(
+        "api.agent", logging.INFO, "x.py", 1, "%d items", ("not a number",), None
+    )
+
+    handler.emit(record)  # must not raise
+
+    # Nothing usable was recorded, and that is the correct outcome: the incident this
+    # ran inside of is what matters, not this line.
+    assert len(handler.entries) <= 1
+
+
+# --- The four filters the screen draws ---------------------------------------
+
+
+def _fill(handler: RecentLogHandler) -> None:
+    for name, level, message in (
+        ("api.smtp", logging.WARNING, "connect refused"),
+        ("api.tools", logging.ERROR, "send_notification timeout"),
+        ("api.db", logging.INFO, "vacuum complete"),
+        ("api.agent", logging.INFO, "call ended, 2:38"),
+    ):
+        handler.emit(logging.LogRecord(name, level, "x.py", 1, message, (), None))
+
+
+def test_errors_shows_only_errors() -> None:
+    handler = RecentLogHandler()
+    _fill(handler)
+
+    assert [e.service for e in handler.recent(level="errors")] == ["tools"]
+
+
+def test_warnings_includes_errors() -> None:
+    """The chip means "at least this serious". Showing warnings alone would hide the
+    errors underneath them - the opposite of the question being asked."""
+    handler = RecentLogHandler()
+    _fill(handler)
+
+    services = {e.service for e in handler.recent(level="warnings")}
+    assert services == {"smtp", "tools"}
+
+
+def test_calls_is_the_services_that_carry_a_conversation() -> None:
+    """ "Calls" is not a level. It is agent, tools, sip, stt, tts."""
+    handler = RecentLogHandler()
+    _fill(handler)
+
+    assert {e.service for e in handler.recent(level="calls")} == {"tools", "agent"}
+
+
+# --- Wiring, and the secret that must not reach the screen -------------------
+
+
+def test_configure_logging_installs_exactly_one_ring() -> None:
+    """Called once per application built. Two rings would double every line."""
+    configure_logging("INFO")
+    configure_logging("INFO")
+
+    root = logging.getLogger()
+    rings = [h for h in root.handlers if isinstance(h, RecentLogHandler)]
+    assert len(rings) == 1
+    assert recent_log_handler() is rings[0]
+
+
+def test_a_secret_never_reaches_the_ring() -> None:
+    """The ring sits behind the same redaction filter as the JSON handler, so the panel
+    cannot show something the log file would not have shown."""
+    configure_logging("INFO")
+    handler = recent_log_handler()
+    assert handler is not None
+    handler.clear()
+
+    logging.getLogger("api.channels").warning("could not connect with token: %s", CREDENTIAL)
+
+    everything = " ".join(entry.message for entry in handler.recent())
+    assert CREDENTIAL not in everything
+    assert "[redacted]" in everything
+
+
+def test_the_request_id_travels_with_the_line() -> None:
+    """A line on the screen has to be findable in the real log, and the id is how."""
+    configure_logging("INFO")
+    handler = recent_log_handler()
+    assert handler is not None
+    handler.clear()
+
+    logging.getLogger("api.agent").info("something", extra={"request_id": "abc-123"})
+
+    assert handler.recent()[0].request_id == "abc-123"
+
+
+# --- The endpoint ------------------------------------------------------------
+
+
+@pytest.fixture
+async def clients(migrated: AsyncSession, settings: Settings, database_url: str):
+    """An admin and a viewer in one workspace."""
+    workspace = Workspace(name="Wagner & Partner")
+    migrated.add(workspace)
+    await migrated.flush()
+
+    password_hash = hash_password(PASSWORD)
+    for username, role in (("mohamed", "admin"), ("lukas", "viewer")):
+        user = User(username=username, password_hash=password_hash)
+        migrated.add(user)
+        await migrated.flush()
+        migrated.add(Membership(user_id=user.id, workspace_id=workspace.id, role=role))
+    await migrated.commit()
+
+    app = create_app(settings.model_copy(update={"database_url": database_url}))
+    opened: dict[str, AsyncClient] = {}
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        for username in ("mohamed", "lukas"):
+            client = AsyncClient(transport=transport, base_url="http://localhost")
+            response = await client.post(
+                "/api/auth/login", json={"username": username, "password": PASSWORD}
+            )
+            assert response.status_code == 200
+            opened[username] = client
+        try:
+            yield opened
+        finally:
+            for client in opened.values():
+                await client.aclose()
+
+
+async def test_an_admin_reads_the_log(clients) -> None:
+    logging.getLogger("api.agent").error("something went wrong")
+
+    response = await clients["mohamed"].get("/api/system/log?level=errors")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["capacity"] == CAPACITY
+    assert any("something went wrong" in entry["message"] for entry in body["entries"])
+
+
+async def test_a_viewer_cannot_read_the_log(clients) -> None:
+    """Every other read here is workspace-scoped; a log line is not. It carries
+    hostnames, paths and the shape of the internals, and the receptionist who may read
+    every transcript has no reason to read the SMTP handshake."""
+    response = await clients["lukas"].get("/api/system/log")
+
+    assert response.status_code == 403
+    assert "admin" in response.json()["error"]["message"]
+
+
+async def test_signed_out_is_refused(clients) -> None:
+    clients["mohamed"].cookies.clear()
+
+    assert (await clients["mohamed"].get("/api/system/log")).status_code == 401
+
+
+async def test_health_stays_public_and_carries_no_log(clients) -> None:
+    """A monitor cannot sign in, so /health stays open - and therefore must not start
+    carrying log lines with it."""
+    clients["mohamed"].cookies.clear()
+
+    response = await clients["mohamed"].get("/health")
+
+    assert response.status_code == 200
+    assert "entries" not in response.json()
+
+
+@pytest.mark.parametrize("bad", ["everything", "ERRORS", "'; drop table users--"])
+async def test_an_unknown_filter_is_refused(clients, bad: str) -> None:
+    response = await clients["mohamed"].get(f"/api/system/log?level={bad}")
+
+    assert response.status_code == 422
+
+
+async def test_the_limit_is_bounded_by_the_ring(clients) -> None:
+    """Asking for more than the ring can hold is a request that cannot be honoured."""
+    assert (
+        await clients["mohamed"].get(f"/api/system/log?limit={CAPACITY + 1}")
+    ).status_code == 422
+
+
+async def test_the_response_says_it_is_a_ring(clients) -> None:
+    """Said out loud rather than left to be discovered: bounded, and empty after a
+    restart. Anything needing a durable record must not read this."""
+    body = (await clients["mohamed"].get("/api/system/log")).json()
+
+    assert body["capacity"] == CAPACITY
+    assert body["retained"] <= CAPACITY
+
+
+def test_the_entry_shape_matches_what_the_screen_renders() -> None:
+    """time · level · service · message - the columns already drawn in health.tsx."""
+    entry = Entry(
+        time="2026-08-27T11:04:22+00:00",
+        level="warning",
+        service="smtp",
+        message="connect refused",
+        request_id=None,
+    )
+
+    assert set(entry.as_json()) == {"time", "level", "service", "message", "request_id"}


### PR DESCRIPTION
The health screen has had a Log panel drawn since the beginning with nothing behind it. This fills it.

### What lands

- `api/syslog.py` — a `deque(maxlen=500)` ring fed by the same handler chain that formats the JSON log, so a line reaching the screen has already passed through `SecretRedactionFilter`.
- `api/routes/system.py` — `GET /api/system/log?level=all|errors|warnings|calls&limit=…`, the four filter chips the screen already draws. `warnings` includes errors on purpose: the chip means "at least this serious".
- `api/logging.py` — installs the ring alongside the JSON handler, replacing only its own two handlers.

### Two decisions worth reading

**A ring in memory, not a table.** Writing every log line to the database means the act of logging can itself fail; a log table is the first thing to fill a small installation's disk — the same disk that holds the transcripts; and what this panel answers is *why is this red right now*, not history. The cost is stated in the response (`capacity`, `retained`) rather than left to be discovered: bounded, and empty after a restart. Anything needing a durable record reads `auth_events` or stdout instead.

**The log needs `admin`, not `viewer`.** Every other read in this product is scoped to a workspace; a log line is not. It carries hostnames, provider names, file paths and the shape of the internals. On an installation a whole small business shares, the receptionist who may read every transcript has no reason to read the SMTP handshake.

### A real bug the new tests found

`SecretRedactionFilter` replaced the placeholder in `log.warning("token: %s", value)` while the credential stayed in `record.args`. `getMessage()` then raised `not all arguments converted` — so the line was **dropped entirely instead of being written redacted**, in the JSON handler just as much as in the new ring. The filter now interpolates before redacting.

The existing E6 test passed a pre-interpolated f-string with empty `args`, which is why it never caught this. A regression test for the argument form is added beside it.

### Verification

`ruff format --check`, `ruff check`, `lint-imports`, `check-locales`, `check-placeholders` all clean; the full suite green on **SQLite and PostgreSQL**.