### PR TITLE
Ask Google about the visitor, and know when not to trust the answer

### DIFF
--- a/api/routes/public_chat.py
+++ b/api/routes/public_chat.py
@@ -30,7 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession as DbSession
 
 from api.errors import envelope_response
 from api.models import Channel, Conversation, Message
-from api.security import quota
+from api.security import captcha, quota
 from api.security.embed import check_origin, normalise_origin
 
 logger = logging.getLogger("api.public_chat")
@@ -48,6 +48,9 @@ class VisitorMessage(BaseModel):
     # starting again. Unguessable, and checked against the channel below - it is the
     # only handle the widget has on anything.
     conversation: str | None = Field(default=None, max_length=64)
+    # reCAPTCHA v3's token, when the channel has it switched on. Long: Google's are
+    # already several hundred characters and the length is theirs to change.
+    captcha: str | None = Field(default=None, max_length=4000)
 
 
 class Accepted(BaseModel):
@@ -155,6 +158,24 @@ async def post_message(
         )
         await db.commit()
         return _too_many()
+
+    # After the origin check and the ceiling, because it is the only one of the three
+    # that leaves this machine. A request that fails either of the cheap local checks
+    # must not also cost a round trip to Google.
+    verdict = await captcha.verify(
+        channel.credentials_encrypted,
+        payload.captcha,
+        threshold=settings.get("recaptcha_threshold"),
+    )
+    if not verdict.ok:
+        logger.info(
+            "web chat refused",
+            extra={"reason": f"captcha: {verdict.reason}", "channel_id": channel.id},
+        )
+        await db.commit()
+        # The same answer as a wrong origin. A bot that learns it was the captcha that
+        # refused it is a bot that starts solving the captcha.
+        return _refused()
 
     conversation = None
     if payload.conversation is not None:

--- a/api/security/captcha.py
+++ b/api/security/captcha.py
@@ -1,0 +1,121 @@
+"""reCAPTCHA v3 — §B14's third layer, and the first outbound call this product makes.
+
+The origin allowlist stops other sites. The rate limit stops a flood. Neither stops a
+bot running on a page the business allowed, which is the case that costs money: an
+unauthenticated endpoint that reaches a paid model is worth automating against.
+
+**Optional, and that is not a hedge.** A self-hosted product cannot make a third party
+mandatory - reCAPTCHA is Google's, and it sees the visitor. An installation that will
+not accept that switches it off and keeps the other two layers, which is a decision the
+operator makes rather than a gap we left.
+
+**"We could not ask" and "we asked and it said no" are different answers**, and this is
+the whole of the design here. A network failure means Google was unreachable - common
+on a machine behind a firewall that was never opened - and refusing every visitor
+because of it would take a business's chat offline for a reason that has nothing to do
+with the visitor. That case allows and logs loudly. A verified low score is Google
+answering, and that refuses.
+
+The secret never reaches a log, an error message, or a response. It is read from an
+encrypted column and used once.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger("api.captcha")
+
+VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify"
+
+# A visitor is waiting on this. Two seconds is long enough for a healthy round trip and
+# short enough that an unreachable Google costs the visitor a pause rather than the
+# request. There is no retry: a second attempt doubles the wait and, on an endpoint
+# somebody is flooding, doubles the outbound traffic too.
+TIMEOUT = httpx.Timeout(2.0)
+
+# Google's default. Below it is "probably automated", not "certainly", and the failure
+# mode of a higher one is refusing real customers - which is why it is configurable per
+# channel and why this is where it starts.
+DEFAULT_THRESHOLD = 0.5
+
+# The action name the widget sends with its token. Checked because a token is issued
+# for one action on one page: without this, a token minted on a public sign-up form of
+# the same site would pass here.
+ACTION = "web_chat_message"
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """What came back, in the two shapes the caller acts on."""
+
+    ok: bool
+    # Why it was refused, for the log. Never returned to the caller - a bot learning
+    # which check it failed is a bot that stops failing it.
+    reason: str = ""
+    score: float | None = None
+
+
+ALLOWED = Verdict(ok=True)
+
+
+async def verify(
+    secret: str | None, token: str | None, *, threshold: float | None = None
+) -> Verdict:
+    """Ask Google about one token.
+
+    `secret` is None when the channel has no reCAPTCHA configured, and then this does
+    nothing at all - not even a request. That is the switched-off case, and it must be
+    free rather than merely permissive.
+    """
+    if not secret:
+        return ALLOWED
+
+    if not token:
+        # Configured but nothing sent. Either the widget failed to load Google's script
+        # or the caller is not the widget; both are refused, because the point of
+        # turning this on is that a message without a token does not pass.
+        return Verdict(ok=False, reason="no captcha token")
+
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+            response = await client.post(VERIFY_URL, data={"secret": secret, "response": token})
+            response.raise_for_status()
+            body = response.json()
+    except (httpx.HTTPError, ValueError) as thrown:
+        # Could not ask. Allowed, and loud: an installation whose firewall blocks
+        # Google is one where this layer is silently absent, and the operator should
+        # find that out from their own log rather than from a bill.
+        #
+        # `thrown` is logged by type and message; it cannot carry the secret, which is
+        # in the request body and never in an httpx exception's text.
+        logger.warning(
+            "captcha could not be verified, allowing",
+            extra={"error": type(thrown).__name__, "detail": str(thrown)[:200]},
+        )
+        return ALLOWED
+
+    if not body.get("success"):
+        # Google answered. `error-codes` says why - an expired token, a duplicate, a
+        # secret that does not match the site key.
+        codes = body.get("error-codes") or []
+        return Verdict(ok=False, reason=f"rejected: {','.join(str(code) for code in codes)}")
+
+    action = body.get("action")
+    if action != ACTION:
+        return Verdict(ok=False, reason=f"token was minted for {action!r}, not {ACTION!r}")
+
+    score = body.get("score")
+    if not isinstance(score, int | float):
+        # A success without a score is v2's shape, which means the key pair is v2 and
+        # the threshold below would compare against nothing.
+        return Verdict(ok=False, reason="no score in the answer - is this a v3 key?")
+
+    limit = DEFAULT_THRESHOLD if threshold is None else threshold
+    if score < limit:
+        return Verdict(ok=False, reason=f"score {score} below {limit}", score=float(score))
+
+    return Verdict(ok=True, score=float(score))

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1184,6 +1184,23 @@ Its limits, stated so nobody treats it as the wall:
 - With it off, the rate limit below is the only thing left, and that is a deliberate
   choice the operator makes rather than a gap.
 
+**"Could not ask" and "asked and was told no" are different answers.** A network failure
+means Google was unreachable, which on a self-hosted box behind a firewall that nobody
+opened is ordinary - and taking a business's chat offline for it would be a refusal
+caused by nothing the visitor did. That case **allows**, and logs at warning so the
+operator finds out from their own log rather than from a bill. A verified low score is
+Google answering, and that refuses. Getting the two the wrong way round is the failure
+worth naming: one unplugs the guard with a cable, the other closes the shop.
+
+**The token carries an action name, and it is checked.** reCAPTCHA issues a token for
+one action; without the check, a token minted by the same site's sign-up form would pass
+here. A `success` with no `score` is v2's answer shape, and is refused rather than
+compared against a threshold it does not have.
+
+**The three checks run cheapest first**: origin, then the rate limit, then this. A
+request that fails either local check must not also cost a round trip to somebody
+else's network.
+
 ### Rate limits, which are not optional
 
 Per conversation and per origin, enforced whether or not reCAPTCHA is on. A public

--- a/tests/test_captcha.py
+++ b/tests/test_captcha.py
@@ -1,0 +1,150 @@
+"""reCAPTCHA, and the distinction the whole design turns on.
+
+"We could not ask" allows; "we asked and it said no" refuses. Getting that backwards
+either takes a business's chat offline because a firewall blocks Google, or lets every
+bot through by unplugging a cable - so both directions are tested, not just the happy
+one.
+
+Nothing here reaches the network. `httpx.MockTransport` answers as Google would.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from api.security import captcha
+
+SECRET = "a-real-looking-secret"  # noqa: S105
+TOKEN = "a-token-from-the-widget"  # noqa: S105
+
+
+def _answers(body: dict | None = None, *, status: int = 200, raises: Exception | None = None):
+    """Patch the client so `verify` talks to this instead of Google."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if raises is not None:
+            raise raises
+        return httpx.Response(status, json=body or {})
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture
+def google(monkeypatch):
+    """Hand `verify` a transport, and record what it sent."""
+    sent: list[httpx.Request] = []
+
+    def install(body=None, *, status=200, raises=None):
+        transport = _answers(body, status=status, raises=raises)
+
+        def recording(request: httpx.Request) -> httpx.Response:
+            sent.append(request)
+            return transport.handler(request)
+
+        original = httpx.AsyncClient
+
+        def factory(*args, **kwargs):
+            kwargs["transport"] = httpx.MockTransport(recording)
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(captcha.httpx, "AsyncClient", factory)
+        return sent
+
+    return install
+
+
+async def test_no_secret_means_no_request_at_all(google) -> None:
+    """Switched off must be free, not merely permissive."""
+    sent = google({"success": True, "score": 0.9, "action": captcha.ACTION})
+    assert (await captcha.verify(None, TOKEN)).ok is True
+    assert sent == []
+
+
+async def test_a_good_score_passes(google) -> None:
+    google({"success": True, "score": 0.9, "action": captcha.ACTION})
+    verdict = await captcha.verify(SECRET, TOKEN)
+    assert verdict.ok is True
+    assert verdict.score == 0.9
+
+
+async def test_a_low_score_is_refused(google) -> None:
+    google({"success": True, "score": 0.1, "action": captcha.ACTION})
+    verdict = await captcha.verify(SECRET, TOKEN)
+    assert verdict.ok is False
+    assert "below" in verdict.reason
+
+
+async def test_the_threshold_is_per_channel(google) -> None:
+    google({"success": True, "score": 0.6, "action": captcha.ACTION})
+    # Passes the default, refused by a business that wants to be stricter.
+    assert (await captcha.verify(SECRET, TOKEN)).ok is True
+    assert (await captcha.verify(SECRET, TOKEN, threshold=0.8)).ok is False
+
+
+async def test_a_token_minted_for_another_action_is_refused(google) -> None:
+    """A token is issued per action. Without this check, one from the same site's
+    sign-up form would pass here."""
+    google({"success": True, "score": 0.9, "action": "signup"})
+    verdict = await captcha.verify(SECRET, TOKEN)
+    assert verdict.ok is False
+    assert "signup" in verdict.reason
+
+
+async def test_google_saying_no_is_refused(google) -> None:
+    google({"success": False, "error-codes": ["timeout-or-duplicate"]})
+    verdict = await captcha.verify(SECRET, TOKEN)
+    assert verdict.ok is False
+    assert "timeout-or-duplicate" in verdict.reason
+
+
+async def test_a_v2_key_pair_is_refused_rather_than_silently_passing(google) -> None:
+    """v2 answers without a score, so the threshold would compare against nothing."""
+    google({"success": True, "action": captcha.ACTION})
+    verdict = await captcha.verify(SECRET, TOKEN)
+    assert verdict.ok is False
+    assert "v3" in verdict.reason
+
+
+async def test_a_missing_token_is_refused_when_it_is_switched_on(google) -> None:
+    sent = google({"success": True, "score": 0.9, "action": captcha.ACTION})
+    verdict = await captcha.verify(SECRET, None)
+    assert verdict.ok is False
+    # Refused without asking: there is nothing to ask about.
+    assert sent == []
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        httpx.ConnectError("no route to host"),
+        httpx.ReadTimeout("too slow"),
+    ],
+)
+async def test_being_unable_to_ask_allows(google, failure) -> None:
+    """The half that would take a business offline if it were the other way round.
+
+    A firewall that never opened outbound HTTPS is common on a self-hosted box, and
+    refusing every visitor for it would be a chat that stops working for a reason
+    nothing about the visitor caused.
+    """
+    google(raises=failure)
+    assert (await captcha.verify(SECRET, TOKEN)).ok is True
+
+
+async def test_a_broken_answer_allows_rather_than_refusing(google) -> None:
+    """A 500 from Google, or HTML from a captive portal. Still 'could not ask'."""
+    google({"success": True}, status=500)
+    assert (await captcha.verify(SECRET, TOKEN)).ok is True
+
+
+async def test_the_secret_is_sent_and_never_logged(google, caplog) -> None:
+    sent = google(raises=httpx.ConnectError("no route to host"))
+    with caplog.at_level("WARNING"):
+        await captcha.verify(SECRET, TOKEN)
+
+    # It goes to Google in the body, which is the only place it belongs...
+    assert sent, "no request was made"
+    assert SECRET in sent[0].content.decode()
+    # ...and nowhere near the log line that says the call failed.
+    assert SECRET not in caplog.text

--- a/tests/test_public_chat.py
+++ b/tests/test_public_chat.py
@@ -17,6 +17,25 @@ from api.main import create_app
 from api.models import Channel, Conversation, Message, Workspace
 
 ALLOWED = "https://shop.test"
+KEY_HEX = "aa" * 32
+
+
+@pytest.fixture(autouse=True)
+def configured_key(monkeypatch: pytest.MonkeyPatch):
+    """The reCAPTCHA secret lives in an encrypted column, so a key is not optional.
+
+    Autouse: the tests that do not touch it are unaffected, and a test that forgot it
+    would fail inside an INSERT whose parameter dump carries the value.
+    """
+    from api.config import get_settings
+    from api.models.encrypted import reset_key_cache
+
+    monkeypatch.setenv("ENCRYPTION_KEY", KEY_HEX)
+    get_settings.cache_clear()
+    reset_key_cache()
+    yield
+    get_settings.cache_clear()
+    reset_key_cache()
 
 
 @pytest.fixture
@@ -322,3 +341,146 @@ async def test_a_refused_origin_never_reaches_the_counter(stage) -> None:
 
     db.expire_all()
     assert (await db.execute(select(RateCounter))).scalars().all() == []
+
+
+# --- reCAPTCHA, through the endpoint -----------------------------------------
+
+
+async def _with_captcha(db, path: str, *, threshold: float | None = None) -> None:
+    """Switch reCAPTCHA on for a channel, as the settings screen would."""
+    from api.models import Channel
+
+    row = await db.scalar(select(Channel).where(Channel.webhook_path == path))
+    assert row is not None
+    row.credentials_encrypted = "the-channel-secret"
+    settings = dict(row.settings_json or {})
+    if threshold is not None:
+        settings["recaptcha_threshold"] = threshold
+    row.settings_json = settings
+    await db.commit()
+
+
+def _google(monkeypatch, body: dict) -> None:
+    import httpx
+
+    from api.security import captcha
+
+    original = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(lambda _: httpx.Response(200, json=body))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(captcha.httpx, "AsyncClient", factory)
+
+
+async def test_a_good_token_gets_through(stage, monkeypatch) -> None:
+    from api.security import captcha
+
+    http, paths, db = stage
+    await _with_captcha(db, paths["ours"])
+    _google(monkeypatch, {"success": True, "score": 0.9, "action": captcha.ACTION})
+
+    answer = await http.post(
+        f"/public/chat/{paths['ours']}/messages",
+        json={"text": "hello", "captcha": "a-token"},
+        headers={"Origin": ALLOWED},
+    )
+    assert answer.status_code == 201
+
+
+async def test_a_low_score_is_refused_like_a_wrong_origin(stage, monkeypatch) -> None:
+    """Same status, same code, same sentence.
+
+    A bot that learns it was the captcha that refused it is a bot that starts solving
+    the captcha instead of going away.
+    """
+    from api.security import captcha
+
+    http, paths, db = stage
+    await _with_captcha(db, paths["ours"])
+    _google(monkeypatch, {"success": True, "score": 0.1, "action": captcha.ACTION})
+
+    answer = await http.post(
+        f"/public/chat/{paths['ours']}/messages",
+        json={"text": "hello", "captcha": "a-token"},
+        headers={"Origin": ALLOWED},
+    )
+    assert answer.status_code == 403
+    assert answer.json()["error"]["code"] == "origin_not_allowed"
+
+    db.expire_all()
+    assert await _count(db, Message) == 0
+
+
+async def test_no_token_is_refused_once_it_is_switched_on(stage, monkeypatch) -> None:
+    from api.security import captcha
+
+    http, paths, db = stage
+    await _with_captcha(db, paths["ours"])
+    _google(monkeypatch, {"success": True, "score": 0.9, "action": captcha.ACTION})
+
+    answer = await http.post(
+        f"/public/chat/{paths['ours']}/messages",
+        json={"text": "hello"},
+        headers={"Origin": ALLOWED},
+    )
+    assert answer.status_code == 403
+    assert await _count(db, Message) == 0
+
+
+async def test_a_channel_without_it_never_calls_google(stage, monkeypatch) -> None:
+    """The switched-off case, which is most installations."""
+    called: list[bool] = []
+
+    import httpx
+
+    from api.security import captcha
+
+    original = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        called.append(True)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(captcha.httpx, "AsyncClient", factory)
+
+    http, paths, _ = stage
+    answer = await http.post(
+        f"/public/chat/{paths['ours']}/messages",
+        json={"text": "hello"},
+        headers={"Origin": ALLOWED},
+    )
+    assert answer.status_code == 201
+    assert called == []
+
+
+async def test_a_refused_origin_never_costs_a_call_to_google(stage, monkeypatch) -> None:
+    """The order of the three checks, made visible.
+
+    The two cheap local ones run first, so a request from a page that was never allowed
+    does not also buy a round trip on somebody else's network.
+    """
+    called: list[bool] = []
+
+    import httpx
+
+    from api.security import captcha
+
+    http, paths, db = stage
+    await _with_captcha(db, paths["ours"])
+    original = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        called.append(True)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(captcha.httpx, "AsyncClient", factory)
+
+    answer = await http.post(
+        f"/public/chat/{paths['ours']}/messages",
+        json={"text": "hello", "captcha": "a-token"},
+        headers={"Origin": "https://evil.test"},
+    )
+    assert answer.status_code == 403
+    assert called == []


### PR DESCRIPTION
§B14's third layer, and the **first outbound call this product makes**.

The origin allowlist stops other sites. The rate limit stops a flood. Neither stops a bot running on a page the business allowed — the case that costs money, because an unauthenticated endpoint reaching a paid model is worth automating against.

## The distinction it turns on

**"We could not ask" and "we asked and were told no" are different answers.**

| | |
|---|---|
| Network failure, timeout, a 500, HTML from a captive portal | **allow**, and log at warning |
| `success: false`, or a score below the threshold | **refuse** |

A firewall that never opened outbound HTTPS is ordinary on a self-hosted box. Taking a business's chat offline for it would be a refusal caused by nothing the visitor did — the operator should learn it from their own log rather than from a bill. Getting the two the wrong way round either unplugs the guard with a cable or closes the shop, so **both directions are tested**.

## Other decisions

- **Optional, and not a hedge.** reCAPTCHA is Google's and it sees the visitor; a self-hosted product cannot make a third party mandatory. Switched off it costs **nothing — not even a request**, and a test asserts no client is constructed.
- **The action name is checked.** A token is issued per action, so without it one minted by the same site's sign-up form would pass here.
- **A `success` with no `score` is refused** rather than compared against a threshold it does not have — that is a v2 key pair, and silently passing would be worse than saying so.
- **Refused the same way a wrong origin is** — same status, same code, same sentence. A bot that learns the captcha refused it is a bot that starts solving the captcha.
- **Cheapest first, and a test holds the order.** A request from a page that was never allowed does not also buy a round trip on somebody else's network.
- **Two seconds, no retry.** A visitor is waiting, and a retry on an endpoint somebody is flooding doubles the outbound traffic as well as the wait.
- **The secret** goes to Google in the request body and nowhere else. A test asserts it is absent from the log line that reports the call failing.

## Verification

- 17 new tests; **538 pass**, no regressions. `ruff` and `ruff format` clean
- Nothing reaches the network: `httpx.MockTransport` answers as Google would, including the failure shapes

§B14 gains the paragraphs this build produced — the two-answers rule, the action check, and the cheapest-first ordering.