### PR TITLE
Format the invites migration, which is failing CI on main

### DIFF
--- a/alembic/versions/2026_08_28_1342-0287df510f9e_invites.py
+++ b/alembic/versions/2026_08_28_1342-0287df510f9e_invites.py
@@ -73,7 +73,9 @@ def upgrade() -> None:
     )
     with op.batch_alter_table("invites", schema=None) as batch_op:
         batch_op.create_index(batch_op.f("ix_invites_user_id"), ["user_id"], unique=False)
-        batch_op.create_index(batch_op.f("ix_invites_workspace_id"), ["workspace_id"], unique=False)
+        batch_op.create_index(
+            batch_op.f("ix_invites_workspace_id"), ["workspace_id"], unique=False
+        )
 
     # ### end Alembic commands ###
 


### PR DESCRIPTION
`main` has been red since #82 merged. `ruff format --check .` fails on one line in the invites migration — 101 characters against a 96-character limit.

It survived the branch because the format runs during that work covered `api tests`, and `alembic/` is in neither. CI formats the whole tree, which is exactly the difference — and the reason the gate is `ruff format --check .` rather than a list of directories somebody has to remember to extend.

One file, three lines, no behaviour change.