### PR TITLE
Give the six declared notification messages their callers

### DIFF
--- a/api/jobs/builtin.py
+++ b/api/jobs/builtin.py
@@ -98,17 +98,51 @@ async def _backup_nightly(db: DbSession) -> None:
     installation with fewer copies than it started with — which is the opposite of
     what a backup system is for.
     """
+    from api import notifications
     from api.backup import service as backup_service
 
     if not await store.get(db, backup_service.TARGET_KEY):
         # No target chosen. Not a failure: the screen already says loudly that there
         # is no backup of this installation, and a task that failed nightly would bury
-        # that message under an error nobody can act on from here.
+        # that message under an error nobody can act on from here. It is still the
+        # situation `backup_no_target` exists for, so it is said once — one open item
+        # per workspace, not a fresh one every night — and said again only after
+        # somebody resolves it without actually choosing a target.
+        await notifications.raise_for_installation(
+            db,
+            category="review",
+            message_key="backup_no_target",
+            needs_decision=True,
+            skip_if_open=True,
+        )
         return
 
     row = await backup_service.run_backup(db, kind="nightly")
     if row.status == "failed":
+        # Raised before the re-raise, so the operator hears about it even though the
+        # task record fails. A nightly job failing is silent by nature — the catalogue
+        # says this is the one an installation most needs to hear about.
+        await notifications.raise_for_installation(
+            db,
+            category="failure",
+            message_key="backup_failed",
+            detail=row.error,
+            needs_decision=True,
+            skip_if_open=True,
+        )
         raise RuntimeError(row.error or "backup failed")
+    if row.status == "unverified":
+        # The bytes are there and could not be read back. Not a failed task — the
+        # archive may well be fine — but not a copy anybody should trust either, and
+        # trusting it silently is how "known to restore" stops being true.
+        await notifications.raise_for_installation(
+            db,
+            category="review",
+            message_key="backup_unverified",
+            detail=row.error,
+            needs_decision=True,
+            skip_if_open=True,
+        )
     await backup_service.prune(db)
 
 
@@ -137,6 +171,8 @@ async def _send_email(db: DbSession, payload: dict) -> None:
     """
     import asyncio
 
+    from api import notifications
+
     settings = get_settings()
     # Resolved at send time, not at enqueue time: an operator who fixes the mail
     # server in Settings should rescue the messages already queued, not only the
@@ -150,6 +186,18 @@ async def _send_email(db: DbSession, payload: dict) -> None:
         body=payload["body"],
     )
     if not sent:
+        # Told on the first failed attempt, not after the last: the person this most
+        # often fails is somebody locked out and waiting for a reset code, and six
+        # hours of quiet backoff is exactly the "quietly" the forgot-password screen
+        # depends on this not being. Deduplicated while unresolved, so the retries do
+        # not add a line each. The address is not in it — a notification is read by
+        # anybody with `viewer`, and who was sent a reset code is personal data.
+        await notifications.raise_for_installation(
+            db,
+            category="failure",
+            message_key="mail_failed",
+            skip_if_open=True,
+        )
         raise RuntimeError("mail delivery failed")
 
 

--- a/api/jobs/runner.py
+++ b/api/jobs/runner.py
@@ -157,10 +157,25 @@ async def run_due_tasks(sessionmaker: async_sessionmaker) -> int:
                 await handler(db)
                 row.last_status, row.last_error = "ok", None
                 ran += 1
-            except Exception:
+            except Exception as error:
                 row.last_status = "failed"
                 row.last_error = traceback.format_exc(limit=5)
                 logger.exception("scheduled task failed", extra={"task": row.name})
+                # The operator's copy of the line above. A scheduled task fails with
+                # nobody watching — that is what "scheduled" means — and the log is
+                # read after somebody already knows something is wrong. Deduplicated
+                # while unresolved, so an hourly task that keeps failing is one line
+                # on the screen, not a wall of them.
+                from api import notifications
+
+                await notifications.raise_for_installation(
+                    db,
+                    category="system",
+                    message_key="task_failed",
+                    params={"task": row.name},
+                    detail=str(error) or repr(error),
+                    skip_if_open=True,
+                )
             await db.commit()
     return ran
 

--- a/api/notifications.py
+++ b/api/notifications.py
@@ -19,7 +19,7 @@ from typing import Any
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession as DbSession
 
-from api.models import Notification
+from api.models import Notification, Workspace
 from api.models.notification import ACTIONS, CATEGORIES
 
 logger = logging.getLogger("api.notifications")
@@ -102,6 +102,36 @@ def check_message(message_key: str, params: dict[str, Any]) -> None:
         )
 
 
+async def _already_open(
+    db: DbSession, workspace_id: int, message_key: str, params: dict[str, Any]
+) -> bool:
+    """Is the same situation already on the screen, unresolved?
+
+    Compared on the message and its parameters, never on `detail`: a nightly backup
+    that fails with a different error each night is still one situation, and five
+    copies of it would teach the operator that this screen repeats itself — which is
+    the last lesson the screen reporting failures can afford to teach.
+
+    Params are compared in Python rather than in SQL. JSON equality differs between
+    the two dialects D-029 commits to, and the open rows for one workspace are a
+    handful, not a table scan.
+    """
+    rows = (
+        (
+            await db.execute(
+                select(Notification).where(
+                    Notification.workspace_id == workspace_id,
+                    Notification.message_key == message_key,
+                    Notification.resolved_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return any(row.params == params for row in rows)
+
+
 async def raise_notification(
     db: DbSession,
     *,
@@ -114,12 +144,17 @@ async def raise_notification(
     primary_action: str = "none",
     action_payload: dict[str, Any] | None = None,
     conversation_id: int | None = None,
+    skip_if_open: bool = False,
 ) -> Notification | None:
-    """Record one notification and commit it. Returns None if recording failed.
+    """Record one notification and commit it. Returns None if nothing was recorded.
 
     Committed immediately rather than riding the caller's transaction: the thing being
     reported has usually just failed, and a rollback of that failure must not also
     erase the record that it happened.
+
+    `skip_if_open` is for callers that run on a beat. A nightly job that fails every
+    night must not add a row every night while the first one is still waiting; once
+    the operator resolves it, the next failure is news again and is raised again.
     """
     assert category in CATEGORIES, f"unknown category {category!r}"  # noqa: S101
     assert primary_action in ACTIONS, f"unknown action {primary_action!r}"  # noqa: S101
@@ -132,6 +167,8 @@ async def raise_notification(
     check_message(message_key, params)
 
     try:
+        if skip_if_open and await _already_open(db, workspace_id, message_key, params):
+            return None
         notification = Notification(
             workspace_id=workspace_id,
             category=category,
@@ -162,6 +199,61 @@ async def raise_notification(
         },
     )
     return notification
+
+
+async def raise_for_installation(
+    db: DbSession,
+    *,
+    category: str,
+    message_key: str,
+    params: dict[str, Any] | None = None,
+    detail: str | None = None,
+    needs_decision: bool = False,
+    primary_action: str = "none",
+    action_payload: dict[str, Any] | None = None,
+    skip_if_open: bool = False,
+) -> list[Notification]:
+    """Raise one event in every workspace, because it belongs to the machine.
+
+    A failed nightly backup, a scheduled task that stopped running, mail that cannot
+    leave the box: none of these happened *to* a workspace, but every workspace's data
+    sits inside that archive and behind that mail server. The notifications table is
+    scoped by workspace (D-028) and there is no installation row to hang these on —
+    inventing one would put machine-level failures on a screen nobody has — so each
+    workspace hears it, and each resolves its own copy.
+
+    Returns the rows that were actually written; an empty list on a fresh installation
+    with no workspace yet, or when every copy was skipped as already open.
+    """
+    # Checked before the loop, so a typo in the key fails even on an installation
+    # that has no workspace yet — the moment nothing would otherwise catch it.
+    check_message(message_key, params or {})
+
+    try:
+        workspace_ids = list((await db.execute(select(Workspace.id))).scalars().all())
+    except Exception:
+        logger.exception(
+            "could not list workspaces to notify", extra={"message_key": message_key}
+        )
+        return []
+
+    raised: list[Notification] = []
+    for workspace_id in workspace_ids:
+        row = await raise_notification(
+            db,
+            workspace_id=workspace_id,
+            category=category,
+            message_key=message_key,
+            params=params,
+            detail=detail,
+            needs_decision=needs_decision,
+            primary_action=primary_action,
+            action_payload=action_payload,
+            skip_if_open=skip_if_open,
+        )
+        if row is not None:
+            raised.append(row)
+    return raised
 
 
 async def resolve(

--- a/api/routes/backup.py
+++ b/api/routes/backup.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession as DbSession
 
+from api import notifications
 from api.backup import archive, service, targets
 from api.backup.service import ROOT
 from api.dependencies import CurrentUser
@@ -303,6 +304,16 @@ async def stage_restore(
         request=request,
         user_id=user.id,
         details={"backup_id": row.id, "taken_at": row.started_at.isoformat()},
+    )
+    # Every workspace hears it, not only the owner's screen: the restart this asks
+    # for drops the phone line for everybody, and the restore itself deletes every
+    # workspace's data since that date. Informational, not a decision — the decision
+    # was the owner's and has been taken; there is no button here that could undo it.
+    await notifications.raise_for_installation(
+        db,
+        category="system",
+        message_key="restore_staged",
+        params={"taken_at": row.started_at.date().isoformat()},
     )
     logger.warning(
         "restore staged; the next start will replace the database",

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -474,6 +474,46 @@ async def test_staging_a_restore_changes_nothing_yet(
     assert (await clients["mohamed"].get("/api/backup")).status_code == 200
 
 
+async def test_staging_a_restore_tells_every_workspace(
+    clients, seeded: AsyncSession, settings: Settings, tmp_path, monkeypatch
+) -> None:
+    """The restart this asks for drops the phone line for everybody, and the restore
+    deletes every workspace's data since that date - not only the owner's."""
+    from sqlalchemy import select
+
+    from api.models import Notification
+    from api.routes import backup as backup_routes
+
+    monkeypatch.setattr(backup_routes, "RESTORE_REQUEST", tmp_path / "restore-request.json")
+    await store.set_value(seeded, service.TARGET_KEY, str(tmp_path / "share"))
+    await seeded.commit()
+    row = await service.run_backup(seeded, kind="manual", settings=settings)
+    # Read before `expire_all`: an expired attribute refreshes lazily, which the
+    # async session refuses outside an await.
+    taken_at = row.started_at.date().isoformat()
+
+    response = await clients["mohamed"].post(
+        f"/api/backup/{row.id}/restore",
+        json={"confirm_date": taken_at},
+    )
+    assert response.status_code == 200
+
+    seeded.expire_all()
+    raised = (
+        (
+            await seeded.execute(
+                select(Notification).where(Notification.message_key == "restore_staged")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [item.params for item in raised] == [{"taken_at": taken_at}]
+    # Informational, not a decision: the decision was the owner's and has been taken,
+    # and there is no button on the screen that could undo it.
+    assert raised[0].needs_decision is False
+
+
 # --- The restore itself -------------------------------------------------------
 
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -17,7 +17,7 @@ from api.config import Settings
 from api.db import create_engine, create_sessionmaker
 from api.jobs import runner
 from api.jobs.builtin import CORE_SCHEDULE
-from api.models import BackgroundJob, ScheduledTask
+from api.models import BackgroundJob, Notification, ScheduledTask, Workspace
 
 
 @pytest.fixture
@@ -309,6 +309,176 @@ async def test_a_job_with_no_handler_fails_rather_than_looping(
     assert row is not None
     assert row.status == "failed"
     assert "no handler" in (row.last_error or "")
+
+
+# --- Failures reach the notifications screen ---------------------------------
+#
+# The catalogue in `api/notifications.py` declared six messages and, until these
+# callers existed, not one of them was ever raised. A declared message with no caller
+# is the same defect as a cleanup function nothing calls - which is the failure this
+# module's own docstring opens with.
+
+
+async def test_a_failing_task_tells_the_operator_once(
+    migrated: AsyncSession, sessionmaker: async_sessionmaker
+) -> None:
+    """A scheduled task fails with nobody watching - that is what "scheduled" means.
+    The log is read after somebody already knows something is wrong; this is how they
+    come to know."""
+    migrated.add(Workspace(name="W"))
+    await migrated.commit()
+
+    @runner.task("broken_loudly")
+    async def broken(db) -> None:
+        raise RuntimeError("the disk is full")
+
+    migrated.add(ScheduledTask(name="broken_loudly", interval_seconds=60, next_run_at=_now()))
+    await migrated.commit()
+
+    await runner.run_due_tasks(sessionmaker)
+
+    migrated.expire_all()
+    rows = (
+        (
+            await migrated.execute(
+                select(Notification).where(Notification.message_key == "task_failed")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].params == {"task": "broken_loudly"}
+    assert "disk is full" in (rows[0].detail or "")
+    assert rows[0].needs_decision is False  # the log, not a decision
+
+    # The next failure, while the first is still on the screen, adds nothing.
+    row = await migrated.scalar(
+        select(ScheduledTask).where(ScheduledTask.name == "broken_loudly")
+    )
+    row.next_run_at = _now() - dt.timedelta(seconds=1)
+    await migrated.commit()
+    await runner.run_due_tasks(sessionmaker)
+
+    migrated.expire_all()
+    count = len(
+        (
+            await migrated.execute(
+                select(Notification).where(Notification.message_key == "task_failed")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert count == 1
+
+
+async def test_a_nightly_backup_that_fails_raises_backup_failed(
+    migrated: AsyncSession, tmp_path
+) -> None:
+    """The one an installation most needs to hear about, because a nightly job failing
+    is silent by nature. Raised even though the task record also fails."""
+    from api.jobs.builtin import _backup_nightly
+    from api.settings import store
+
+    migrated.add(Workspace(name="W"))
+    await migrated.flush()
+    # A target that looks like a path and is not usable: a file where the directory
+    # should be - the shape of a share that went away.
+    blocker = tmp_path / "not-a-directory"
+    blocker.write_text("i am a file")
+    await store.set_value(migrated, "backup.target_path", str(blocker / "backups"))
+    await migrated.commit()
+
+    with pytest.raises(RuntimeError):
+        await _backup_nightly(migrated)
+
+    rows = (
+        (
+            await migrated.execute(
+                select(Notification).where(Notification.message_key == "backup_failed")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].needs_decision is True
+    assert rows[0].category == "failure"
+
+
+async def test_a_nightly_backup_with_no_target_says_so_once(
+    migrated: AsyncSession,
+) -> None:
+    """Not a failed task - the early return stands - but it is the situation
+    `backup_no_target` exists for, and two nights are still one situation."""
+    from api.jobs.builtin import _backup_nightly
+
+    migrated.add(Workspace(name="W"))
+    await migrated.commit()
+
+    await _backup_nightly(migrated)  # tonight
+    await _backup_nightly(migrated)  # tomorrow night, still unconfigured
+
+    rows = (
+        (
+            await migrated.execute(
+                select(Notification).where(Notification.message_key == "backup_no_target")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].needs_decision is True
+
+
+async def test_failed_mail_reaches_the_screen_before_the_backoff_does(
+    migrated: AsyncSession,
+    sessionmaker: async_sessionmaker,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The person this fails is locked out, waiting for a reset code. Six hours of
+    quiet backoff is exactly the "quietly" the forgot screen depends on this not
+    being - so the first failed attempt says so, and the retries add nothing."""
+    from api import mail
+
+    migrated.add(Workspace(name="W"))
+    await migrated.commit()
+
+    def refused(config, *, to: str, subject: str, body: str) -> bool:
+        return False
+
+    monkeypatch.setattr(mail, "send", refused)
+
+    await runner.enqueue(
+        migrated, "send_email", {"to": "sabine@example.test", "subject": "s", "body": "b"}
+    )
+    await migrated.commit()
+
+    await runner.run_due_jobs(sessionmaker)
+
+    migrated.expire_all()
+    rows = (
+        (
+            await migrated.execute(
+                select(Notification).where(Notification.message_key == "mail_failed")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    # And the address stayed out of it: a notification is read by anybody with
+    # `viewer`, and who was sent a reset code is personal data.
+    assert rows[0].params == {}
+    assert "sabine" not in (rows[0].detail or "")
+
+    # The job itself still failed and is back in the queue - the notification is a
+    # report, not a rescue.
+    job_row = await migrated.scalar(select(BackgroundJob))
+    assert job_row is not None
+    assert job_row.status == "queued"
 
 
 # --- The core schedule -------------------------------------------------------

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -260,6 +260,130 @@ async def test_an_unknown_category_is_caught_at_the_call_site(
         )
 
 
+# --- Installation-level events reach every workspace ---------------------------
+
+
+async def test_an_installation_event_reaches_every_workspace(
+    migrated: AsyncSession,
+) -> None:
+    """A failed backup did not happen to one workspace. Every workspace's data is in
+    that archive, and there is no installation-level screen to say it on (D-028)."""
+    first = Workspace(name="Wagner & Partner")
+    second = Workspace(name="Wolf Studio")
+    migrated.add_all([first, second])
+    await migrated.commit()
+
+    raised = await notifications.raise_for_installation(
+        migrated, category="failure", message_key="backup_failed", needs_decision=True
+    )
+
+    assert {row.workspace_id for row in raised} == {first.id, second.id}
+
+
+async def test_an_installation_event_with_a_bad_key_fails_even_with_no_workspace(
+    migrated: AsyncSession,
+) -> None:
+    """On a fresh installation the loop body never runs, which is exactly where a typo
+    would otherwise survive until the first workspace existed to crash on."""
+    with pytest.raises(notifications.UnknownMessage):
+        await notifications.raise_for_installation(
+            migrated, category="system", message_key="no_such_message"
+        )
+
+
+# --- skip_if_open: a repeating failure is one line, not a wall -----------------
+
+
+async def test_a_repeating_failure_is_raised_once_while_open(
+    migrated: AsyncSession,
+) -> None:
+    """A nightly job that fails every night must not add a row every night. Five
+    copies of one situation teach the operator that this screen repeats itself."""
+    workspace = Workspace(name="W")
+    migrated.add(workspace)
+    await migrated.flush()
+
+    first = await notifications.raise_notification(
+        migrated,
+        workspace_id=workspace.id,
+        category="failure",
+        message_key="backup_failed",
+        needs_decision=True,
+        skip_if_open=True,
+    )
+    # The next night fails differently. Still the same situation.
+    second = await notifications.raise_notification(
+        migrated,
+        workspace_id=workspace.id,
+        category="failure",
+        message_key="backup_failed",
+        detail="a different error tonight",
+        needs_decision=True,
+        skip_if_open=True,
+    )
+
+    assert first is not None
+    assert second is None
+
+
+async def test_a_resolved_failure_is_news_again(migrated: AsyncSession) -> None:
+    """Once the operator has dealt with it, the next failure is a new fact — resolving
+    without actually fixing anything must not silence the screen for good."""
+    workspace = Workspace(name="W")
+    migrated.add(workspace)
+    await migrated.flush()
+
+    first = await notifications.raise_notification(
+        migrated,
+        workspace_id=workspace.id,
+        category="failure",
+        message_key="backup_failed",
+        skip_if_open=True,
+    )
+    assert first is not None
+    await notifications.resolve(migrated, first)
+    await migrated.commit()
+
+    again = await notifications.raise_notification(
+        migrated,
+        workspace_id=workspace.id,
+        category="failure",
+        message_key="backup_failed",
+        skip_if_open=True,
+    )
+
+    assert again is not None
+
+
+async def test_the_dedup_tells_situations_apart_by_their_parameters(
+    migrated: AsyncSession,
+) -> None:
+    """Two different tasks failing are two situations, not a repeat of one."""
+    workspace = Workspace(name="W")
+    migrated.add(workspace)
+    await migrated.flush()
+
+    first = await notifications.raise_notification(
+        migrated,
+        workspace_id=workspace.id,
+        category="system",
+        message_key="task_failed",
+        params={"task": "cleanup_sessions"},
+        skip_if_open=True,
+    )
+    second = await notifications.raise_notification(
+        migrated,
+        workspace_id=workspace.id,
+        category="system",
+        message_key="task_failed",
+        params={"task": "backup_nightly"},
+        skip_if_open=True,
+    )
+
+    assert first is not None
+    assert second is not None
+
+
 # --- The catalogue and the translations must not drift apart ------------------
 
 


### PR DESCRIPTION
## What

The catalogue in `api/notifications.py` declared six messages and not one of them was ever raised. This wires all six, which is the smallest end-to-end proof that the notification contract works - the next step `HANDOFF.md` names.

## How

**Installation-level events reach every workspace.** A failed backup did not happen to one workspace, but the table is scoped by workspace (D-028) and there is no installation row to hang it on. `raise_for_installation` raises the event in each workspace; each resolves its own copy.

**A repeating failure is one line, not a wall.** `skip_if_open` skips raising while an unresolved copy of the same message with the same parameters is on the screen. Resolving it makes the next failure news again. Compared in Python, not SQL - JSON equality differs between the two dialects.

**The callers:**

| Message | Raised by | Shape |
|---|---|---|
| `backup_failed` | nightly task | failure, decision |
| `backup_unverified` | nightly task | review, decision |
| `backup_no_target` | nightly task (early return stands) | review, decision |
| `restore_staged` | the restore endpoint | system, log |
| `task_failed` | the runner, any task that throws | system, log |
| `mail_failed` | `send_email`, first failed attempt | failure, log |

`mail_failed` fires on the first attempt rather than after the backoff runs out - the person it fails is locked out waiting for a reset code, and six quiet hours is exactly the quietly the forgot screen depends on this not being. The address stays out of the notification: it is read by anybody with `viewer`.

## Verified

- Full suite on SQLite: 336 passed. `ruff format --check`, `ruff check`, `lint-imports` clean.
- PostgreSQL half rides this PR's CI - no server is installed on this machine.