### PR TITLE
Serve the widget, and fix the guard that could never have matched

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -48,12 +48,18 @@ PUBLIC_PATHS: frozenset[str] = frozenset(
         # of the customer's page; guarded by the origin allowlist instead of a
         # session. Listed by pattern so the route-table walk knows it is deliberate.
         "/public/chat/{path}/messages",
+        # The widget: the script a customer pastes and the document it frames. Public
+        # for the same reason - both are fetched by a stranger's browser, on a page
+        # this installation does not control. Neither reads a session; the page carries
+        # its own `frame-ancestors` policy instead (§B14).
+        "/embed.js",
+        "/widget/{path}",
     }
 )
 
 # Parameterised public routes carry a token in the path, so the request-time URL
 # never equals its pattern. The prefix is the runtime half of the two entries above.
-PUBLIC_PREFIXES: tuple[str, ...] = ("/api/invites/", "/public/chat/")
+PUBLIC_PREFIXES: tuple[str, ...] = ("/api/invites/", "/public/chat/", "/widget/")
 
 
 def is_public(path: str) -> bool:

--- a/api/main.py
+++ b/api/main.py
@@ -55,6 +55,7 @@ from api.routes import settings as settings_routes
 from api.routes import system as system_routes
 from api.routes import web_channel as web_channel_routes
 from api.routes import webhooks as webhook_routes
+from api.routes import widget as widget_routes
 from api.routes import workspaces as workspace_routes
 
 TAGS_METADATA = [
@@ -280,6 +281,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(knowledge_routes.router)
     app.include_router(public_chat_routes.router)
     app.include_router(web_channel_routes.router)
+    app.include_router(widget_routes.router)
     app.include_router(webhook_routes.router)
     app.include_router(rule_routes.router)
     app.include_router(contact_routes.router)

--- a/api/routes/public_chat.py
+++ b/api/routes/public_chat.py
@@ -123,7 +123,15 @@ async def post_message(
         return _refused()
 
     settings = channel.settings_json or {}
-    refusal = check_origin(origin, settings.get("allowed_origins"))
+    # `own` is this installation's origin: the widget is served from here, inside an
+    # iframe on the customer's page, so the browser stamps this origin on its POST
+    # rather than the site the iframe sits in. See `check_origin` for why accepting it
+    # gives a browser nothing, and for what really decides who may embed.
+    refusal = check_origin(
+        origin,
+        settings.get("allowed_origins"),
+        own=str(request.base_url).rstrip("/"),
+    )
     if refusal is not None:
         logger.info(
             "web chat refused",

--- a/api/routes/widget.py
+++ b/api/routes/widget.py
@@ -275,7 +275,16 @@ async def widget_page(request: Request, path: str) -> Response:
     # The header the browser enforces. `'none'` when there is nothing to allow, which
     # is also what an unknown address gets.
     ancestors = " ".join(allowed) if allowed else "'none'"
-    body = _page(path) if channel and allowed else "<!doctype html><title>Chat</title>"
+    # `channel.webhook_path`, not the `path` from the URL. They are equal - the lookup
+    # matched on exact equality - but they do not come from the same place, and what is
+    # written into a page should be the value this product stored rather than the string
+    # a stranger sent. The escaping in `_js_string` stands either way; this is the half
+    # that makes it unnecessary.
+    body = (
+        _page(channel.webhook_path or "")
+        if channel and allowed
+        else "<!doctype html><title>Chat</title>"
+    )
 
     if not allowed:
         logger.info(

--- a/api/routes/widget.py
+++ b/api/routes/widget.py
@@ -1,0 +1,269 @@
+"""The widget: the script a customer pastes, and the page it frames.
+
+Two public, unauthenticated GETs, and between them the correction that this file exists
+to carry.
+
+**`frame-ancestors` is what decides who may embed the widget.** Not the `Origin` header
+on the message - that is stamped by the browser with the *iframe's* origin, which is
+this installation, on every page including the allowed ones. The embedding guard has to
+be enforced where the embedding happens, which is when the browser decides whether to
+render this document inside somebody's page, and `Content-Security-Policy:
+frame-ancestors` is the header that decides it. A browser obeys it; there is no header
+to compare and nothing for a page to forge.
+
+An empty allowlist renders `frame-ancestors 'none'`, so an unconfigured channel cannot
+be embedded anywhere. Same rule as everywhere in §B14: not configured refuses.
+
+**The page is served from this installation, not from the customer's site**, which is
+the whole point of the iframe - their page cannot read the conversation and this page
+cannot read theirs. It also means the widget's own fetches are same-origin, so there is
+no CORS between the widget and the endpoint it posts to.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import APIRouter, Request, Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession as DbSession
+
+from api.models import Channel
+
+logger = logging.getLogger("api.widget")
+
+router = APIRouter(tags=["web chat"])
+
+# The bubble's size, and the panel's when it is open. In the script rather than the page
+# because the *host* page owns this box - the iframe cannot resize itself.
+_CLOSED = "60px"
+_OPEN_WIDTH = "380px"
+_OPEN_HEIGHT = "560px"
+
+
+async def _channel(db: DbSession, path: str) -> Channel | None:
+    return await db.scalar(
+        select(Channel).where(
+            Channel.webhook_path == path,
+            Channel.kind == "web",
+            Channel.status == "active",
+        )
+    )
+
+
+@router.get("/embed.js", include_in_schema=False)
+async def embed_script(request: Request) -> Response:
+    """The one line a customer pastes, and everything it does.
+
+    It reads its own `data-tel-agent`, builds an iframe at this installation, and sizes
+    it. Nothing else: no analytics, no cookies, no reading of the host page. A script on
+    somebody else's site is a liability they took on trust, and the way to deserve that
+    is to do the minimum in public view.
+
+    Served with no channel lookup - the same file for every installation and every
+    channel, so it caches. The address in the tag is checked when the iframe loads.
+    """
+    base = str(request.base_url).rstrip("/")
+    javascript = f"""(function () {{
+  var tag = document.currentScript;
+  if (!tag) return;
+  var path = tag.getAttribute("data-tel-agent");
+  if (!path) return;
+
+  var frame = document.createElement("iframe");
+  frame.src = "{base}/widget/" + encodeURIComponent(path);
+  frame.title = "Chat";
+  // No `allow`, and a sandbox that grants only what a chat needs. Anything this
+  // widget does not need is something the host page should not have to trust it with.
+  frame.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
+  frame.style.cssText = [
+    "position:fixed", "bottom:16px", "inset-inline-end:16px",
+    "width:{_CLOSED}", "height:{_CLOSED}", "border:0",
+    "border-radius:16px", "z-index:2147483000",
+    "box-shadow:0 6px 24px rgba(0,0,0,.18)",
+    "color-scheme:normal", "transition:width .18s ease,height .18s ease"
+  ].join(";");
+  document.body.appendChild(frame);
+
+  // The iframe cannot resize itself; the host page owns the box. This is the only
+  // message accepted, and only from the frame that was just created.
+  window.addEventListener("message", function (event) {{
+    if (event.source !== frame.contentWindow) return;
+    if (!event.data || event.data.telAgent !== "resize") return;
+    var open = event.data.open === true;
+    frame.style.width = open ? "{_OPEN_WIDTH}" : "{_CLOSED}";
+    frame.style.height = open ? "{_OPEN_HEIGHT}" : "{_CLOSED}";
+  }});
+}})();
+"""
+    return Response(
+        content=javascript,
+        media_type="application/javascript; charset=utf-8",
+        headers={
+            # Short, because a customer who changes their allowlist should not wait a
+            # day for a browser to notice. The file rarely changes; the iframe it points
+            # at is what carries the per-channel policy.
+            "Cache-Control": "public, max-age=300",
+        },
+    )
+
+
+def _page(path: str) -> str:
+    """The widget's document. Written here rather than in `web/` on purpose.
+
+    It is served by the API so that its fetches are same-origin with the endpoint, and
+    so that an installation running only the API still has a working chat. It is also
+    deliberately small: a build step between a customer pasting a tag and a visitor
+    seeing a bubble is a build step that will be out of date on somebody's server.
+    """
+    return f"""<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Chat</title>
+<style>
+  :root {{ color-scheme: light dark; font-family: system-ui, sans-serif; }}
+  * {{ box-sizing: border-box; }}
+  body {{ margin: 0; height: 100vh; overflow: hidden; }}
+  #bubble {{ position: absolute; inset: 0; border: 0; border-radius: 16px;
+    background: #4f46e5; color: #fff; font-size: 24px; cursor: pointer; }}
+  #panel {{ display: none; height: 100vh; flex-direction: column;
+    background: Canvas; color: CanvasText; border-radius: 16px; overflow: hidden; }}
+  #panel.open {{ display: flex; }}
+  header {{ display: flex; align-items: center; justify-content: space-between;
+    gap: 8px; padding: 12px 14px; background: #4f46e5; color: #fff; }}
+  header button {{ background: none; border: 0; color: inherit; font-size: 20px;
+    cursor: pointer; }}
+  #log {{ flex: 1; overflow-y: auto; padding: 12px 14px; display: flex;
+    flex-direction: column; gap: 8px; }}
+  .msg {{ max-width: 85%; padding: 8px 11px; border-radius: 12px; font-size: 14px;
+    line-height: 1.45; overflow-wrap: anywhere; }}
+  .me {{ align-self: flex-end; background: #4f46e5; color: #fff; }}
+  .note {{ align-self: center; font-size: 12.5px; opacity: .7; text-align: center; }}
+  form {{ display: flex; gap: 8px; padding: 10px; border-top: 1px solid rgba(128,128,128,.3); }}
+  input {{ flex: 1; min-width: 0; padding: 9px 11px; font: inherit; border-radius: 9px;
+    border: 1px solid rgba(128,128,128,.4); background: Canvas; color: CanvasText; }}
+  form button {{ padding: 9px 14px; font: inherit; border: 0; border-radius: 9px;
+    background: #4f46e5; color: #fff; cursor: pointer; }}
+  form button[disabled] {{ opacity: .5; cursor: default; }}
+</style>
+</head><body>
+<button id="bubble" aria-label="Open chat">&#128172;</button>
+<div id="panel" role="dialog" aria-label="Chat">
+  <header><span>Chat</span><button id="close" aria-label="Close chat">&times;</button></header>
+  <div id="log" aria-live="polite"></div>
+  <form id="form">
+    <input id="text" autocomplete="off" placeholder="Type a message" maxlength="4000">
+    <button type="submit">Send</button>
+  </form>
+</div>
+<script>
+(function () {{
+  var PATH = {json.dumps(path)};
+  var panel = document.getElementById("panel");
+  var bubble = document.getElementById("bubble");
+  var log = document.getElementById("log");
+  var form = document.getElementById("form");
+  var text = document.getElementById("text");
+  var conversation = null;
+
+  function resize(open) {{
+    parent.postMessage({{ telAgent: "resize", open: open }}, "*");
+  }}
+  function show(open) {{
+    panel.classList.toggle("open", open);
+    bubble.style.display = open ? "none" : "block";
+    resize(open);
+    if (open) text.focus();
+  }}
+  function say(body, cls) {{
+    var line = document.createElement("div");
+    line.className = "msg " + cls;
+    // textContent, never innerHTML: what a visitor types is not markup, and what
+    // comes back is not either.
+    line.textContent = body;
+    log.appendChild(line);
+    log.scrollTop = log.scrollHeight;
+  }}
+
+  bubble.addEventListener("click", function () {{ show(true); }});
+  document.getElementById("close").addEventListener("click", function () {{ show(false); }});
+
+  form.addEventListener("submit", async function (event) {{
+    event.preventDefault();
+    var body = text.value.trim();
+    if (!body) return;
+    text.value = "";
+    say(body, "me");
+    var button = form.querySelector("button");
+    button.disabled = true;
+    try {{
+      var answer = await fetch("/public/chat/" + encodeURIComponent(PATH) + "/messages", {{
+        method: "POST",
+        headers: {{ "Content-Type": "application/json" }},
+        body: JSON.stringify({{ text: body, conversation: conversation }})
+      }});
+      if (answer.ok) {{
+        conversation = (await answer.json()).conversation;
+      }} else {{
+        // One sentence for every refusal, because the server gives one. A visitor
+        // cannot act on "origin not allowed" and should not be shown it.
+        say("This message could not be sent.", "note");
+      }}
+    }} catch (error) {{
+      say("This message could not be sent.", "note");
+    }} finally {{
+      button.disabled = false;
+      text.focus();
+    }}
+  }});
+}})();
+</script>
+</body></html>
+"""
+
+
+@router.get("/widget/{path}", include_in_schema=False)
+async def widget_page(request: Request, path: str) -> Response:
+    """The document the iframe loads, carrying its own embedding policy.
+
+    A channel that does not exist, one that is switched off, and one with nothing
+    allowed all render the same empty page with `frame-ancestors 'none'` - the address
+    must not answer "is this a real installation" any more than the message endpoint
+    does.
+    """
+    db: DbSession = request.state.db
+    channel = await _channel(db, path)
+    allowed = (
+        list((channel.settings_json or {}).get("allowed_origins") or []) if channel else []
+    )
+
+    # The header the browser enforces. `'none'` when there is nothing to allow, which
+    # is also what an unknown address gets.
+    ancestors = " ".join(allowed) if allowed else "'none'"
+    body = _page(path) if channel and allowed else "<!doctype html><title>Chat</title>"
+
+    if not allowed:
+        logger.info(
+            "widget page served closed",
+            extra={"reason": "no channel or no allowed origins", "path": path},
+        )
+
+    return Response(
+        content=body,
+        media_type="text/html; charset=utf-8",
+        headers={
+            "Content-Security-Policy": (
+                f"frame-ancestors {ancestors}; "
+                # The page loads nothing from anywhere: its style and script are inline
+                # and its only request goes back here.
+                "default-src 'none'; connect-src 'self'; "
+                "style-src 'unsafe-inline'; script-src 'unsafe-inline'"
+            ),
+            # Per channel, and the policy is in the body's headers, so it must not be
+            # cached across channels by anything in between.
+            "Cache-Control": "no-store",
+            "Referrer-Policy": "no-referrer",
+        },
+    )

--- a/api/routes/widget.py
+++ b/api/routes/widget.py
@@ -109,6 +109,39 @@ async def embed_script(request: Request) -> Response:
     )
 
 
+def _js_string(value: str) -> str:
+    """A JSON string safe to sit inside a `<script>` block.
+
+    `json.dumps` escapes quotes and backslashes and stops there - it does not touch
+    `<`, so a value containing `</script>` ends the block and everything after it is
+    parsed as markup. That is the whole of the reflective-XSS class, and JSON encoding
+    alone is the usual near-miss.
+
+    U+2028 and U+2029 are here too: they are valid inside a JSON string and are
+    line terminators to a JavaScript parser, so an unescaped one truncates the
+    statement.
+
+    This value is a channel address that was matched against the database before
+    reaching here, so today it can only be what this product generated. That is not a
+    reason to interpolate it unescaped - it is a reason the bug would have waited for
+    somebody to add a second caller.
+    """
+    encoded = json.dumps(value)
+    # The right-hand sides are the six-character escape *sequences*, so what lands
+    # in the page is a backslash followed by u003c - not the character itself.
+    # Replacing `<` with `<` is the version of this that reads correctly and does
+    # nothing at all, which is how the first attempt at this went.
+    for raw, escaped in (
+        ("<", "\\u003c"),
+        (">", "\\u003e"),
+        ("&", "\\u0026"),
+        ("\u2028", "\\u2028"),
+        ("\u2029", "\\u2029"),
+    ):
+        encoded = encoded.replace(raw, escaped)
+    return encoded
+
+
 def _page(path: str) -> str:
     """The widget's document. Written here rather than in `web/` on purpose.
 
@@ -160,7 +193,7 @@ def _page(path: str) -> str:
 </div>
 <script>
 (function () {{
-  var PATH = {json.dumps(path)};
+  var PATH = {_js_string(path)};
   var panel = document.getElementById("panel");
   var bubble = document.getElementById("bubble");
   var log = document.getElementById("log");

--- a/api/security/embed.py
+++ b/api/security/embed.py
@@ -72,8 +72,26 @@ def normalise_origin(raw: str) -> str | None:
     return f"{parsed.scheme}://{host}:{port}"
 
 
-def check_origin(sent: str | None, allowed: list[str] | None) -> Refusal | None:
+def check_origin(
+    sent: str | None, allowed: list[str] | None, *, own: str | None = None
+) -> Refusal | None:
     """None when the page may post here. A `Refusal` otherwise.
+
+    **`own` is the installation's own origin, and it is accepted.** The widget runs in
+    an iframe served by this installation, so the browser stamps *that* origin on the
+    message it posts - not the site the iframe is embedded on. Checking only the
+    customer's list would refuse the widget on every page including the allowed ones,
+    which is a guard that stops nothing and everything.
+
+    Accepting it costs nothing a browser can abuse: a page on `evil.test` cannot send
+    `Origin: https://telagent.example`, because the browser writes that header and
+    scripts cannot. What may is a client that is not a browser, and the guards for that
+    are the rate limit and the captcha - neither of which an origin check was ever going
+    to provide.
+
+    **What actually decides who may embed the widget is `frame-ancestors`** on the
+    widget page (§B14): the browser refuses to render it inside a page that is not on
+    the list, and unlike a header comparison that cannot be forged at all.
 
     Four ways to be refused, one answer to the caller:
 
@@ -99,6 +117,9 @@ def check_origin(sent: str | None, allowed: list[str] | None) -> Refusal | None:
     # than matching by accident.
     permitted = {normalise_origin(entry) for entry in allowed}
     permitted.discard(None)
+    if own is not None:
+        permitted.add(normalise_origin(own))
+        permitted.discard(None)
     if origin not in permitted:
         return Refusal(_REFUSED, f"origin {origin} not in allowlist")
     return None

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1150,6 +1150,33 @@ is an **address**, and what protects the address is the next section. Treating i
 secret is the mistake to avoid, because it would mean the guard is a value printed on
 every page that uses it.
 
+### The allowlist is enforced by `frame-ancestors`, not by the `Origin` header
+
+This paragraph replaces an earlier one that had it wrong, and the mistake is worth
+keeping because it is easy to make twice.
+
+The widget runs in an iframe **served by this installation**. When it posts a message
+the browser stamps the request with the *iframe's* origin - `https://telagent.example` -
+and never with the site the iframe is embedded in. An allowlist of customer sites
+compared against that header therefore matches nothing, on every page including the
+allowed ones. The check reads like a guard and refuses everybody.
+
+The embedding decision has to be enforced where the embedding happens: when the browser
+decides whether to render this document inside somebody's page. That is
+`Content-Security-Policy: frame-ancestors`, sent on the widget page and built from the
+same list. A browser obeys it, and unlike a header comparison there is nothing for a
+page to forge - the attacking page never gets to send anything.
+
+So the list does two jobs, and this is the important half:
+
+- **On the widget page, as `frame-ancestors`** - who may embed it at all. An empty list
+  renders `'none'`, and so does an unknown or switched-off address.
+- **On the message, as an `Origin` check** that also accepts the installation's own
+  origin. Accepting it gives a browser nothing: a page on `evil.test` cannot send
+  `Origin: https://telagent.example`, because the browser writes that header and scripts
+  cannot. A client that is not a browser can send anything, and the guards for that are
+  the rate limit and the captcha - which an origin check was never going to be.
+
 ### The origin allowlist is the guard
 
 Each web channel stores the origins allowed to embed it. A request whose `Origin` is not

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -195,7 +195,14 @@ async def test_every_route_is_protected_unless_it_is_on_the_public_list(
     # And the list itself is short enough to read in one go. If it is growing, that is
     # the thing to notice. Raised from 12 when D-034 added the two invite routes,
     # which are guarded by their one-time token rather than a session.
-    assert len(PUBLIC_PATHS) <= 14
+    #
+    # Raised again to 17 for web chat (§B14): the message endpoint, the embed script and
+    # the widget page. All three are fetched by a stranger's browser on a page this
+    # installation does not control, so there is no session to ask for - they are
+    # guarded by an origin allowlist, a rate limit, a captcha, and a `frame-ancestors`
+    # policy the browser enforces. Three at once is the largest jump this list has
+    # taken, which is exactly what this number exists to make somebody notice.
+    assert len(PUBLIC_PATHS) <= 17
 
 
 async def test_an_expired_session_is_refused_and_deleted(
@@ -358,6 +365,11 @@ async def test_every_route_under_a_public_prefix_is_pinned(client) -> None:
         # A second route under `/public/` is a decision, not an addition. Read
         # `api/routes/public_chat.py`'s docstring before adding one.
         "/public/chat/{path}/messages",
+        # The widget's own document, §B14. Public for the same reason the message
+        # endpoint is - a stranger's browser fetches it, on a page this installation
+        # does not control. It opens no session either; what limits it is the
+        # `frame-ancestors` policy it carries, which is the browser's to enforce.
+        "/widget/{path}",
     }, (
         "A route was added under a public prefix. If it is meant to be public, add it "
         "here; if it is not, it needs a different prefix - it is currently reachable "

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1,0 +1,169 @@
+"""The widget's two public GETs.
+
+The one that matters is `frame-ancestors`: it is what actually decides who may embed
+the chat, because the `Origin` on a message is stamped with the iframe's own origin and
+never with the site the iframe sits in. A test that only checked the message endpoint
+would have let this ship believing the allowlist protected the embed, which it does not
+on its own.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.config import Settings
+from api.main import create_app
+from api.models import Channel, Workspace
+
+ALLOWED = "https://shop.test"
+
+
+@pytest.fixture
+async def stage(migrated: AsyncSession, settings: Settings, database_url: str):
+    workspace = Workspace(name="Wagner & Partner")
+    migrated.add(workspace)
+    await migrated.flush()
+
+    channels = {
+        "live": Channel(
+            workspace_id=workspace.id,
+            kind="web",
+            name="Web chat",
+            webhook_path="live-" + "a" * 28,
+            settings_json={"allowed_origins": [ALLOWED, "https://www.shop.test"]},
+            status="active",
+        ),
+        "off": Channel(
+            workspace_id=workspace.id,
+            kind="web",
+            name="Old",
+            webhook_path="off-" + "b" * 29,
+            settings_json={"allowed_origins": [ALLOWED]},
+            status="disabled",
+        ),
+        "unconfigured": Channel(
+            workspace_id=workspace.id,
+            kind="web",
+            name="New",
+            webhook_path="new-" + "c" * 29,
+            settings_json={},
+            status="active",
+        ),
+    }
+    migrated.add_all(channels.values())
+    await migrated.commit()
+    paths = {name: row.webhook_path for name, row in channels.items()}
+
+    app = create_app(settings.model_copy(update={"database_url": database_url}))
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://localhost") as http:
+            yield http, paths
+
+
+async def test_the_script_needs_no_session_and_names_no_channel(stage) -> None:
+    http, _ = stage
+    answer = await http.get("/embed.js")
+    assert answer.status_code == 200
+    assert "javascript" in answer.headers["content-type"]
+
+    body = answer.text
+    # The same file for every channel, which is why it can be cached.
+    assert "data-tel-agent" in body
+    assert "iframe" in body
+    assert "max-age" in answer.headers.get("cache-control", "")
+
+
+async def test_the_script_does_nothing_it_does_not_need_to(stage) -> None:
+    """A script on somebody else's site is a liability they took on trust."""
+    http, _ = stage
+    body = (await http.get("/embed.js")).text
+
+    for forbidden in ("document.cookie", "localStorage", "XMLHttpRequest", "navigator."):
+        assert forbidden not in body, forbidden
+    # It reads its own tag and nothing else on the page.
+    assert "document.currentScript" in body
+    # And the only message it listens to is checked against the frame it created.
+    assert "event.source !== frame.contentWindow" in body
+
+
+async def test_the_page_carries_the_allowlist_as_frame_ancestors(stage) -> None:
+    """The guard that actually decides who may embed, and cannot be forged."""
+    http, paths = stage
+    answer = await http.get(f"/widget/{paths['live']}")
+    assert answer.status_code == 200
+
+    csp = answer.headers["content-security-policy"]
+    assert f"frame-ancestors {ALLOWED} https://www.shop.test" in csp
+    # It loads nothing from anywhere, and talks only back here.
+    assert "default-src 'none'" in csp
+    assert "connect-src 'self'" in csp
+
+
+@pytest.mark.parametrize("which", ["off", "unconfigured"])
+async def test_a_closed_channel_cannot_be_framed_anywhere(stage, which) -> None:
+    http, paths = stage
+    answer = await http.get(f"/widget/{paths[which]}")
+    assert "frame-ancestors 'none'" in answer.headers["content-security-policy"]
+    # And there is no chat in it to run.
+    assert 'id="form"' not in answer.text
+
+
+async def test_an_unknown_address_answers_like_a_closed_one(stage) -> None:
+    """The address must not tell a stranger whether a business runs this."""
+    http, paths = stage
+    unknown = await http.get("/widget/no-such-address-at-all")
+    closed = await http.get(f"/widget/{paths['off']}")
+
+    assert unknown.status_code == closed.status_code == 200
+    assert unknown.text == closed.text
+    assert (
+        unknown.headers["content-security-policy"] == closed.headers["content-security-policy"]
+    )
+
+
+async def test_the_page_is_never_cached(stage) -> None:
+    """Its policy is per channel, so anything in between must not reuse it."""
+    http, paths = stage
+    answer = await http.get(f"/widget/{paths['live']}")
+    assert answer.headers["cache-control"] == "no-store"
+
+
+async def test_the_page_posts_to_its_own_channel(stage) -> None:
+    http, paths = stage
+    body = (await http.get(f"/widget/{paths['live']}")).text
+    # The address is embedded as JSON, so a path with a quote in it cannot end the
+    # string and start being code.
+    assert f"var PATH = {json.dumps(paths['live'])};" in body
+    assert "/public/chat/" in body
+
+
+async def test_the_page_renders_what_a_visitor_typed_as_text(stage) -> None:
+    """A chat that renders its own input as markup is an XSS in every host page."""
+    http, paths = stage
+    body = (await http.get(f"/widget/{paths['live']}")).text
+    assert "textContent" in body
+    # Not a plain `not in`: the file names `innerHTML` in the comment that says why it
+    # is not used, and a test that fails on its own explanation teaches people to
+    # delete explanations.
+    code = [line for line in body.splitlines() if not line.strip().startswith("//")]
+    assert "innerHTML" not in "\n".join(code)
+
+
+async def test_the_widget_can_reach_the_endpoint_it_points_at(stage) -> None:
+    """End to end, as the iframe does it: same origin, no session, no cookie.
+
+    This is the case the origin guard originally refused - the browser stamps the
+    iframe's own origin on the message, not the site it is embedded in.
+    """
+    http, paths = stage
+    answer = await http.post(
+        f"/public/chat/{paths['live']}/messages",
+        json={"text": "Do you open on Saturday?"},
+        headers={"Origin": "http://localhost"},
+    )
+    assert answer.status_code == 201

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -167,3 +167,42 @@ async def test_the_widget_can_reach_the_endpoint_it_points_at(stage) -> None:
         headers={"Origin": "http://localhost"},
     )
     assert answer.status_code == 201
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "</script><img src=x onerror=alert(1)>",
+        '" + alert(1) + "',
+        chr(0x2028) + "alert(1)",
+    ],
+)
+def test_the_address_cannot_end_the_script_block(hostile) -> None:
+    """CodeQL found this one, and it was real.
+
+    `json.dumps` escapes quotes and backslashes and stops there - it leaves `<` alone,
+    so a value containing `</script>` closes the block and everything after it parses
+    as markup. The address is matched against the database before it reaches the page,
+    so today it can only be what this product generated; that is not a reason to
+    interpolate it unescaped, it is a reason the bug would have waited for a second
+    caller.
+    """
+    from api.routes.widget import _js_string, _page
+
+    encoded = _js_string(hostile)
+    page = _page(hostile)
+
+    # One closing tag: the one that ends the widget's own script.
+    assert page.count("</script>") == 1
+    # Nothing from the address arrives as markup.
+    assert "<img" not in page
+
+    # And it cannot leave the string it is in. The encoded form is a JSON string whose
+    # only unescaped quotes are its own delimiters - `" + alert(1) + "` stays inside it
+    # rather than being three tokens, which is why asserting on the raw text would have
+    # been the wrong question.
+    assert encoded.startswith('"') and encoded.endswith('"')
+    inner = encoded[1:-1]
+    assert '"' not in inner.replace(chr(92) + '"', "")
+    assert "<" not in inner
+    assert encoded in page


### PR DESCRIPTION
The embed script and the page it frames — and with them a correction to §B14 that building the widget forced.

## The origin allowlist could not have worked

The widget runs in an iframe **served by this installation**. When it posts a message the browser stamps the request with the *iframe's* origin — this installation — and never with the site the iframe is embedded in.

So an allowlist of customer sites compared against that header matches **nothing**, on every page including the allowed ones. It reads like a guard and refuses everybody.

I wrote the check assuming the request came from the customer's page directly, which is what it would be if the script injected its interface into the page. §B14 chose an iframe for isolation. I wrote both and did not notice they disagreed.

## What actually enforces it

`Content-Security-Policy: frame-ancestors`, built from the same list, sent on the widget page. The browser obeys it, and unlike a header comparison there is **nothing to forge** — the attacking page never gets to send anything.

An empty list, an unknown address and a switched-off channel all render `'none'` **and the same empty document**, so the address does not answer *"does this business run Tel-Agent"*.

The `Origin` check stays and now also accepts this installation's own origin. That gives a browser nothing: a page on `evil.test` cannot send `Origin: https://telagent.example`, because the browser writes that header and scripts cannot. A non-browser client can send anything — and the guards for that are the rate limit and the captcha, which an origin check was never going to be.

## The two files

**`/embed.js`** does the minimum in public view: reads its own tag, builds a sandboxed iframe, and listens for one resize message *from the frame it created*. No cookies, no storage, no reading of the host page — a script on somebody else's site is a liability they took on trust. Tests assert the absences.

**`/widget/{path}`** is served by the API rather than built in `web/`: its fetches are then same-origin with the endpoint, an installation running only the API still has a working chat, and there is no build step between a customer pasting a tag and a visitor seeing a bubble. It renders with `textContent`, never `innerHTML` — a chat that renders its own input as markup is an XSS in every page that embeds it.

## Two guard tests failed and were answered

The closed-by-default walk, and the **ceiling on how many public paths exist**. Three at once is the largest jump that list has taken, which is exactly what the number is there to make somebody notice — so it was raised with the reason written next to it, not quietly.

## Verification

- 10 new tests; **562 pass**, no regressions. `ruff` clean
- Driven live with curl: configured the channel **through the API rather than SQL**, copied the snippet, and confirmed `frame-ancestors https://shop.test http://localhost:3100` on the page, `'none'` plus a 34-byte body on an unknown address, and the message flow in all three shapes — **from the iframe's own origin (201, the case that was broken)**, from an unallowed site (403), and from an allowed site directly (201). Test rows removed and the dev channel put back