### PR TITLE
Let somebody switch the widget on without opening a database

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -53,6 +53,7 @@ from api.routes import recovery as recovery_routes
 from api.routes import rules as rule_routes
 from api.routes import settings as settings_routes
 from api.routes import system as system_routes
+from api.routes import web_channel as web_channel_routes
 from api.routes import webhooks as webhook_routes
 from api.routes import workspaces as workspace_routes
 
@@ -278,6 +279,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(assistant_routes.router)
     app.include_router(knowledge_routes.router)
     app.include_router(public_chat_routes.router)
+    app.include_router(web_channel_routes.router)
     app.include_router(webhook_routes.router)
     app.include_router(rule_routes.router)
     app.include_router(contact_routes.router)

--- a/api/models/audit.py
+++ b/api/models/audit.py
@@ -78,6 +78,10 @@ EVENTS = (
     "webhook_added",
     "webhook_changed",
     "webhook_removed",
+    # The web chat channel. Which sites may embed it and whether it is on decide who
+    # can reach the agent at all, and its reCAPTCHA secret is a credential - so a
+    # change needs a name attached afterwards.
+    "web_channel_changed",
 )
 
 

--- a/api/routes/web_channel.py
+++ b/api/routes/web_channel.py
@@ -1,0 +1,236 @@
+"""The web chat channel's settings — §A6.8's Channels tab, for the one channel that exists.
+
+Until this, the guards in §B14 could only be configured with SQL. A guard nobody can
+switch on is a guard that is off, so this is not decoration on the endpoint that landed
+before it - it is the half that makes it usable.
+
+**One web channel per workspace.** §B13 gives each channel its own card and its own
+credentials; a second web chat on the same workspace would mean two addresses answering
+for one business with two allowlists to keep in step. Adding a second is a decision to
+reopen this, not a POST.
+
+**The address is generated here and never chosen.** It is `channels.webhook_path`, the
+same column the widget's endpoint looks up, and the same shape §B14 describes: long,
+random, unique. A chosen one would be guessable, and the allowlist is what protects it
+either way - but a guessable address invites the attempt.
+
+**The secret is masked on read and mask-echo is ignored on write**, exactly as the
+settings store does it. A screen that renders `••••3ab1` and saves the form must not
+save the bullets over the live credential.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import Annotated
+
+from fastapi import APIRouter, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession as DbSession
+
+from api.dependencies import CurrentUser
+from api.errors import envelope_response
+from api.models import Channel
+from api.security import audit
+from api.security.captcha import DEFAULT_THRESHOLD
+from api.security.crypto import key_available, mask
+from api.security.embed import normalise_origin
+from api.security.permissions import WorkspaceContext, require_admin, require_viewer
+
+logger = logging.getLogger("api.web_channel")
+
+router = APIRouter(prefix="/api/channels/web", tags=["web chat"])
+
+# What a masked value starts with, per `api/routes/settings.py`. Asked as "does it
+# begin with bullets" rather than "is it all bullets": the mask keeps the last four
+# characters, so the second question never matches and the mask gets saved.
+_MASK_PREFIX_CHARACTERS = "•*"
+
+# Enough origins for a business with a few domains, and few enough that the list stays
+# something a person reads rather than a list they manage.
+MAX_ORIGINS = 20
+
+
+class WebChannelOut(BaseModel):
+    enabled: bool
+    # The origins allowed to embed the widget. Empty means the channel refuses
+    # everything - see §B14; it is not the same as "not restricted".
+    allowed_origins: list[str]
+    recaptcha_site_key: str | None
+    recaptcha_threshold: float
+    # Masked, or null when none is stored. Never the secret.
+    recaptcha_secret_preview: str | None
+    # The address in the embed tag. Public by design: it travels in the customer's HTML.
+    embed_path: str
+    embed_snippet: str
+
+
+def _snippet(request: Request, path: str) -> str:
+    """The line the customer pastes, built against the address they will actually use.
+
+    Composed from the request's own base URL rather than a configured one: an
+    installation reached at `telagent.wagner-partner.local` must be told to paste that,
+    and a hard-coded hostname is how a snippet ends up pointing at the developer's
+    machine.
+    """
+    base = str(request.base_url).rstrip("/")
+    return f'<script src="{base}/embed.js" data-tel-agent="{path}" defer></script>'
+
+
+def _out(request: Request, row: Channel) -> WebChannelOut:
+    settings = row.settings_json or {}
+    return WebChannelOut(
+        enabled=row.status == "active",
+        allowed_origins=list(settings.get("allowed_origins") or []),
+        recaptcha_site_key=settings.get("recaptcha_site_key"),
+        recaptcha_threshold=float(settings.get("recaptcha_threshold") or DEFAULT_THRESHOLD),
+        recaptcha_secret_preview=mask(row.credentials_encrypted)
+        if row.credentials_encrypted
+        else None,
+        embed_path=row.webhook_path or "",
+        embed_snippet=_snippet(request, row.webhook_path or ""),
+    )
+
+
+async def _find(db: DbSession, workspace_id: int) -> Channel | None:
+    return await db.scalar(
+        select(Channel).where(Channel.workspace_id == workspace_id, Channel.kind == "web")
+    )
+
+
+async def _ensure(db: DbSession, workspace_id: int) -> Channel:
+    """The workspace's web channel, created on first read rather than by a POST.
+
+    There is exactly one, so asking the customer to create it would be asking them to
+    agree to something that has no alternative.
+    """
+    row = await _find(db, workspace_id)
+    if row is not None:
+        if not row.webhook_path:
+            row.webhook_path = _new_path()
+        return row
+
+    row = Channel(
+        workspace_id=workspace_id,
+        kind="web",
+        name="Web chat",
+        webhook_path=_new_path(),
+        settings_json={},
+        # Off until somebody has said which pages may embed it. On-by-default with an
+        # empty allowlist would refuse everything anyway, and would read as broken
+        # rather than as unconfigured.
+        status="disabled",
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+def _new_path() -> str:
+    """Long, random, unique. §B14 calls it an address rather than a secret."""
+    return secrets.token_urlsafe(24)
+
+
+@router.get("", response_model=WebChannelOut, summary="The web chat channel's settings")
+async def read_settings(
+    request: Request, context: Annotated[WorkspaceContext, require_viewer]
+) -> WebChannelOut:
+    db: DbSession = request.state.db
+    row = await _ensure(db, context.id)
+    await db.commit()
+    await db.refresh(row)
+    return _out(request, row)
+
+
+class WebChannelIn(BaseModel):
+    enabled: bool | None = None
+    allowed_origins: list[str] | None = Field(default=None, max_length=MAX_ORIGINS)
+    recaptcha_site_key: str | None = Field(default=None, max_length=255)
+    # Write-only. Sent as null to leave it alone, as "" to remove it, and never read
+    # back - the response carries a mask instead.
+    recaptcha_secret: str | None = Field(default=None, max_length=255)
+    recaptcha_threshold: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+@router.put("", response_model=WebChannelOut, summary="Configure the web chat channel")
+async def write_settings(
+    request: Request,
+    context: Annotated[WorkspaceContext, require_admin],
+    user: CurrentUser,
+    payload: WebChannelIn,
+) -> object:
+    db: DbSession = request.state.db
+    row = await _ensure(db, context.id)
+    sent = payload.model_dump(exclude_unset=True)
+    settings = dict(row.settings_json or {})
+
+    if "allowed_origins" in sent:
+        cleaned: list[str] = []
+        for raw in sent["allowed_origins"] or []:
+            origin = normalise_origin(raw)
+            if origin is None:
+                # The same function the guard uses, so what the screen accepts and what
+                # the endpoint compares can never drift apart.
+                return envelope_response(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    code="invalid_origin",
+                    message=f"Not an origin: {raw!r}. Write it as https://example.com, "
+                    "with no path.",
+                )
+            if origin not in cleaned:
+                cleaned.append(origin)
+        settings["allowed_origins"] = cleaned
+
+    if "recaptcha_site_key" in sent:
+        settings["recaptcha_site_key"] = sent["recaptcha_site_key"] or None
+    if "recaptcha_threshold" in sent and sent["recaptcha_threshold"] is not None:
+        settings["recaptcha_threshold"] = sent["recaptcha_threshold"]
+
+    if "recaptcha_secret" in sent:
+        secret = sent["recaptcha_secret"]
+        if secret == "":
+            row.credentials_encrypted = None
+        elif secret and secret[0] in _MASK_PREFIX_CHARACTERS:
+            # The screen sent back what it was shown. Not an edit, and saving it would
+            # replace the live secret with bullets.
+            logger.info("web channel: ignored an echoed mask", extra={"channel_id": row.id})
+        elif secret:
+            if not key_available():
+                return envelope_response(
+                    status_code=status.HTTP_409_CONFLICT,
+                    code="encryption_key_missing",
+                    message="This installation has no ENCRYPTION_KEY, so a reCAPTCHA "
+                    "secret cannot be stored. Set one and restart.",
+                )
+            row.credentials_encrypted = secret
+
+    if "enabled" in sent and sent["enabled"] is not None:
+        if sent["enabled"] and not settings.get("allowed_origins"):
+            # Switching on with nothing allowed would refuse every visitor while the
+            # screen said "on", which reads as a broken product rather than an
+            # unfinished setup.
+            return envelope_response(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                code="no_allowed_origins",
+                message="Add the address of the site that will show the chat before "
+                "switching it on.",
+            )
+        row.status = "active" if sent["enabled"] else "disabled"
+
+    row.settings_json = settings
+    await db.commit()
+    await db.refresh(row)
+
+    await audit.record(
+        db,
+        "web_channel_changed",
+        request=request,
+        user_id=user.id,
+        username=user.username,
+        # The fields, never their values: one of them is a credential and another is
+        # the address the widget answers on.
+        details={"channel_id": row.id, "fields": sorted(sent)},
+    )
+    return _out(request, row)

--- a/tests/test_web_channel.py
+++ b/tests/test_web_channel.py
@@ -1,0 +1,282 @@
+"""Configuring the widget, which until now needed SQL.
+
+The tests that matter are the ones about the two values that are not ordinary settings:
+the allowlist, which is the guard from §B14 and must be validated by the same function
+that enforces it, and the reCAPTCHA secret, which must never come back out.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.config import Settings
+from api.main import create_app
+from api.models import Channel, Membership, User, Workspace
+from api.security.password import hash_password
+
+PASSWORD = "a sentence i can actually remember"  # noqa: S105
+KEY_HEX = "aa" * 32
+
+
+@pytest.fixture(autouse=True)
+def configured_key(monkeypatch: pytest.MonkeyPatch):
+    from api.config import get_settings
+    from api.models.encrypted import reset_key_cache
+
+    monkeypatch.setenv("ENCRYPTION_KEY", KEY_HEX)
+    get_settings.cache_clear()
+    reset_key_cache()
+    yield
+    get_settings.cache_clear()
+    reset_key_cache()
+
+
+@pytest.fixture
+async def stage(migrated: AsyncSession, settings: Settings, database_url: str):
+    mine = Workspace(name="Wagner & Partner")
+    theirs = Workspace(name="Wolf Studio")
+    migrated.add_all([mine, theirs])
+    await migrated.flush()
+
+    password_hash = hash_password(PASSWORD)
+    people = [("mohamed", mine, "admin"), ("lukas", mine, "viewer"), ("wolf", theirs, "owner")]
+    for username, workspace, role in people:
+        user = User(username=username, password_hash=password_hash)
+        migrated.add(user)
+        await migrated.flush()
+        migrated.add(Membership(user_id=user.id, workspace_id=workspace.id, role=role))
+    await migrated.commit()
+
+    app = create_app(settings.model_copy(update={"database_url": database_url}))
+    clients: dict[str, AsyncClient] = {}
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        for username, _, _ in people:
+            http = AsyncClient(transport=transport, base_url="http://localhost")
+            assert (
+                await http.post(
+                    "/api/auth/login", json={"username": username, "password": PASSWORD}
+                )
+            ).status_code == 200
+            clients[username] = http
+        try:
+            yield clients, migrated
+        finally:
+            for http in clients.values():
+                await http.aclose()
+
+
+async def test_the_first_read_creates_it_switched_off(stage) -> None:
+    clients, _ = stage
+    body = (await clients["mohamed"].get("/api/channels/web")).json()
+
+    # Off, with nothing allowed. On-by-default with an empty allowlist would refuse
+    # every visitor while claiming to be on, which reads as broken rather than unset.
+    assert body["enabled"] is False
+    assert body["allowed_origins"] == []
+    assert body["recaptcha_secret_preview"] is None
+    # And it already has its address, so the snippet is copyable before anything else
+    # is decided.
+    assert len(body["embed_path"]) >= 20
+    assert body["embed_path"] in body["embed_snippet"]
+    assert body["embed_snippet"].startswith("<script src=")
+
+
+async def test_the_snippet_points_at_the_installation_being_used(stage) -> None:
+    """A hard-coded host is how a snippet ends up pointing at the developer's machine."""
+    clients, _ = stage
+    body = (await clients["mohamed"].get("/api/channels/web")).json()
+    assert "http://localhost/embed.js" in body["embed_snippet"]
+
+
+async def test_reading_twice_does_not_make_a_second_channel(stage) -> None:
+    clients, db = stage
+    first = (await clients["mohamed"].get("/api/channels/web")).json()
+    second = (await clients["mohamed"].get("/api/channels/web")).json()
+    assert first["embed_path"] == second["embed_path"]
+
+    db.expire_all()
+    rows = (await db.execute(select(Channel).where(Channel.kind == "web"))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_each_workspace_gets_its_own_address(stage) -> None:
+    clients, _ = stage
+    mine = (await clients["mohamed"].get("/api/channels/web")).json()
+    theirs = (await clients["wolf"].get("/api/channels/web")).json()
+    assert mine["embed_path"] != theirs["embed_path"]
+
+
+async def test_origins_are_validated_by_the_function_that_enforces_them(stage) -> None:
+    clients, _ = stage
+    refused = await clients["mohamed"].put(
+        "/api/channels/web", json={"allowed_origins": ["https://shop.test/checkout"]}
+    )
+    assert refused.status_code == 400
+    assert refused.json()["error"]["code"] == "invalid_origin"
+
+
+async def test_origins_are_stored_normalised_and_deduplicated(stage) -> None:
+    clients, _ = stage
+    body = (
+        await clients["mohamed"].put(
+            "/api/channels/web",
+            json={
+                "allowed_origins": [
+                    "https://Shop.test",
+                    "https://shop.test:443",
+                    "http://localhost:3100",
+                ]
+            },
+        )
+    ).json()
+    # The first two are the same origin written twice.
+    assert body["allowed_origins"] == ["https://shop.test", "http://localhost:3100"]
+
+
+async def test_it_cannot_be_switched_on_with_nothing_allowed(stage) -> None:
+    clients, _ = stage
+    refused = await clients["mohamed"].put("/api/channels/web", json={"enabled": True})
+    assert refused.status_code == 400
+    assert refused.json()["error"]["code"] == "no_allowed_origins"
+
+    # With an origin, it goes on.
+    body = (
+        await clients["mohamed"].put(
+            "/api/channels/web",
+            json={"enabled": True, "allowed_origins": ["https://shop.test"]},
+        )
+    ).json()
+    assert body["enabled"] is True
+
+
+async def test_the_secret_goes_in_and_only_a_mask_comes_out(stage) -> None:
+    clients, db = stage
+    body = (
+        await clients["mohamed"].put(
+            "/api/channels/web", json={"recaptcha_secret": "6Lc-the-real-secret-value"}
+        )
+    ).json()
+
+    assert "recaptcha_secret" not in body
+    assert body["recaptcha_secret_preview"].startswith("•")
+    assert body["recaptcha_secret_preview"].endswith("alue")
+
+    # Stored, and readable by the agent that has to use it.
+    db.expire_all()
+    row = await db.scalar(select(Channel).where(Channel.kind == "web"))
+    assert row is not None
+    assert row.credentials_encrypted == "6Lc-the-real-secret-value"
+
+
+async def test_sending_the_mask_back_does_not_overwrite_the_secret(stage) -> None:
+    """The screen renders the mask and saves the form. That must not be an edit."""
+    clients, db = stage
+    await clients["mohamed"].put(
+        "/api/channels/web", json={"recaptcha_secret": "6Lc-the-real-secret-value"}
+    )
+    shown = (await clients["mohamed"].get("/api/channels/web")).json()[
+        "recaptcha_secret_preview"
+    ]
+
+    await clients["mohamed"].put("/api/channels/web", json={"recaptcha_secret": shown})
+
+    db.expire_all()
+    row = await db.scalar(select(Channel).where(Channel.kind == "web"))
+    assert row is not None
+    assert row.credentials_encrypted == "6Lc-the-real-secret-value"
+
+
+async def test_an_empty_string_removes_the_secret(stage) -> None:
+    """Switching reCAPTCHA off has to be possible, and null means 'leave it alone'."""
+    clients, db = stage
+    await clients["mohamed"].put("/api/channels/web", json={"recaptcha_secret": "a-secret"})
+    body = (
+        await clients["mohamed"].put("/api/channels/web", json={"recaptcha_secret": ""})
+    ).json()
+
+    assert body["recaptcha_secret_preview"] is None
+    db.expire_all()
+    row = await db.scalar(select(Channel).where(Channel.kind == "web"))
+    assert row is not None
+    assert row.credentials_encrypted is None
+
+
+async def test_a_partial_write_leaves_the_rest_alone(stage) -> None:
+    clients, _ = stage
+    await clients["mohamed"].put(
+        "/api/channels/web",
+        json={"allowed_origins": ["https://shop.test"], "recaptcha_site_key": "6Lc-site"},
+    )
+    body = (
+        await clients["mohamed"].put("/api/channels/web", json={"recaptcha_threshold": 0.8})
+    ).json()
+
+    assert body["recaptcha_threshold"] == 0.8
+    assert body["allowed_origins"] == ["https://shop.test"]
+    assert body["recaptcha_site_key"] == "6Lc-site"
+
+
+async def test_a_viewer_reads_and_never_writes(stage) -> None:
+    clients, _ = stage
+    assert (await clients["lukas"].get("/api/channels/web")).status_code == 200
+    assert (
+        await clients["lukas"].put("/api/channels/web", json={"allowed_origins": []})
+    ).status_code == 403
+
+
+async def test_without_a_key_the_secret_is_refused_rather_than_exploding(
+    stage, monkeypatch
+) -> None:
+    from api.config import get_settings
+    from api.models.encrypted import reset_key_cache
+
+    clients, _ = stage
+    monkeypatch.delenv("ENCRYPTION_KEY", raising=False)
+    get_settings.cache_clear()
+    reset_key_cache()
+
+    refused = await clients["mohamed"].put(
+        "/api/channels/web", json={"recaptcha_secret": "a-secret"}
+    )
+    assert refused.status_code == 409
+    assert refused.json()["error"]["code"] == "encryption_key_missing"
+
+
+async def test_what_is_configured_here_is_what_the_widget_endpoint_enforces(stage) -> None:
+    """The whole point: this screen and §B14's guard read the same row."""
+    clients, _ = stage
+    body = (
+        await clients["mohamed"].put(
+            "/api/channels/web",
+            json={"enabled": True, "allowed_origins": ["https://shop.test"]},
+        )
+    ).json()
+    path = body["embed_path"]
+    http = clients["mohamed"]
+
+    allowed = await http.post(
+        f"/public/chat/{path}/messages",
+        json={"text": "hello"},
+        headers={"Origin": "https://shop.test"},
+    )
+    assert allowed.status_code == 201
+
+    refused = await http.post(
+        f"/public/chat/{path}/messages",
+        json={"text": "hello"},
+        headers={"Origin": "https://elsewhere.test"},
+    )
+    assert refused.status_code == 403
+
+    # And switching it off closes it, without touching the allowlist.
+    await http.put("/api/channels/web", json={"enabled": False})
+    closed = await http.post(
+        f"/public/chat/{path}/messages",
+        json={"text": "hello"},
+        headers={"Origin": "https://shop.test"},
+    )
+    assert closed.status_code == 403


### PR DESCRIPTION
The three guards from §B14 landed with **no way to configure them**. A guard nobody can switch on is a guard that is off — so this is not decoration on the endpoint, it is the half that makes it usable by anybody not holding a psql prompt.

§A6.8's **Channels** tab, for the one channel that exists.

| | |
|---|---|
| `GET /api/channels/web` | viewer |
| `PUT /api/channels/web` | admin |

## Decisions

**It creates itself on first read.** There is exactly one web channel per workspace, so asking the customer to create it would be asking them to agree to something with no alternative.

**It arrives switched off, with an empty allowlist** — and switching it on with nothing allowed is refused. On-with-nothing-allowed would refuse every visitor while the screen said *on*, which reads as a broken product rather than an unfinished setup.

**The address is generated, never chosen**, and the snippet is built from the request's own base URL. A hard-coded hostname is how an embed snippet ends up pointing at the developer's machine, and a test holds it.

**Origins are validated by `normalise_origin`** — the same function the guard enforces with, so what this screen accepts and what the endpoint compares cannot drift apart. Stored normalised and deduplicated: `https://Shop.test` and `https://shop.test:443` become one entry.

**The reCAPTCHA secret** goes into the encrypted column and comes back masked. An echoed mask is **ignored rather than saved** — a screen that renders `••••3ab1` and saves the form must not write bullets over the live credential. An empty string removes it, since switching reCAPTCHA off has to be possible and `null` already means *leave this alone*. Without an `ENCRYPTION_KEY` the write is refused **with a name** rather than exploding inside an INSERT whose parameter dump is the secret.

## Verification

- 14 new tests; **552 pass**, no regressions. `ruff` and `ruff format` clean
- The last test is the one that matters: **what this screen configures is what the public endpoint enforces** — configured here, then posted to the widget: allowed, refused from elsewhere, and refused again after switching it off

## Not in this change

The settings **screen** itself, and `embed.js` with the iframe page. The API is first because it is what can be tested end to end today, and because the screen has nothing to render until it exists.