### PR TITLE
Answer, one word at a time

### DIFF
--- a/agent/reply.py
+++ b/agent/reply.py
@@ -1,0 +1,52 @@
+"""What the agent says back, and the shape it has to say it in.
+
+Milestone 0 step 2 is "it replies with a hardcoded greeting". This is that greeting -
+and deliberately not a function that returns it.
+
+**Rule 3 is why.** An agent that composes a whole answer and then sends it can never be
+put on a call: the caller hears silence for the length of the generation and then a
+paragraph. The fix is not something to retrofit at Milestone 11, because every interface
+above it would have been written to a signature that hands back one finished string.
+So the signature is an async iterator from the first line, when what it yields is a
+greeting nobody had to generate.
+
+Step 3 replaces the body of `reply` with a model call. Nothing above it changes: the
+route already consumes chunks as they arrive, and already stops when the visitor goes
+away.
+
+**Cancellation is the same argument.** `cancel()` on a provider is not optional (Rule 3),
+and an iterator is cancellable by construction - the consumer stops consuming and the
+generator's `finally` runs. A function that returns a string has nowhere to put that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+# Roughly a word at a time, which is what a model emits and what a person reads. Fixed
+# here rather than in the route: how a reply is broken up is the generator's business,
+# and the route's job is only to pass along whatever arrives.
+GREETING = (
+    "Hello. I am not answering for anybody yet - the model is not connected. "
+    "Your message was stored, and somebody will read it."
+)
+
+# Enough delay that streaming is visibly streaming during development, and small enough
+# that it is not a latency budget anybody has to think about. It goes when the model
+# arrives, because then the pauses are real.
+_CHUNK_DELAY = 0.04
+
+
+async def reply(text: str, *, history: list[str] | None = None) -> AsyncIterator[str]:
+    """The agent's answer, in the pieces it becomes available in.
+
+    `text` and `history` are unused at step 2 and are in the signature anyway: they are
+    what step 3 needs, and adding a parameter later means changing every caller at the
+    moment the change is least welcome.
+    """
+    for index, word in enumerate(GREETING.split(" ")):
+        # Cancellation lands here: when the consumer stops, this sleep is cancelled and
+        # the generator unwinds. Nothing above has to know how.
+        await asyncio.sleep(_CHUNK_DELAY)
+        yield word if index == 0 else " " + word

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -48,6 +48,10 @@ PUBLIC_PATHS: frozenset[str] = frozenset(
         # of the customer's page; guarded by the origin allowlist instead of a
         # session. Listed by pattern so the route-table walk knows it is deliberate.
         "/public/chat/{path}/messages",
+        # The reply, streamed. Same guards as the message that asked for it,
+        # minus the captcha - that was paid when the message was accepted, and
+        # asking twice per exchange doubles the cost to verify nobody new.
+        "/public/chat/{path}/stream",
         # The widget: the script a customer pastes and the document it frames. Public
         # for the same reason - both are fetched by a stranger's browser, on a page
         # this installation does not control. Neither reads a session; the page carries

--- a/api/routes/public_chat.py
+++ b/api/routes/public_chat.py
@@ -19,15 +19,20 @@ endpoint stores and acknowledges, and says nothing that implies otherwise.
 
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
+import json
 import logging
 import secrets
+from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Header, Request, status
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession as DbSession
 
+from agent.reply import reply as generate_reply
 from api.errors import envelope_response
 from api.models import Channel, Conversation, Message
 from api.security import captcha, quota
@@ -247,3 +252,146 @@ def _new_handle() -> str:
     the business has had, and let them try the one next door.
     """
     return secrets.token_urlsafe(24)
+
+
+def _event(payload: dict[str, object]) -> str:
+    """One server-sent event.
+
+    `json.dumps` guarantees the payload is one line, which is what the format requires -
+    a raw newline inside `data:` would end the event early and the rest would arrive as
+    a field nobody reads.
+    """
+    body = json.dumps(payload, ensure_ascii=False)
+    # Two newlines end an event. Built rather than written inline so no layer between
+    # here and the file can eat one of them - which is exactly how this line first
+    # arrived, as an f-string cut in half.
+    return "data: " + body + "\n\n"
+
+
+async def _reply_stream(
+    request: Request, channel: Channel, conversation: Conversation, text: str
+) -> AsyncIterator[str]:
+    """The agent's answer, forwarded as it arrives, and stored when it is whole.
+
+    **Stored at the end, not at each chunk.** A half-written reply in the archive would
+    be indistinguishable from one the agent actually gave, and the transcript is what
+    somebody reads back later to find out what a customer was told.
+
+    **A visitor who closes the tab cancels it.** The generator's `finally` runs, nothing
+    is stored, and no further tokens are produced - which is what Rule 3 means by
+    `cancel()` not being optional, in the only shape that survives being retrofitted.
+    """
+    pieces: list[str] = []
+    try:
+        async for chunk in generate_reply(text):
+            if await request.is_disconnected():
+                logger.info(
+                    "web chat reply cancelled by the visitor",
+                    extra={"conversation_id": conversation.id},
+                )
+                return
+            pieces.append(chunk)
+            yield _event({"delta": chunk})
+    except asyncio.CancelledError:
+        # The server is shutting down or the connection dropped mid-chunk. Same
+        # outcome: say nothing, store nothing.
+        logger.info("web chat reply cancelled", extra={"conversation_id": conversation.id})
+        raise
+
+    whole = "".join(pieces)
+    if not whole:
+        return
+
+    db: DbSession = request.state.db
+    stored = Message(
+        workspace_id=channel.workspace_id,
+        conversation_id=conversation.id,
+        ts_ms=int(dt.datetime.now(dt.UTC).timestamp() * 1000),
+        speaker="agent",
+        text=whole,
+    )
+    db.add(stored)
+    await db.commit()
+    await db.refresh(stored)
+    yield _event({"done": True, "message_id": stored.id})
+
+
+@router.get("/{path}/stream", summary="The agent's reply, as it is produced")
+async def stream_reply(
+    request: Request,
+    path: str,
+    conversation: str,
+    origin: str | None = Header(default=None),
+) -> object:
+    """Milestone 0 step 2, in the shape step 5 needs.
+
+    A GET rather than the POST's response body, because the visitor's message has to be
+    stored and acknowledged whether or not the reply ever starts - and because a
+    response that carries both is a response nobody can cancel half of.
+
+    The captcha is not repeated here: it was paid when the message was accepted, and
+    asking Google twice for one exchange would double the cost of every conversation to
+    verify a visitor who has not changed.
+    """
+    db: DbSession = request.state.db
+
+    channel = await _channel(db, path)
+    if channel is None:
+        return _refused()
+
+    settings = channel.settings_json or {}
+    # `require_header=False`: this is a GET, and a browser sends no `Origin` on a
+    # same-origin one - so `EventSource` opening the widget's own reply stream has no
+    # header to offer. The thread handle below is what guards it, and it is a better
+    # guard than a header: random, per conversation, scoped to this channel, and only
+    # ever issued to somebody who passed every check on the message that created it.
+    refusal = check_origin(
+        origin,
+        settings.get("allowed_origins"),
+        own=str(request.base_url).rstrip("/"),
+        require_header=False,
+    )
+    if refusal is not None:
+        logger.info("web chat stream refused", extra={"reason": refusal.reason})
+        return _refused()
+
+    thread = await db.scalar(
+        select(Conversation).where(
+            Conversation.external_id == conversation,
+            Conversation.channel_id == channel.id,
+            Conversation.status == "open",
+        )
+    )
+    if thread is None:
+        return _refused()
+
+    # The visitor's last message is what the agent is answering. Read here rather than
+    # taken from the query string: a caller could otherwise ask for a reply to text the
+    # conversation never contained.
+    last = await db.scalar(
+        select(Message)
+        .where(Message.conversation_id == thread.id, Message.speaker == "caller")
+        .order_by(Message.ts_ms.desc(), Message.id.desc())
+        .limit(1)
+    )
+    if last is None:
+        return _refused()
+
+    if not await quota.consume(
+        db, f"webchat:conversation:{conversation}", quota.PER_CONVERSATION
+    ):
+        await db.commit()
+        return _too_many()
+    await db.commit()
+
+    return StreamingResponse(
+        _reply_stream(request, channel, thread, last.text),
+        media_type="text/event-stream",
+        headers={
+            # Without this a proxy buffers the whole stream and delivers it at once,
+            # which is the failure Rule 3 exists to prevent, arriving from outside the
+            # application.
+            "X-Accel-Buffering": "no",
+            "Cache-Control": "no-store",
+        },
+    )

--- a/api/routes/widget.py
+++ b/api/routes/widget.py
@@ -173,6 +173,7 @@ def _page(path: str) -> str:
   .msg {{ max-width: 85%; padding: 8px 11px; border-radius: 12px; font-size: 14px;
     line-height: 1.45; overflow-wrap: anywhere; }}
   .me {{ align-self: flex-end; background: #4f46e5; color: #fff; }}
+  .them {{ align-self: flex-start; background: rgba(128,128,128,.16); }}
   .note {{ align-self: center; font-size: 12.5px; opacity: .7; text-align: center; }}
   form {{ display: flex; gap: 8px; padding: 10px; border-top: 1px solid rgba(128,128,128,.3); }}
   input {{ flex: 1; min-width: 0; padding: 9px 11px; font: inherit; border-radius: 9px;
@@ -223,6 +224,40 @@ def _page(path: str) -> str:
   bubble.addEventListener("click", function () {{ show(true); }});
   document.getElementById("close").addEventListener("click", function () {{ show(false); }});
 
+  // The reply, as it is produced. A bubble that fills in word by word is the only
+  // shape that survives the phone: an agent that composes a whole answer before
+  // sending it leaves a caller listening to silence (Rule 3).
+  async function listen() {{
+    var line = document.createElement("div");
+    line.className = "msg them";
+    log.appendChild(line);
+
+    var source = new EventSource(
+      "/public/chat/" + encodeURIComponent(PATH) + "/stream?conversation=" +
+      encodeURIComponent(conversation)
+    );
+    await new Promise(function (done) {{
+      source.onmessage = function (event) {{
+        var payload = JSON.parse(event.data);
+        if (payload.delta) {{
+          // textContent again: what the agent says is not markup either, and it will
+          // be a model's output before long.
+          line.textContent += payload.delta;
+          log.scrollTop = log.scrollHeight;
+        }}
+        if (payload.done) {{ source.close(); done(); }}
+      }};
+      source.onerror = function () {{
+        source.close();
+        if (!line.textContent) {{
+          line.className = "msg note";
+          line.textContent = "No reply just now.";
+        }}
+        done();
+      }};
+    }});
+  }}
+
   form.addEventListener("submit", async function (event) {{
     event.preventDefault();
     var body = text.value.trim();
@@ -239,6 +274,7 @@ def _page(path: str) -> str:
       }});
       if (answer.ok) {{
         conversation = (await answer.json()).conversation;
+        await listen();
       }} else {{
         // One sentence for every refusal, because the server gives one. A visitor
         // cannot act on "origin not allowed" and should not be shown it.

--- a/api/security/embed.py
+++ b/api/security/embed.py
@@ -73,7 +73,11 @@ def normalise_origin(raw: str) -> str | None:
 
 
 def check_origin(
-    sent: str | None, allowed: list[str] | None, *, own: str | None = None
+    sent: str | None,
+    allowed: list[str] | None,
+    *,
+    own: str | None = None,
+    require_header: bool = True,
 ) -> Refusal | None:
     """None when the page may post here. A `Refusal` otherwise.
 
@@ -95,9 +99,18 @@ def check_origin(
 
     Four ways to be refused, one answer to the caller:
 
-    * **No `Origin` header.** A browser sets it on every cross-origin POST and page
-      script cannot forge it. Absent means the request did not come from a page, which
-      a widget request always does.
+    * **No `Origin` header**, when `require_header` is set. A browser sets it on every
+      POST and page script cannot forge it, so on a write, absent means the request did
+      not come from a page - which a widget message always does.
+
+      **`require_header=False` is for a GET**, and it is not a weakening: the browser
+      simply does not send `Origin` on a same-origin GET, so `EventSource` reaching the
+      reply stream has no header to check and refusing it refuses the widget itself. A
+      header that is present is still checked. What guards that request instead is the
+      thread handle - random, per conversation, scoped to its channel, and issued only
+      to somebody who already passed every check on the message that created it. A
+      capability, which is the right shape for a stream a page opens about its own
+      conversation.
     * **Not a well-formed origin.**
     * **The channel has no list.** Not configured is refused, not open: the safe
       reading of an empty list is the one that stores nothing.
@@ -106,7 +119,9 @@ def check_origin(
     if not allowed:
         return Refusal(_REFUSED, "channel has no allowed origins configured")
     if sent is None:
-        return Refusal(_REFUSED, "no Origin header")
+        if require_header:
+            return Refusal(_REFUSED, "no Origin header")
+        return None
 
     origin = normalise_origin(sent)
     if origin is None:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,7 +85,7 @@ Six checks, in order:
 |---|---|---|
 | 0 | **Refuse** | A message from an origin the channel does not allow is refused, and nothing is stored |
 | 1 | Arrive | A message typed in a browser reaches the agent process |
-| 2 | Answer | It replies with a hardcoded greeting |
+| 2 | Answer | It replies with a hardcoded greeting — **and streams it**, because an interface that returns one finished answer is the one Rule 3 says cannot be fixed later |
 | 3 | Understand | The model's reply appears in the page, in the visitor's language |
 | 4 | **Full loop** | Visitor writes → model replies → visitor writes again, thread intact |
 | 5 | **Stream and cancel** | Tokens appear as they are produced, and stop instantly when cancelled |

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -202,7 +202,7 @@ async def test_every_route_is_protected_unless_it_is_on_the_public_list(
     # guarded by an origin allowlist, a rate limit, a captcha, and a `frame-ancestors`
     # policy the browser enforces. Three at once is the largest jump this list has
     # taken, which is exactly what this number exists to make somebody notice.
-    assert len(PUBLIC_PATHS) <= 17
+    assert len(PUBLIC_PATHS) <= 18
 
 
 async def test_an_expired_session_is_refused_and_deleted(
@@ -365,6 +365,7 @@ async def test_every_route_under_a_public_prefix_is_pinned(client) -> None:
         # A second route under `/public/` is a decision, not an addition. Read
         # `api/routes/public_chat.py`'s docstring before adding one.
         "/public/chat/{path}/messages",
+        "/public/chat/{path}/stream",
         # The widget's own document, §B14. Public for the same reason the message
         # endpoint is - a stranger's browser fetches it, on a page this installation
         # does not control. It opens no session either; what limits it is the

--- a/tests/test_public_chat.py
+++ b/tests/test_public_chat.py
@@ -484,3 +484,187 @@ async def test_a_refused_origin_never_costs_a_call_to_google(stage, monkeypatch)
     )
     assert answer.status_code == 403
     assert called == []
+
+
+# --- Milestone 0 step 2: the reply ------------------------------------------
+
+
+def _events(body: str) -> list[dict]:
+    """The payloads out of an SSE body."""
+    import json as _json
+
+    return [
+        _json.loads(line[len("data: ") :])
+        for line in body.splitlines()
+        if line.startswith("data: ")
+    ]
+
+
+async def test_the_reply_arrives_in_pieces_and_is_stored_whole(stage) -> None:
+    """Rule 3's shape, and the archive's.
+
+    Chunks on the wire so a caller never waits on a whole paragraph; one row in the
+    transcript, because a half-written reply is indistinguishable from one the agent
+    actually gave.
+    """
+    from agent.reply import GREETING
+
+    http, paths, db = stage
+    first = (
+        await http.post(
+            f"/public/chat/{paths['ours']}/messages",
+            json={"text": "Do you open on Saturday?"},
+            headers={"Origin": ALLOWED},
+        )
+    ).json()
+
+    answer = await http.get(
+        f"/public/chat/{paths['ours']}/stream",
+        params={"conversation": first["conversation"]},
+        headers={"Origin": ALLOWED},
+    )
+    assert answer.status_code == 200
+    assert answer.headers["content-type"].startswith("text/event-stream")
+    assert answer.headers["cache-control"] == "no-store"
+
+    events = _events(answer.text)
+    deltas = [event["delta"] for event in events if "delta" in event]
+    # More than one, or it is not streaming.
+    assert len(deltas) > 1
+    assert "".join(deltas) == GREETING
+
+    done = [event for event in events if event.get("done")]
+    assert len(done) == 1
+
+    db.expire_all()
+    stored = await db.scalar(select(Message).where(Message.id == done[0]["message_id"]))
+    assert stored is not None
+    assert stored.speaker == "agent"
+    assert stored.text == GREETING
+
+
+async def test_the_reply_answers_the_message_that_was_stored(stage) -> None:
+    """Not one the caller passed in the query string.
+
+    Otherwise anybody could ask for an answer to text the conversation never held.
+    """
+    http, paths, db = stage
+    first = (
+        await http.post(
+            f"/public/chat/{paths['ours']}/messages",
+            json={"text": "the real question"},
+            headers={"Origin": ALLOWED},
+        )
+    ).json()
+    await http.get(
+        f"/public/chat/{paths['ours']}/stream",
+        params={"conversation": first["conversation"], "text": "a different question"},
+        headers={"Origin": ALLOWED},
+    )
+
+    db.expire_all()
+    rows = (await db.execute(select(Message).order_by(Message.id))).scalars().all()
+    assert [row.speaker for row in rows] == ["caller", "agent"]
+    assert rows[0].text == "the real question"
+
+
+@pytest.mark.parametrize(
+    ("origin", "conversation", "because"),
+    [
+        ("https://evil.test", None, "a page that is not on the list"),
+        (ALLOWED, "not-a-real-handle", "a thread handle that resolves to nothing"),
+    ],
+)
+async def test_the_stream_is_guarded_like_the_message(
+    stage, origin, conversation, because
+) -> None:
+    http, paths, db = stage
+    first = (
+        await http.post(
+            f"/public/chat/{paths['ours']}/messages",
+            json={"text": "hello"},
+            headers={"Origin": ALLOWED},
+        )
+    ).json()
+
+    answer = await http.get(
+        f"/public/chat/{paths['ours']}/stream",
+        params={"conversation": conversation or first["conversation"]},
+        headers={"Origin": origin},
+    )
+    assert answer.status_code == 403, because
+    assert answer.json()["error"]["code"] == "origin_not_allowed"
+
+    db.expire_all()
+    # One message: the visitor's. No agent row from a refused stream.
+    assert await _count(db, Message) == 1
+
+
+async def test_a_thread_with_nothing_in_it_gets_no_reply(stage) -> None:
+    """There is nothing to answer, and inventing one would be the agent talking first."""
+    from api.models import Conversation as Thread
+
+    http, paths, db = stage
+    empty = Thread(
+        workspace_id=1,
+        channel_id=1,
+        direction="inbound",
+        external_id="empty-thread-handle-000000",
+        handling="ai",
+        status="open",
+    )
+    db.add(empty)
+    await db.commit()
+
+    answer = await http.get(
+        f"/public/chat/{paths['ours']}/stream",
+        params={"conversation": "empty-thread-handle-000000"},
+        headers={"Origin": ALLOWED},
+    )
+    assert answer.status_code == 403
+
+
+async def test_the_stream_works_without_an_origin_header(stage) -> None:
+    """The browser found this one, and no test could have.
+
+    `EventSource` issues a GET, and a browser sends no `Origin` on a same-origin GET -
+    so the widget's own reply stream arrives with no header at all. The first version
+    refused it as "no Origin header" and the chat replied to nobody. httpx sends
+    whatever a test tells it to, which is exactly why every test passed.
+
+    A header that *is* present is still checked; the test above covers that.
+    """
+    http, paths, _ = stage
+    first = (
+        await http.post(
+            f"/public/chat/{paths['ours']}/messages",
+            json={"text": "hello"},
+            headers={"Origin": ALLOWED},
+        )
+    ).json()
+
+    answer = await http.get(
+        f"/public/chat/{paths['ours']}/stream",
+        params={"conversation": first["conversation"]},
+        # No Origin, deliberately.
+    )
+    assert answer.status_code == 200
+    assert [event for event in _events(answer.text) if "delta" in event]
+
+
+async def test_a_handle_from_another_channel_gets_no_stream(stage) -> None:
+    """What guards the stream instead of the header: the handle is the capability."""
+    http, paths, _ = stage
+    ours = (
+        await http.post(
+            f"/public/chat/{paths['ours']}/messages",
+            json={"text": "hello"},
+            headers={"Origin": ALLOWED},
+        )
+    ).json()
+
+    answer = await http.get(
+        f"/public/chat/{paths['theirs']}/stream",
+        params={"conversation": ours["conversation"]},
+    )
+    assert answer.status_code == 403


### PR DESCRIPTION
Milestone 0 **step 2** — *"it replies with a hardcoded greeting"* — built in the shape step 5 needs, because Rule 3 says the other shape can never be fixed.

## Why an iterator for a hardcoded string

An agent that composes a whole answer and then sends it leaves a caller listening to silence and then a paragraph. That is not something to retrofit at Milestone 11: every interface above it would have been written against a signature that returns one finished string.

So `agent/reply.py` is an async iterator from its first line, and what it yields today is a greeting nobody had to generate. **Step 3 replaces its body with a model call and nothing above it changes.**

Cancellation comes free from the same choice: a visitor who closes the tab stops the consumer, the generator's `finally` runs, no further tokens are produced, and nothing is stored. That is what Rule 3 means by `cancel()` not being optional — in the only shape that survives being added later.

**Stored whole, at the end.** A half-written reply in the archive is indistinguishable from one the agent actually gave, and the transcript is what somebody reads back to find out what a customer was told.

**`X-Accel-Buffering: no`**, because a proxy that buffers the stream delivers it all at once — the failure Rule 3 exists to prevent, arriving from outside the application.

## The bug the browser found, which no test could have

`EventSource` issues a **GET**, and a browser sends no `Origin` header on a same-origin GET. The stream refused it as *"no Origin header"*: the widget posted a message, opened the stream, and got a **403**. The chat replied to nobody.

Every test passed — because httpx sends whatever a test tells it to.

The check now takes `require_header`, false on the stream. Not a weakening: a header that *is* present is still checked, and what guards the request instead is the **thread handle** — random, per conversation, scoped to its channel, and issued only to somebody who already passed every check on the message that created it. A capability, which is the right shape for a stream a page opens about its own conversation. Two tests pin it.

## Verification

- 5 new tests; **572 pass**. `ruff` clean
- `curl -N` shows the events arriving one at a time
- **In the browser**: the reply grew **0 → 25 → 53 → 96 → 123** characters across 300 ms samples, so it is visibly streaming rather than appearing whole. Screenshot-confirmed as a working chat: question in a violet bubble, answer filling in beside it