### PR TITLE
Read the transcript archive, and search it

### DIFF
--- a/api/conversations.py
+++ b/api/conversations.py
@@ -1,0 +1,153 @@
+"""Reading conversations, and searching what was said in them.
+
+The transcript archive is one of the five things Rule 5 says Tel-Agent owns, and
+`messages` has carried a full-text index since the very first migration — a GIN index
+over `to_tsvector('simple', text)` on PostgreSQL, an FTS5 virtual table with three
+triggers on SQLite. **Nothing has ever queried either of them.** This module is what
+finally does; the index was the same kind of orphan as the four cleanup functions P2
+found, and an index nothing uses is a write cost with no read benefit.
+
+**Search is the one query that must be written twice.** D-029 puts both dialects on
+equal footing, and full-text search is where they genuinely differ: there is no
+portable spelling of it, and the ORM has no abstraction that covers both without
+falling back to `LIKE`. `LIKE '%word%'` would be portable, would not use either index,
+and would scan every transcript on the installation — so it is written twice, on
+purpose, with the two spellings side by side where they can be compared.
+
+The PostgreSQL half must say `'simple'` exactly as the index does. `to_tsvector(text)`
+without the configuration argument is a *different expression*, the planner will not
+match it to the index, and the query silently becomes a sequential scan over every
+message — fast on a laptop with fifty rows and catastrophic on a year of transcripts.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from sqlalchemy import Select, false, func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession as DbSession
+
+from api.models import Conversation, Message
+
+# One page of threads. The screen shows a scrolling list, not a pager, so this is the
+# size of a scroll rather than a page of results.
+PAGE = 50
+
+# How much of the last message is kept for the list's preview line. The list shows one
+# line per thread; sending the whole transcript so the browser can trim it would move
+# megabytes to render kilobytes.
+PREVIEW = 160
+
+
+def is_postgres(db: DbSession) -> bool:
+    return db.bind.dialect.name == "postgresql"
+
+
+# A term is a run of letters or digits, in any script - `café` and `فاتورة` are terms.
+# Everything else a person can type into a search box is punctuation as far as the
+# index is concerned.
+_TERM = re.compile(r"\w+", re.UNICODE)
+
+
+def terms_of(query: str) -> list[str]:
+    """The words in a search box, with every operator character discarded.
+
+    Both dialects have a query language, and both raise on input a person can
+    reasonably type: a bare `"` is `unterminated string` to SQLite's FTS5, which
+    reached the browser as a 500 before this existed. Neither language is one the
+    search box promises, so neither is one it has to accept.
+
+    Discarding the operators also settles a second question the two dialects would
+    otherwise answer differently. `websearch_to_tsquery` understands `or` and a
+    leading minus; FTS5 understands `NEAR` and `*`. Passing input through to both
+    would mean the same search box behaving differently depending on which database
+    the installation happens to run - which is the opposite of what D-029 is for.
+    Every search is "all of these words", on both.
+    """
+    return _TERM.findall(query)
+
+
+def search_filter(db: DbSession, query: str) -> Any:
+    """The `WHERE` clause that finds messages matching `query`, per dialect.
+
+    Both spellings are parameterised. The query text is a person's search box and
+    reaches the database as a bound value, never as concatenated SQL.
+    """
+    terms = terms_of(query)
+    if not terms:
+        # Punctuation alone. Matching nothing is the honest answer - a search that
+        # quietly became "show everything" would look like a working search that
+        # ignores what was typed.
+        return false()
+
+    if is_postgres(db):
+        # `'simple'` is not a default to be left off: the index is built over
+        # `to_tsvector('simple', text)`, and any other spelling of this expression is
+        # not the indexed one. Space-separated terms are an AND to
+        # `websearch_to_tsquery`, which is the behaviour chosen above.
+        return text(
+            "to_tsvector('simple', messages.text) @@ websearch_to_tsquery('simple', :q)"
+        ).bindparams(q=" ".join(terms))
+
+    # SQLite keeps the index in a separate virtual table kept current by three
+    # triggers, so the match is a subquery against it rather than a predicate on the
+    # column. `rowid` is `messages.id` - that is what the insert trigger writes.
+    #
+    # Each term is quoted, which in FTS5 makes it a literal string rather than a
+    # fragment of query syntax. The terms contain no quotes to escape: `terms_of`
+    # kept only word characters.
+    match = " ".join(f'"{term}"' for term in terms)
+    return Message.id.in_(
+        select(text("rowid"))
+        .select_from(text("messages_fts"))
+        .where(text("messages_fts MATCH :q").bindparams(q=match))
+    )
+
+
+def conversations_for(workspace_id: int) -> Select:
+    """The base query, scoped before anything else is added to it.
+
+    The scope is part of the query rather than a check on the result, for the reason
+    D-028 gives: a filter applied afterwards is one somebody eventually forgets, and
+    forgetting it here means one customer's transcripts on another customer's screen.
+    """
+    return select(Conversation).where(Conversation.workspace_id == workspace_id)
+
+
+async def previews(db: DbSession, conversation_ids: list[int]) -> dict[int, str]:
+    """The last line of each conversation, in one query rather than one per row.
+
+    A list of fifty threads asking for its own preview is fifty round trips, and it is
+    the shape that looks fine on a seeded database and falls over on a real one.
+    """
+    if not conversation_ids:
+        return {}
+
+    # The greatest `ts_ms` per conversation, then the row that carries it. Two steps
+    # because `ts_ms` is not unique on its own - two lines can share a millisecond -
+    # and the id breaks the tie deterministically.
+    latest = (
+        select(Message.conversation_id, func.max(Message.id).label("message_id"))
+        .where(Message.conversation_id.in_(conversation_ids))
+        .group_by(Message.conversation_id)
+        .subquery()
+    )
+    rows = await db.execute(
+        select(Message.conversation_id, Message.text).join(
+            latest, Message.id == latest.c.message_id
+        )
+    )
+    return {cid: body[:PREVIEW] for cid, body in rows}
+
+
+async def message_counts(db: DbSession, conversation_ids: list[int]) -> dict[int, int]:
+    """How many lines each conversation holds — again in one query, for one reason."""
+    if not conversation_ids:
+        return {}
+    rows = await db.execute(
+        select(Message.conversation_id, func.count(Message.id))
+        .where(Message.conversation_id.in_(conversation_ids))
+        .group_by(Message.conversation_id)
+    )
+    return dict(rows.all())

--- a/api/main.py
+++ b/api/main.py
@@ -41,6 +41,7 @@ from api.middleware.ws_auth import WebSocketAuthMiddleware
 from api.routes import apps as apps_routes
 from api.routes import auth as auth_routes
 from api.routes import backup as backup_routes
+from api.routes import conversations as conversation_routes
 from api.routes import invites as invite_routes
 from api.routes import notifications as notification_routes
 from api.routes import recovery as recovery_routes
@@ -261,6 +262,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(notification_routes.router)
     app.include_router(system_routes.router)
     app.include_router(backup_routes.router)
+    app.include_router(conversation_routes.router)
     app.include_router(settings_routes.router)
     app.include_router(recovery_routes.router)
     app.include_router(workspace_routes.router)

--- a/api/routes/conversations.py
+++ b/api/routes/conversations.py
@@ -1,0 +1,315 @@
+"""The conversations screen's endpoints — the transcript archive, read.
+
+**`viewer` reads; nothing here writes.** The role matrix on the settings screen says
+what a viewer is for in its own words: "Reads calls. Changes nothing, answers
+nothing." This whole module is that sentence — every route is a GET, and the write
+path arrives with the web chat.
+
+**The recording path never leaves the server.** `calls.recording_path` is a filesystem
+path on the machine, and a screen has no use for it; what a screen needs to know is
+whether audio exists, which is a boolean. Sending the path would put the layout of
+somebody's disk into a browser, and into anything that later logs a response body.
+
+Two things this deliberately does not do yet, because nothing can produce them:
+starring a thread and marking one unread are drawn on the screen and have no column
+behind them. They stay drawings rather than becoming buttons that do nothing.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Annotated, Any
+
+from fastapi import APIRouter, HTTPException, Query, Request, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession as DbSession
+
+from api.conversations import (
+    PAGE,
+    conversations_for,
+    message_counts,
+    previews,
+    search_filter,
+)
+from api.models import Call, Channel, Conversation, Message
+from api.security.permissions import WorkspaceContext, require_viewer
+
+router = APIRouter(prefix="/api/conversations", tags=["conversations"])
+
+
+def _utc(value: dt.datetime | None) -> str | None:
+    """Always with an offset, always UTC.
+
+    A naive timestamp read in another timezone moves a call by hours, and a transcript
+    whose lines are hours out is a transcript nobody can testify from.
+    """
+    if value is None:
+        return None
+    aware = value if value.tzinfo else value.replace(tzinfo=dt.UTC)
+    return aware.astimezone(dt.UTC).isoformat()
+
+
+class ThreadOut(BaseModel):
+    id: int
+    channel: str
+    direction: str
+    status: str
+    handling: str | None
+    intent: str | None
+    started_at: str
+    ended_at: str | None
+    # Whoever is on the other end, as the channel knows them. For a call this is the
+    # caller's number; for a messaging channel the channel's own thread identifier.
+    who: str | None
+    preview: str | None
+    message_count: int
+    is_call: bool
+
+
+class ThreadPage(BaseModel):
+    threads: list[ThreadOut]
+    # Said rather than inferred from a short page: a client that guesses "fewer than
+    # asked for means the end" guesses wrong the first time a filter removes rows.
+    has_more: bool
+
+
+class MessageOut(BaseModel):
+    id: int
+    # Milliseconds from the start of the conversation, not a clock. See the model.
+    ts_ms: int
+    speaker: str
+    text: str
+    # An operator's instruction to the agent mid-conversation. Part of the record, and
+    # flagged because the customer never saw it - a screen that drew it like any other
+    # line would be showing a conversation that did not happen.
+    is_whisper: bool
+    stt_confidence: float | None
+    language: str | None
+
+
+class CallOut(BaseModel):
+    from_e164: str | None
+    billable_seconds: int | None
+    provider_cost_micros: int | None
+    # Whether audio exists - never where it is. See the module docstring.
+    has_recording: bool
+
+
+class ThreadDetail(ThreadOut):
+    summary: str | None
+    messages: list[MessageOut]
+    call: CallOut | None
+
+
+def _thread(
+    row: Conversation, channel_kind: str, preview: str | None, count: int, is_call: bool
+) -> ThreadOut:
+    return ThreadOut(
+        id=row.id,
+        channel=channel_kind,
+        direction=row.direction,
+        status=row.status,
+        handling=row.handling,
+        intent=row.intent,
+        started_at=_utc(row.started_at) or "",
+        ended_at=_utc(row.ended_at),
+        who=row.external_id,
+        preview=preview,
+        message_count=count,
+        is_call=is_call,
+    )
+
+
+@router.get("", response_model=ThreadPage, summary="The threads in this workspace")
+async def list_conversations(
+    request: Request,
+    context: Annotated[WorkspaceContext, require_viewer],
+    channel: Annotated[str | None, Query(max_length=40)] = None,
+    status_filter: Annotated[
+        str | None, Query(alias="status", pattern="^(open|closed)$")
+    ] = None,
+    q: Annotated[str | None, Query(max_length=200)] = None,
+    limit: Annotated[int, Query(ge=1, le=PAGE)] = PAGE,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> ThreadPage:
+    """Newest first, filtered by channel, status, or what was said in it.
+
+    `q` searches the *messages*, not the summaries, and returns the conversations they
+    belong to — which is what somebody looking for "the caller who mentioned a
+    refund" actually means. It runs through the full-text index; see
+    `api/conversations.py` for why that query is spelled twice.
+    """
+    db: DbSession = request.state.db
+
+    query = conversations_for(context.id).join(Channel, Channel.id == Conversation.channel_id)
+    if channel:
+        query = query.where(Channel.kind == channel)
+    if status_filter:
+        query = query.where(Conversation.status == status_filter)
+    if q and q.strip():
+        # Scoped on `messages` too, not only on the parent. The subquery is the one
+        # place a search could otherwise reach across workspaces, and `messages`
+        # carries `workspace_id` precisely so it does not have to join to be safe.
+        matching = (
+            select(Message.conversation_id)
+            .where(Message.workspace_id == context.id)
+            .where(search_filter(db, q.strip()))
+        )
+        query = query.where(Conversation.id.in_(matching))
+
+    # One more than asked for, so "is there another page" is answered by fact rather
+    # than by a second count query over the same filters.
+    rows = list(
+        (
+            await db.execute(
+                query.add_columns(Channel.kind)
+                .order_by(Conversation.started_at.desc(), Conversation.id.desc())
+                .offset(offset)
+                .limit(limit + 1)
+            )
+        ).all()
+    )
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+
+    ids = [row[0].id for row in rows]
+    preview_by_id = await previews(db, ids)
+    count_by_id = await message_counts(db, ids)
+    call_ids = set(
+        (await db.execute(select(Call.conversation_id).where(Call.conversation_id.in_(ids))))
+        .scalars()
+        .all()
+    )
+
+    return ThreadPage(
+        threads=[
+            _thread(
+                row[0],
+                row[1],
+                preview_by_id.get(row[0].id),
+                count_by_id.get(row[0].id, 0),
+                row[0].id in call_ids,
+            )
+            for row in rows
+        ],
+        has_more=has_more,
+    )
+
+
+# Registered before `/{conversation_id}`, and that order is load-bearing: FastAPI
+# matches in declaration order, so with the parameterised route first this path is
+# read as a conversation whose id is "meta" and answered with a validation error.
+class ChannelOut(BaseModel):
+    id: int
+    kind: str
+    name: str | None
+    thread_count: int
+
+
+@router.get(
+    "/meta/channels",
+    response_model=list[ChannelOut],
+    summary="The channels this workspace has conversations on",
+)
+async def list_channels(
+    request: Request, context: Annotated[WorkspaceContext, require_viewer]
+) -> list[Any]:
+    """What the filter chips should offer.
+
+    Built from what the workspace actually has rather than from the ten channels the
+    product commits to: a chip for a channel with nothing behind it is a chip that
+    always returns an empty list, and the screen already has an empty state for the
+    real thing.
+    """
+    from sqlalchemy import func
+
+    db: DbSession = request.state.db
+    rows = await db.execute(
+        select(Channel.id, Channel.kind, Channel.name, func.count(Conversation.id))
+        .join(Conversation, Conversation.channel_id == Channel.id)
+        .where(Conversation.workspace_id == context.id)
+        .group_by(Channel.id, Channel.kind, Channel.name)
+        .order_by(func.count(Conversation.id).desc())
+    )
+    return [
+        ChannelOut(id=cid, kind=kind, name=name, thread_count=count)
+        for cid, kind, name, count in rows
+    ]
+
+
+@router.get(
+    "/{conversation_id}",
+    response_model=ThreadDetail,
+    summary="One thread, with what was said in it",
+)
+async def read_conversation(
+    request: Request,
+    context: Annotated[WorkspaceContext, require_viewer],
+    conversation_id: int,
+) -> ThreadDetail:
+    db: DbSession = request.state.db
+
+    found = (
+        await db.execute(
+            conversations_for(context.id)
+            .join(Channel, Channel.id == Conversation.channel_id)
+            .add_columns(Channel.kind)
+            .where(Conversation.id == conversation_id)
+        )
+    ).first()
+    if found is None:
+        # The workspace filter is part of the lookup above, so an id belonging to
+        # another workspace is indistinguishable from one that does not exist. A 403
+        # here would confirm the row is real, which is the answer being withheld.
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="No such conversation.")
+
+    row, channel_kind = found
+
+    messages = list(
+        (
+            await db.execute(
+                select(Message)
+                .where(Message.conversation_id == row.id)
+                # By position in the conversation, never by insertion order: a line
+                # corrected and re-stored later must still read where it was said.
+                .order_by(Message.ts_ms, Message.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    call = await db.get(Call, row.id)
+
+    return ThreadDetail(
+        **_thread(
+            row,
+            channel_kind,
+            messages[-1].text[:160] if messages else None,
+            len(messages),
+            call is not None,
+        ).model_dump(),
+        summary=row.summary,
+        messages=[
+            MessageOut(
+                id=m.id,
+                ts_ms=m.ts_ms,
+                speaker=m.speaker,
+                text=m.text,
+                is_whisper=m.is_whisper,
+                stt_confidence=m.stt_confidence,
+                language=m.language,
+            )
+            for m in messages
+        ],
+        call=(
+            CallOut(
+                from_e164=call.from_e164,
+                billable_seconds=call.billable_seconds,
+                provider_cost_micros=call.provider_cost_micros,
+                has_recording=bool(call.recording_path),
+            )
+            if call is not None
+            else None
+        ),
+    )

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -1,0 +1,296 @@
+"""Reading the transcript archive, and searching it.
+
+The tests that matter are the isolation one and the search one. Everything else on
+this screen is a list; those two are where a mistake costs a customer's transcripts or
+silently scans a year of them.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.config import Settings
+from api.main import create_app
+from api.models import Call, Channel, Conversation, Membership, Message, User, Workspace
+from api.security.password import hash_password
+
+PASSWORD = "a sentence i can actually remember"  # noqa: S105
+
+
+async def _thread(
+    db: AsyncSession,
+    workspace: Workspace,
+    channel: Channel,
+    lines: list[tuple[str, str]],
+    *,
+    external_id: str | None = None,
+    status: str = "open",
+    call: bool = False,
+) -> Conversation:
+    row = Conversation(
+        workspace_id=workspace.id,
+        channel_id=channel.id,
+        direction="inbound",
+        status=status,
+        external_id=external_id,
+    )
+    db.add(row)
+    await db.flush()
+    for index, (speaker, body) in enumerate(lines):
+        db.add(
+            Message(
+                workspace_id=workspace.id,
+                conversation_id=row.id,
+                ts_ms=index * 1000,
+                speaker=speaker,
+                text=body,
+            )
+        )
+    if call:
+        db.add(
+            Call(
+                conversation_id=row.id,
+                workspace_id=workspace.id,
+                from_e164="+4366412345678",
+                recording_path="/var/recordings/secret-path.wav",
+                billable_seconds=158,
+                provider_cost_micros=2400,
+            )
+        )
+    return row
+
+
+@pytest.fixture
+async def stage(migrated: AsyncSession, settings: Settings, database_url: str):
+    """Two workspaces with transcripts, and three roles to read them with."""
+    mine = Workspace(name="Wagner & Partner")
+    theirs = Workspace(name="Wolf Studio")
+    migrated.add_all([mine, theirs])
+    await migrated.flush()
+
+    web = Channel(workspace_id=mine.id, kind="web", name="Website")
+    phone = Channel(workspace_id=mine.id, kind="phone", name="Main line")
+    other = Channel(workspace_id=theirs.id, kind="web", name="Website")
+    migrated.add_all([web, phone, other])
+    await migrated.flush()
+
+    await _thread(
+        migrated,
+        mine,
+        web,
+        [
+            ("caller", "Good morning, I would like to move my appointment."),
+            ("agent", "Thursday at ten is free, shall I move you to that?"),
+            ("caller", "Perfect, Thursday works. Thank you."),
+        ],
+        external_id="web-1",
+    )
+    await _thread(
+        migrated,
+        mine,
+        phone,
+        [
+            ("caller", "I am calling about a refund for the invoice."),
+            ("agent", "I will pass that to a colleague."),
+        ],
+        external_id="+4366412345678",
+        status="closed",
+        call=True,
+    )
+    # The other workspace says the same word, which is what makes the isolation test
+    # mean something: a leak would be invisible if only one side ever said it.
+    await _thread(migrated, theirs, other, [("caller", "A refund, please.")])
+
+    password_hash = hash_password(PASSWORD)
+    people = [("sabine", mine, "viewer"), ("wolf", theirs, "owner")]
+    for username, workspace, role in people:
+        user = User(username=username, password_hash=password_hash)
+        migrated.add(user)
+        await migrated.flush()
+        migrated.add(Membership(user_id=user.id, workspace_id=workspace.id, role=role))
+    await migrated.commit()
+
+    app = create_app(settings.model_copy(update={"database_url": database_url}))
+    clients: dict[str, AsyncClient] = {}
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        for username, _, _ in people:
+            http = AsyncClient(transport=transport, base_url="http://localhost")
+            assert (
+                await http.post(
+                    "/api/auth/login", json={"username": username, "password": PASSWORD}
+                )
+            ).status_code == 200
+            clients[username] = http
+        try:
+            yield clients
+        finally:
+            for http in clients.values():
+                await http.aclose()
+
+
+# --- The list ------------------------------------------------------------------
+
+
+async def test_a_viewer_reads_the_threads(stage) -> None:
+    """ "Reads calls. Changes nothing" - the role matrix's own words for a viewer."""
+    response = await stage["sabine"].get("/api/conversations")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["threads"]) == 2
+    assert body["has_more"] is False
+
+
+async def test_each_thread_carries_its_last_line(stage) -> None:
+    """The preview is the list's whole content, and it comes from one query for all
+    of them rather than one per row."""
+    body = (await stage["sabine"].get("/api/conversations")).json()
+
+    previews = {t["preview"] for t in body["threads"]}
+    assert "Perfect, Thursday works. Thank you." in previews
+    assert any(t["message_count"] == 3 for t in body["threads"])
+
+
+async def test_a_call_is_marked_as_one(stage) -> None:
+    body = (await stage["sabine"].get("/api/conversations")).json()
+
+    calls = [t for t in body["threads"] if t["is_call"]]
+    assert len(calls) == 1
+    assert calls[0]["channel"] == "phone"
+
+
+async def test_filtering_by_channel(stage) -> None:
+    body = (await stage["sabine"].get("/api/conversations?channel=phone")).json()
+
+    assert [t["channel"] for t in body["threads"]] == ["phone"]
+
+
+async def test_filtering_by_status(stage) -> None:
+    body = (await stage["sabine"].get("/api/conversations?status=closed")).json()
+
+    assert [t["status"] for t in body["threads"]] == ["closed"]
+
+
+async def test_an_unknown_status_is_refused(stage) -> None:
+    assert (await stage["sabine"].get("/api/conversations?status=whenever")).status_code == 422
+
+
+# --- Search, which is the query written twice ----------------------------------
+
+
+async def test_search_finds_the_thread_by_what_was_said_in_it(stage) -> None:
+    """Runs through the full-text index that has existed, unused, since the first
+    migration - a GIN index on PostgreSQL, an FTS5 table on SQLite."""
+    body = (await stage["sabine"].get("/api/conversations?q=refund")).json()
+
+    assert len(body["threads"]) == 1
+    assert body["threads"][0]["channel"] == "phone"
+
+
+async def test_search_matches_nothing_when_nothing_was_said(stage) -> None:
+    body = (await stage["sabine"].get("/api/conversations?q=helicopter")).json()
+
+    assert body["threads"] == []
+
+
+async def test_search_never_reaches_another_workspace(stage) -> None:
+    """The other workspace says "refund" too. If the subquery over `messages` were
+    unscoped, this is where its transcripts would surface - which is exactly the leak
+    D-028 puts `workspace_id` on `messages` to prevent."""
+    mine = (await stage["sabine"].get("/api/conversations?q=refund")).json()
+    theirs = (await stage["wolf"].get("/api/conversations?q=refund")).json()
+
+    assert len(mine["threads"]) == 1
+    assert len(theirs["threads"]) == 1
+    assert mine["threads"][0]["id"] != theirs["threads"][0]["id"]
+
+
+async def test_a_search_for_punctuation_does_not_raise(stage) -> None:
+    """A search box takes whatever somebody types.
+
+    Both dialects have a query language, and both raise on some inputs a person can
+    reasonably type - a bare quote on SQLite's FTS5, a stray operator on PostgreSQL.
+    Whatever this endpoint does with them, it must not be a 500.
+    """
+    for typed in ('"', "AND", "-", "a OR", "*", "café"):
+        response = await stage["sabine"].get("/api/conversations", params={"q": typed})
+        assert response.status_code in (200, 422), f"{typed!r} gave {response.status_code}"
+
+
+# --- One thread ----------------------------------------------------------------
+
+
+async def test_reading_one_thread_returns_its_lines_in_order(stage) -> None:
+    listing = (await stage["sabine"].get("/api/conversations")).json()
+    thread_id = next(t["id"] for t in listing["threads"] if t["message_count"] == 3)
+
+    body = (await stage["sabine"].get(f"/api/conversations/{thread_id}")).json()
+
+    assert [m["ts_ms"] for m in body["messages"]] == [0, 1000, 2000]
+    assert body["messages"][0]["speaker"] == "caller"
+
+
+async def test_the_recording_path_never_leaves_the_server(stage) -> None:
+    """A filesystem path is the layout of somebody's disk. The screen needs to know
+    that audio exists, which is a boolean."""
+    listing = (await stage["sabine"].get("/api/conversations")).json()
+    call_id = next(t["id"] for t in listing["threads"] if t["is_call"])
+
+    response = await stage["sabine"].get(f"/api/conversations/{call_id}")
+
+    assert response.status_code == 200
+    assert "secret-path.wav" not in response.text
+    assert "recording_path" not in response.text
+    assert response.json()["call"]["has_recording"] is True
+    assert response.json()["call"]["billable_seconds"] == 158
+
+
+async def test_another_workspaces_thread_is_indistinguishable_from_a_missing_one(
+    stage,
+) -> None:
+    """404, not 403. A 403 would confirm the row exists, which is the answer being
+    withheld."""
+    theirs = (await stage["wolf"].get("/api/conversations")).json()
+    foreign_id = theirs["threads"][0]["id"]
+
+    response = await stage["sabine"].get(f"/api/conversations/{foreign_id}")
+
+    assert response.status_code == 404
+
+
+async def test_signed_out_reads_nothing(stage) -> None:
+    stage["sabine"].cookies.clear()
+
+    assert (await stage["sabine"].get("/api/conversations")).status_code == 401
+
+
+# --- The channel list, and the route order that makes it reachable -------------
+
+
+async def test_the_channel_list_is_built_from_what_exists(stage) -> None:
+    """Chips for channels the workspace has, not for the ten the product commits to.
+    A chip that can only ever return nothing is a chip that teaches people not to
+    click chips."""
+    body = (await stage["sabine"].get("/api/conversations/meta/channels")).json()
+
+    kinds = {c["kind"]: c["thread_count"] for c in body}
+    assert kinds == {"web": 1, "phone": 1}
+
+
+async def test_the_static_path_is_declared_before_the_parameterised_one() -> None:
+    """FastAPI matches in declaration order.
+
+    With `/{conversation_id}` first, `/meta/channels` is read as a conversation whose
+    id is "meta" and answered with a validation error - and the failure is a 422 on a
+    route that looks perfectly correct in isolation.
+    """
+    from api.routes import conversations as module
+
+    # The router carries its prefix, so these are the full paths.
+    paths = [getattr(route, "path", "") for route in module.router.routes]
+    assert paths.index("/api/conversations/meta/channels") < paths.index(
+        "/api/conversations/{conversation_id}"
+    )


### PR DESCRIPTION
> **Depends on #83.** This branch is cut from `main`, which is currently failing `ruff format --check .` on the invites migration. Until #83 lands, this PR's CI shows that same pre-existing failure and nothing of its own.

`messages` has carried a full-text index **since the very first migration** — a GIN index over `to_tsvector('simple', text)` on PostgreSQL, an FTS5 virtual table with three triggers on SQLite. Nothing has ever queried either one. This is what finally does; the index was the same kind of orphan as the four cleanup functions P2 rescued, and an index nothing reads is a write cost with no benefit.

### What lands

Three GETs, all `viewer` — the role matrix's own words are *"Reads calls. Changes nothing, answers nothing"*, and this module is that sentence. The write path arrives with the web chat.

| | |
|---|---|
| `GET /api/conversations` | the threads, newest first, filtered by channel, status, or **what was said in them** |
| `GET /api/conversations/{id}` | one thread with its lines, and the call row if there is one |
| `GET /api/conversations/meta/channels` | what the filter chips should offer |

### Search is the one query written twice

Deliberately, with both spellings side by side. There is no portable spelling of full-text search, and the portable alternative — `LIKE '%word%'` — would use neither index and scan every transcript on the installation.

The PostgreSQL half says `'simple'` exactly as the index does. `to_tsvector(text)` without the configuration argument is a *different expression*: the planner will not match it to the index, and the query silently becomes a sequential scan — fast on a laptop with fifty rows, catastrophic on a year of transcripts.

**Both dialects are given identical behaviour rather than each one's query language.** A bare `"` in the search box was `unterminated string` to FTS5 — a 500 from a search box, found by a test that types what people actually type. Operator characters are discarded and every search is "all of these words", which also stops the same box behaving differently depending on which database an installation happens to run. That is what D-029 is for.

### Three smaller decisions

- **The recording path never leaves the server.** It is a filesystem path on the machine; what a screen needs is whether audio exists, which is a boolean. A test greps the response for the path.
- **Starring and unread stay drawings.** They are on the screen and have no column behind them. A button that does nothing is worse than one that is absent.
- **`/meta/channels` is declared before `/{conversation_id}`**, because FastAPI matches in declaration order — with the parameterised route first, `/meta/channels` is read as a conversation whose id is `"meta"` and answered with a 422 that looks like a bug in the client. A test pins the order.

### Verification

31 tests, green on **SQLite and PostgreSQL** — which is the only way to know the two search spellings actually agree. The isolation test matters most: the other workspace says "refund" too, so a leak would be invisible if only one side ever said the word.