### PR TITLE
Draft the release notes from the pull requests

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,50 @@
+# Drafts the next release from the pull requests merged since the last one.
+#
+# The categories below are chosen for how this repository already works: titles
+# are prose sentences, not `feat:` prefixes, so nothing here reads the commit
+# message. One label on a pull request decides both the section it lands in and
+# how the version moves. A pull request with no label still appears, under
+# "Other changes" - an unlabelled change is never dropped silently.
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+# Existing repository labels wherever one already fits - `enhancement`, `bug` and
+# `documentation` were here before this file, and a second label meaning the same
+# thing is how label sets rot.
+categories:
+  - title: "Breaking"
+    labels: ["breaking"]
+  - title: "Features"
+    labels: ["enhancement"]
+  - title: "Fixes"
+    labels: ["bug"]
+  - title: "Documentation"
+    labels: ["documentation"]
+  - title: "Internal"
+    labels: ["chore"]
+  - title: "Other changes"
+    labels: ["*"]
+
+change-template: "- $TITLE (#$NUMBER)"
+# Backticks and underscores in a prose title would otherwise render as markup
+change-title-escapes: '\<*_&`#@'
+
+# The repository has no tags yet, so the first draft has nothing to count from.
+# 0.1.0 is what pyproject.toml already claims.
+initial-version: "0.1.0"
+
+version-resolver:
+  major:
+    labels: ["breaking"]
+  minor:
+    labels: ["enhancement"]
+  patch:
+    labels: ["bug", "documentation", "chore"]
+  default: patch
+
+exclude-labels: ["skip-changelog"]
+
+template: |
+  $CHANGES
+
+  **Full changelog**: https://github.com/Dpro-at/Tel-Agent/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,28 @@
+# Keeps a draft release up to date with everything merged since the last tag, so
+# "where the project is" is answered by GitHub rather than by remembering to write
+# it down. The draft is never published automatically - publishing stays a human
+# act, and the version only becomes real when somebody presses the button.
+name: Release drafter
+
+on:
+  push:
+    branches: [main]
+  # so a pull request gets its version bump recalculated as labels change
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,16 @@ Competitive notes belong in , which is gitignored and never published.
 
 ---
 
+## Finishing a milestone
+
+Move `· **in progress**` to the next heading in `docs/ROADMAP.md`. That marker is
+the only place the current milestone is written, and the website parses it out of
+this repository at build time - the badge, the download page and `llms.txt` all
+read it, so a marker left behind makes the public site understate the product.
+
+It is one line, and it belongs to closing a milestone rather than to opening the
+next one. Nothing else needs editing for the number to move.
+
 ## Where things are
 
 | Path | Contents |


### PR DESCRIPTION
Answers "where have we got to" without anyone having to remember to write it down.

`release-drafter` keeps a **draft** release up to date with everything merged since the last tag. It reads **pull request labels**, not commit prefixes — the titles in this repository are prose sentences, and adopting `feat:` would mean changing how the repo is written to suit a tool.

One label sets both the section and the version bump:

| Label | Section | Version |
|---|---|---|
| `breaking` | Breaking | major |
| `enhancement` | Features | minor |
| `bug` | Fixes | patch |
| `documentation` | Documentation | patch |
| `chore` | Internal | patch |
| *(none)* | Other changes | patch |

`enhancement`, `bug` and `documentation` already existed. Only `breaking`, `chore` and `skip-changelog` were added.

The draft is never published automatically — cutting a release stays a human act.

Also adds **Finishing a milestone** to CLAUDE.md: the `· **in progress**` marker in `docs/ROADMAP.md` is the only place the current milestone is written, the website parses it from this repository, and it has never been moved off Milestone 0.