### PR TITLE
Show the real channels, and let the sidebar collapse

### DIFF
--- a/locales/ar/shell.json
+++ b/locales/ar/shell.json
@@ -1,5 +1,9 @@
 {
   "account_menu": "الحساب ومساحة العمل",
+  "channel_email": "البريد الإلكتروني",
+  "channel_phone": "الهاتف",
+  "channel_sms": "الرسائل النصية",
+  "channel_web": "دردشة الويب",
   "expand_children": "إظهار العناصر الفرعية",
   "group_overview": "نظرة عامة",
   "nav_archive": "أرشيف المكالمات",

--- a/locales/ar/shell.json
+++ b/locales/ar/shell.json
@@ -20,6 +20,8 @@
   "nav_notifications": "الإشعارات",
   "on_the_line_many": "{count} مكالمات على الخط",
   "on_the_line_one": "مكالمة واحدة على الخط",
+  "rail_collapse": "طيّ الشريط الجانبي",
+  "rail_expand": "إبقاء الشريط الجانبي مفتوحًا",
   "role_admin": "مدير",
   "role_invited": "مدعو",
   "role_owner": "المالك",

--- a/locales/de/shell.json
+++ b/locales/de/shell.json
@@ -20,6 +20,8 @@
   "nav_notifications": "Benachrichtigungen",
   "on_the_line_many": "{count} Anrufe in der Leitung",
   "on_the_line_one": "1 Anruf in der Leitung",
+  "rail_collapse": "Seitenleiste einklappen",
+  "rail_expand": "Seitenleiste offen halten",
   "role_admin": "Admin",
   "role_invited": "Eingeladen",
   "role_owner": "Inhaber",

--- a/locales/de/shell.json
+++ b/locales/de/shell.json
@@ -1,5 +1,9 @@
 {
   "account_menu": "Konto und Arbeitsbereich",
+  "channel_email": "E-Mail",
+  "channel_phone": "Telefon",
+  "channel_sms": "SMS",
+  "channel_web": "Web-Chat",
   "expand_children": "Untereinträge anzeigen",
   "group_overview": "Übersicht",
   "nav_archive": "Anrufarchiv",

--- a/locales/en/shell.json
+++ b/locales/en/shell.json
@@ -20,6 +20,8 @@
   "nav_notifications": "Notifications",
   "on_the_line_many": "{count} calls on the line",
   "on_the_line_one": "1 call on the line",
+  "rail_collapse": "Collapse the sidebar",
+  "rail_expand": "Keep the sidebar open",
   "role_admin": "Admin",
   "role_invited": "Invited",
   "role_owner": "Owner",

--- a/locales/en/shell.json
+++ b/locales/en/shell.json
@@ -1,5 +1,9 @@
 {
   "account_menu": "Account and workspace",
+  "channel_email": "Email",
+  "channel_phone": "Phone",
+  "channel_sms": "SMS",
+  "channel_web": "Web chat",
   "expand_children": "Show sub-items",
   "group_overview": "Overview",
   "nav_archive": "Call archive",

--- a/web/app/[locale]/apps/apps.tsx
+++ b/web/app/[locale]/apps/apps.tsx
@@ -96,8 +96,8 @@ export function Apps({ locale, t }: { locale: Locale; t: AppsDictionary }) {
     .filter((section) => section.apps.length > 0);
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="settings" />
       </div>
 

--- a/web/app/[locale]/assistants/[id]/editor.tsx
+++ b/web/app/[locale]/assistants/[id]/editor.tsx
@@ -125,8 +125,8 @@ export function AssistantEditor({
   const meta = PANEL_META[panel];
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="assistants" />
       </div>
 

--- a/web/app/[locale]/assistants/assistants.tsx
+++ b/web/app/[locale]/assistants/assistants.tsx
@@ -100,8 +100,8 @@ export function Assistants({ locale, t }: { locale: Locale; t: AssistantsDiction
     : all;
 
   return (
-    <div className="bg-od-canvas text-od-text-3 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-3 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="assistants" />
       </div>
 

--- a/web/app/[locale]/backup/backup.tsx
+++ b/web/app/[locale]/backup/backup.tsx
@@ -581,8 +581,8 @@ function RestoreDialog({
 
 function Frame({ locale, children }: { locale: Locale; children: React.ReactNode }) {
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="settings" liveCalls={0} />
       </div>
       <div className="mx-auto max-w-[1000px] p-[26px_28px_80px]">{children}</div>

--- a/web/app/[locale]/calendar/calendar.tsx
+++ b/web/app/[locale]/calendar/calendar.tsx
@@ -189,8 +189,8 @@ export function Calendar({ locale, t }: { locale: Locale; t: CalendarDictionary 
   const nowRow = toRow("11:15");
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="calendar" />
       </div>
 

--- a/web/app/[locale]/calls/[id]/call-detail.tsx
+++ b/web/app/[locale]/calls/[id]/call-detail.tsx
@@ -78,8 +78,8 @@ export function CallDetail({
   const thread = useResource<ThreadDetail>(() => conversationDetail(id), [id]);
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="calls" />
       </div>
 

--- a/web/app/[locale]/calls/calls-list.tsx
+++ b/web/app/[locale]/calls/calls-list.tsx
@@ -99,8 +99,8 @@ export function CallsList({ locale, t }: { locale: Locale; t: CallsDictionary })
   };
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="calls" />
       </div>
 

--- a/web/app/[locale]/campaigns/campaigns.tsx
+++ b/web/app/[locale]/campaigns/campaigns.tsx
@@ -185,8 +185,8 @@ export function Campaigns({ locale, t }: { locale: Locale; t: CampaignsDictionar
   const showBody = state === "default" || empty || offline;
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="campaigns" />
       </div>
 

--- a/web/app/[locale]/catalogue/catalogue.tsx
+++ b/web/app/[locale]/catalogue/catalogue.tsx
@@ -159,8 +159,8 @@ export function Catalogue({ locale, t }: { locale: Locale; t: CatalogueDictionar
   }
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="settings" />
       </div>
 

--- a/web/app/[locale]/connectors/connectors.tsx
+++ b/web/app/[locale]/connectors/connectors.tsx
@@ -107,8 +107,8 @@ export function Connectors({ locale, t }: { locale: Locale; t: ConnectorsDiction
     setOff((current) => ({ ...current, [`${connectorId}.${tool.name}`]: !isOn(connectorId, tool) }));
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="settings" />
       </div>
 

--- a/web/app/[locale]/consent/consent.tsx
+++ b/web/app/[locale]/consent/consent.tsx
@@ -89,8 +89,8 @@ export function Consent({ locale, t }: { locale: Locale; t: ConsentDictionary })
   const hasRows = !empty && shown.length > 0;
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="consent" />
       </div>
 

--- a/web/app/[locale]/contacts/contacts.tsx
+++ b/web/app/[locale]/contacts/contacts.tsx
@@ -114,8 +114,8 @@ export function Contacts({ locale, t }: { locale: Locale; t: ContactsDictionary 
   };
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="contacts" />
       </div>
 

--- a/web/app/[locale]/conversations/conversations.tsx
+++ b/web/app/[locale]/conversations/conversations.tsx
@@ -179,8 +179,8 @@ export function Conversations({
   };
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="conversations" />
       </div>
 

--- a/web/app/[locale]/health/health.tsx
+++ b/web/app/[locale]/health/health.tsx
@@ -449,8 +449,8 @@ export function Health({ locale, t }: { locale: Locale; t: HealthDictionary }) {
 
 function Frame({ locale, children }: { locale: Locale; children: React.ReactNode }) {
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="settings" liveCalls={0} />
       </div>
       <div className="mx-auto max-w-[1080px] p-[26px_28px_80px]">{children}</div>

--- a/web/app/[locale]/home/home.tsx
+++ b/web/app/[locale]/home/home.tsx
@@ -114,8 +114,8 @@ export function Home({ locale, t }: { locale: Locale; t: HomeDictionary }) {
   const waiting = summary.data?.waiting ?? 0;
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="home" />
       </div>
 

--- a/web/app/[locale]/knowledge/knowledge.tsx
+++ b/web/app/[locale]/knowledge/knowledge.tsx
@@ -78,8 +78,8 @@ export function Knowledge({ locale, t }: { locale: Locale; t: KnowledgeDictionar
   };
 
   return (
-    <div className="bg-od-canvas text-od-text-3 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-3 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="knowledge" />
       </div>
 

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -16,8 +16,12 @@ export const metadata: Metadata = {
   description: "An agent that answers, on every channel.",
 };
 
-/** Applied before first paint so a light-theme user never sees a dark flash. */
-const THEME_SCRIPT = `try{if(localStorage.getItem("od-theme")==="light")document.documentElement.setAttribute("data-od-theme","light")}catch(e){}`;
+/**
+ * Applied before first paint, so a light-theme user never sees a dark flash and a
+ * reader who collapsed the sidebar never sees it wide for a frame and the page jump
+ * as it narrows. Both are attributes on `<html>`; the CSS does the rest.
+ */
+const SHELL_SCRIPT = `try{var d=document.documentElement;if(localStorage.getItem("od-theme")==="light")d.setAttribute("data-od-theme","light");if(localStorage.getItem("od-rail")==="on")d.setAttribute("data-od-rail","on")}catch(e){}`;
 
 export function generateStaticParams() {
   return LOCALES.map((locale) => ({ locale }));
@@ -45,7 +49,7 @@ export default async function LocaleLayout({
       suppressHydrationWarning
     >
       <head>
-        <script dangerouslySetInnerHTML={{ __html: THEME_SCRIPT }} />
+        <script dangerouslySetInnerHTML={{ __html: SHELL_SCRIPT }} />
       </head>
       <body
         className={cn(

--- a/web/app/[locale]/live/live-call.tsx
+++ b/web/app/[locale]/live/live-call.tsx
@@ -185,8 +185,8 @@ export function LiveCall({ locale, t }: { locale: Locale; t: LiveDictionary }) {
   const dutyLine = inCall ? t[open.duty] : offline ? t.duty_offline : t.duty_idle;
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="live" liveCalls={hasLive ? alive.length : 0} />
       </div>
 

--- a/web/app/[locale]/notifications/notifications.tsx
+++ b/web/app/[locale]/notifications/notifications.tsx
@@ -444,8 +444,8 @@ function Head({
 
 function Frame({ locale, children }: { locale: Locale; children: React.ReactNode }) {
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="notifications" />
       </div>
       <div className="mx-auto max-w-[1000px] p-[26px_28px_80px]">{children}</div>

--- a/web/app/[locale]/numbers/numbers.tsx
+++ b/web/app/[locale]/numbers/numbers.tsx
@@ -87,8 +87,8 @@ export function Numbers({ locale, t }: { locale: Locale; t: NumbersDictionary })
   };
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="numbers" />
       </div>
 

--- a/web/app/[locale]/rules/routing-rules.tsx
+++ b/web/app/[locale]/rules/routing-rules.tsx
@@ -131,8 +131,8 @@ export function RoutingRules({ locale, t }: { locale: Locale; t: RulesDictionary
   };
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="settings" />
       </div>
 

--- a/web/app/[locale]/settings/settings.tsx
+++ b/web/app/[locale]/settings/settings.tsx
@@ -213,8 +213,8 @@ export function Settings({ locale, t }: { locale: Locale; t: SettingsDictionary 
   const section = SECTIONS[tab as keyof typeof SECTIONS];
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="settings" />
       </div>
 

--- a/web/app/[locale]/update/update.tsx
+++ b/web/app/[locale]/update/update.tsx
@@ -154,8 +154,8 @@ export function Update({ locale, t }: { locale: Locale; t: UpdateDictionary }) {
   const changes = security ? SECURITY_CHANGES : CHANGES;
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="settings" liveCalls={0} />
       </div>
 

--- a/web/app/[locale]/usage/usage.tsx
+++ b/web/app/[locale]/usage/usage.tsx
@@ -86,8 +86,8 @@ export function Usage({ locale, t }: { locale: Locale; t: UsageDictionary }) {
   ];
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="settings" />
       </div>
 

--- a/web/app/[locale]/workspaces/new/new-workspace.tsx
+++ b/web/app/[locale]/workspaces/new/new-workspace.tsx
@@ -85,8 +85,8 @@ export function NewWorkspace({ locale, t }: { locale: Locale; t: NewWorkspaceDic
         : interpolate(t.access_team_note, { count: copied });
 
   return (
-    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[224px]">
-      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[224px]">
+    <div className="bg-od-canvas text-od-text-2 min-h-dvh text-[14px] leading-[1.45] ps-[var(--od-shell-w)]">
+      <div className="fixed inset-y-0 start-0 z-50 h-dvh w-[var(--od-shell-w)]">
         <Sidebar locale={locale} active="settings" />
       </div>
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -160,6 +160,49 @@ html[data-od-theme="light"] {
   }
 }
 
+/* The shell's rail.
+
+   `--od-shell-w` is the space every screen leaves for the sidebar, so collapsing it
+   is one attribute on `<html>` rather than an edit to twenty-four screens. The
+   sidebar itself widens back to the open width while it is pointed at or tabbed
+   through, and overflows its own column to do it - a peek lies over the page instead
+   of pushing it sideways, in both directions. */
+:root {
+    --od-shell-open: 224px;
+    --od-shell-rail: 56px;
+    --od-shell-w: var(--od-shell-open);
+}
+:root[data-od-rail="on"] {
+    --od-shell-w: var(--od-shell-rail);
+}
+
+.od-rail {
+    width: var(--od-shell-w);
+    transition: width .14s ease;
+}
+:root[data-od-rail="on"] .od-rail:hover,
+:root[data-od-rail="on"] .od-rail:focus-within {
+    width: var(--od-shell-open);
+    /* A peek covers the page rather than moving it, so it needs an edge to sit on. */
+    box-shadow: 0 0 44px var(--od-scrim-3);
+}
+
+/* Collapsed: the rail is on and nobody is pointing at or tabbing through it. Only
+   the icons survive; `.od-rail-narrow` is the mark that stands in for the wordmark. */
+:root[data-od-rail="on"] .od-rail:not(:hover):not(:focus-within) .od-rail-wide {
+    display: none;
+}
+:root[data-od-rail="on"] .od-rail:not(:hover):not(:focus-within) .od-rail-narrow {
+    display: inline-flex;
+}
+:root[data-od-rail="on"] .od-rail:not(:hover):not(:focus-within) .od-rail-row {
+    justify-content: center;
+    padding-inline: 0;
+}
+.od-rail-narrow {
+    display: none;
+}
+
 /* Animations used by the ported screens. */
 @keyframes od-ring {
   0% { box-shadow: 0 0 0 0 rgba(240, 96, 94, .55); }

--- a/web/components/shell/icons.tsx
+++ b/web/components/shell/icons.tsx
@@ -12,6 +12,9 @@ const PATHS: Record<string, string> = {
   bot: "M6 8h12v9H6V8Z M9.5 12v1.5 M14.5 12v1.5 M12 5v3 M3.5 11.5v3 M20.5 11.5v3",
   bell: "M6 9a6 6 0 0 1 12 0c0 4 1.5 5.5 1.5 5.5h-15S6 13 6 9Z M10 18.5a2 2 0 0 0 4 0",
   book: "M4 5h6a2 2 0 0 1 2 2v12a2 2 0 0 0-2-2H4V5Z M20 5h-6a2 2 0 0 0-2 2v12a2 2 0 0 1 2-2h6V5Z",
+  // The sidebar toggle. A panel with its rail drawn in, and no arrow: an arrow would
+  // point the wrong way the moment the interface is read right to left.
+  panel: "M4 5h16v14H4V5Z M9.5 5v14",
 };
 
 export function NavIcon({ name, color }: { name: string; color: string }) {

--- a/web/components/shell/sidebar.tsx
+++ b/web/components/shell/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import type { Route } from "next";
 import Link from "next/link";
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore, type MouseEvent } from "react";
 
 import ar from "../../../locales/ar/shell.json";
 import de from "../../../locales/de/shell.json";
@@ -43,6 +43,31 @@ function readTheme(): "dark" | "light" {
 /** What the server renders, and what hydration matches against. */
 function darkTheme(): "dark" {
   return "dark";
+}
+
+/**
+ * Whether the sidebar is collapsed to a rail of icons, kept on `<html data-od-rail>`
+ * for the same reason the theme is: the inline script in the locale layout sets it
+ * before first paint, so the page never renders wide and then narrows.
+ *
+ * Only the toggle's own wording is read from here. The width, and what a collapsed
+ * rail hides, are CSS in `globals.css` - hovering it must widen it without React
+ * hearing about the mouse at all.
+ */
+const RAIL_EVENT = "od-rail-change";
+
+function subscribeRail(onChange: () => void) {
+  addEventListener(RAIL_EVENT, onChange);
+  return () => removeEventListener(RAIL_EVENT, onChange);
+}
+
+function readRail(): boolean {
+  return document.documentElement.getAttribute("data-od-rail") === "on";
+}
+
+/** The server renders the sidebar open, and hydration matches that. */
+function railOpen(): false {
+  return false;
 }
 
 /**
@@ -164,6 +189,7 @@ export function Sidebar({
 }) {
   const t = pickDictionary<ShellDictionary>(locale, DICTIONARIES);
   const theme = useSyncExternalStore(subscribeTheme, readTheme, darkTheme);
+  const rail = useSyncExternalStore(subscribeRail, readRail, railOpen);
   const [open, setOpen] = useState<string | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -215,6 +241,23 @@ export function Sidebar({
     window.location.assign(`/${locale}/login`);
   }
 
+  function toggleRail(event: MouseEvent<HTMLButtonElement>) {
+    const next = !rail;
+    const root = document.documentElement;
+    if (next) root.setAttribute("data-od-rail", "on");
+    else root.removeAttribute("data-od-rail");
+    try {
+      localStorage.setItem("od-rail", next ? "on" : "off");
+    } catch {
+      // A browser with storage disabled still collapses, it just does not remember.
+    }
+    // The button keeps focus after a click, and focus is what holds a rail open for
+    // somebody reading by keyboard - so without this the collapse would not be
+    // visible until the next click landed somewhere else.
+    event.currentTarget.blur();
+    dispatchEvent(new Event(RAIL_EVENT));
+  }
+
   function toggleTheme() {
     const next = theme === "dark" ? "light" : "dark";
     const root = document.documentElement;
@@ -238,27 +281,47 @@ export function Sidebar({
     <>
       <IncomingCall locale={locale} enabled={incomingCall} />
 
-      <div className="bg-od-canvas-2 text-od-text border-od-border flex h-full flex-col gap-5 border-e p-[18px_12px] text-[14px] leading-[1.45]">
-        <div className="flex items-center justify-between gap-2 p-[4px_11px]">
-          <Link href={href("/home")} className="text-od-text flex items-baseline gap-2 hover:no-underline">
-            <span className="font-semibold tracking-[-0.01em]">Tel-Agent</span>
-            <span className="mono ltr-data text-od-faint text-[11px]">v1.4.2</span>
-          </Link>
-          <button
-            type="button"
-            onClick={toggleTheme}
-            title={theme === "dark" ? t.theme_to_light : t.theme_to_dark}
-            aria-label={theme === "dark" ? t.theme_to_light : t.theme_to_dark}
-            className="border-od-border-2 bg-od-panel text-od-muted-4 hover:bg-od-raise hover:text-od-text inline-flex size-[26px] flex-none cursor-pointer items-center justify-center rounded-[7px] border text-[13px] leading-none"
+      <div className="od-rail bg-od-canvas-2 text-od-text border-od-border flex h-full flex-col gap-5 border-e p-[18px_12px] text-[14px] leading-[1.45]">
+        <div className="od-rail-row flex items-center justify-between gap-2 p-[4px_11px]">
+          <Link
+            href={href("/home")}
+            className="text-od-text flex items-baseline gap-2 whitespace-nowrap hover:no-underline"
           >
-            {theme === "dark" ? "☀" : "☾"}
-          </button>
+            {/* The wordmark does not fit a rail of icons; the mark stands in for it,
+                and is the one thing that appears only while the rail is collapsed. */}
+            <span className="od-rail-narrow border-od-border-2 bg-od-panel size-[26px] items-center justify-center rounded-[7px] border text-[12px] font-semibold">
+              T
+            </span>
+            <span className="od-rail-wide font-semibold tracking-[-0.01em]">Tel-Agent</span>
+            <span className="mono ltr-data text-od-faint od-rail-wide text-[11px]">v1.4.2</span>
+          </Link>
+          <div className="od-rail-wide flex flex-none items-center gap-[6px]">
+            <button
+              type="button"
+              onClick={toggleTheme}
+              title={theme === "dark" ? t.theme_to_light : t.theme_to_dark}
+              aria-label={theme === "dark" ? t.theme_to_light : t.theme_to_dark}
+              className="border-od-border-2 bg-od-panel text-od-muted-4 hover:bg-od-raise hover:text-od-text inline-flex size-[26px] flex-none cursor-pointer items-center justify-center rounded-[7px] border text-[13px] leading-none"
+            >
+              {theme === "dark" ? "☀" : "☾"}
+            </button>
+            <button
+              type="button"
+              onClick={toggleRail}
+              title={rail ? t.rail_expand : t.rail_collapse}
+              aria-label={rail ? t.rail_expand : t.rail_collapse}
+              aria-pressed={rail}
+              className="border-od-border-2 bg-od-panel text-od-muted-4 hover:bg-od-raise hover:text-od-text inline-flex size-[26px] flex-none cursor-pointer items-center justify-center rounded-[7px] border leading-none"
+            >
+              <NavIcon name="panel" color="currentColor" />
+            </button>
+          </div>
         </div>
 
         <nav className="flex min-h-0 flex-[1_1_auto] flex-col gap-[18px] overflow-auto">
           {nav.map((group) => (
             <div key={group.label} className="flex flex-col gap-[2px]">
-              <div className="p-[0_11px_6px] text-[10.5px] tracking-[.1em] uppercase text-[color:var(--od-faint-5)]">
+              <div className="od-rail-wide p-[0_11px_6px] text-[10.5px] tracking-[.1em] uppercase text-[color:var(--od-faint-5)]">
                 {t[group.label]}
               </div>
               {group.items.map((item) => {
@@ -273,7 +336,7 @@ export function Sidebar({
                     <div className="flex items-center gap-[2px]">
                       <Link
                         href={href(item.href)}
-                        className={`hover:bg-od-raise hover:text-od-text-2 flex min-w-0 flex-[1_1_auto] items-center gap-[10px] rounded-[7px] p-[8px_11px] hover:no-underline ${
+                        className={`od-rail-row hover:bg-od-raise hover:text-od-text-2 flex min-w-0 flex-[1_1_auto] items-center gap-[10px] rounded-[7px] p-[8px_11px] hover:no-underline ${
                           on ? "bg-[var(--od-raise-7)] text-od-text font-medium" : "text-od-muted-4"
                         }`}
                       >
@@ -283,14 +346,14 @@ export function Sidebar({
                             color={on ? "var(--od-text)" : "var(--od-faint-2)"}
                           />
                         </span>
-                        <span>{t[item.label]}</span>
+                        <span className="od-rail-wide">{t[item.label]}</span>
                       </Link>
                       {item.kids ? (
                         <button
                           type="button"
                           onClick={() => setOpen(open === item.id ? "__none" : item.id)}
                           aria-label={t.expand_children}
-                          className="text-od-faint-2 hover:bg-od-raise hover:text-od-text-2 inline-flex h-[30px] w-6 flex-none cursor-pointer items-center justify-center rounded-md border-none bg-transparent text-[12px] leading-none"
+                          className="od-rail-wide text-od-faint-2 hover:bg-od-raise hover:text-od-text-2 inline-flex h-[30px] w-6 flex-none cursor-pointer items-center justify-center rounded-md border-none bg-transparent text-[12px] leading-none"
                         >
                           {expanded ? "⌄" : "›"}
                         </button>
@@ -298,7 +361,7 @@ export function Sidebar({
                     </div>
 
                     {item.kids && expanded ? (
-                      <div className="my-[3px] flex flex-col gap-px ps-[21px]">
+                      <div className="od-rail-wide my-[3px] flex flex-col gap-px ps-[21px]">
                         {item.kids.map((kid) => {
                           const id = kidId(kid);
                           // Only the live row carries a number, and only when
@@ -347,13 +410,13 @@ export function Sidebar({
           {liveCalls > 0 && active !== "live" ? (
             <Link
               href={href("/live")}
-              className="text-od-text-2 hover:bg-od-raise flex items-center gap-[9px] rounded-[9px] border border-[color:var(--od-violet-border)] bg-[var(--od-canvas-violet)] p-[9px_11px] text-[13px] font-medium hover:no-underline"
+              className="od-rail-row text-od-text-2 hover:bg-od-raise flex items-center gap-[9px] rounded-[9px] border border-[color:var(--od-violet-border)] bg-[var(--od-canvas-violet)] p-[9px_11px] text-[13px] font-medium hover:no-underline"
             >
               <span
                 className="size-2 flex-none rounded-full bg-[color:var(--od-violet)]"
                 style={{ animation: "od-ring-violet 1.8s ease-out infinite" }}
               />
-              <span className="min-w-0">
+              <span className="od-rail-wide min-w-0">
                 {liveCalls === 1
                   ? t.on_the_line_one
                   : interpolate(t.on_the_line_many, { count: liveCalls })}
@@ -438,14 +501,14 @@ export function Sidebar({
               type="button"
               onClick={() => setMenuOpen((value) => !value)}
               aria-label={t.account_menu}
-              className={`flex w-full cursor-pointer items-center gap-[9px] rounded-[7px] border-none p-[8px_11px] ${
+              className={`od-rail-row flex w-full cursor-pointer items-center gap-[9px] rounded-[7px] border-none p-[8px_11px] ${
                 menuOpen ? "bg-od-raise" : "bg-transparent"
               }`}
             >
               <span className="border-od-border-9 text-od-text-2 inline-flex size-[26px] flex-none items-center justify-center rounded-full border bg-[var(--od-raise-5)] text-[11.5px] font-semibold">
                 {me.data?.username.slice(0, 1).toUpperCase() ?? "·"}
               </span>
-              <span className="min-w-0 flex-[1_1_auto] text-start">
+              <span className="od-rail-wide min-w-0 flex-[1_1_auto] text-start">
                 <span className="text-od-text-2 block text-[13px]">
                   {me.data?.username ?? "…"}
                 </span>
@@ -453,7 +516,9 @@ export function Sidebar({
                   <span className="text-od-faint block text-[11.5px]">{current.name}</span>
                 ) : null}
               </span>
-              <span className="text-od-faint-2 flex-none text-[10px]">{menuOpen ? "⌄" : "›"}</span>
+              <span className="od-rail-wide text-od-faint-2 flex-none text-[10px]">
+                {menuOpen ? "⌄" : "›"}
+              </span>
             </button>
           </div>
         </div>

--- a/web/components/shell/sidebar.tsx
+++ b/web/components/shell/sidebar.tsx
@@ -10,7 +10,13 @@ import en from "../../../locales/en/shell.json";
 
 import { NavIcon } from "@/components/shell/icons";
 import { IncomingCall } from "@/components/shell/incoming-call";
-import { currentUser, signOut, type Me } from "@/lib/api";
+import {
+  conversationChannels,
+  currentUser,
+  signOut,
+  type ConversationChannel,
+  type Me,
+} from "@/lib/api";
 import { interpolate, pickDictionary } from "@/lib/i18n";
 import type { Locale } from "@/lib/locales";
 import { useResource } from "@/lib/use-resource";
@@ -57,7 +63,6 @@ type Kid = {
   label?: LabelKey;
   name?: string;
   href?: string;
-  count?: number;
   live?: boolean;
   tone: Tone;
 };
@@ -70,52 +75,68 @@ const TONES: Record<Tone, string> = {
   grey: "var(--od-stroke-5)",
 };
 
-/** Channel names - WhatsApp, Telegram - are product names and are never translated. */
-const CHANNELS: { id: string; name: string; count: number; tone: Tone }[] = [
-  { id: "whatsapp", name: "WhatsApp", count: 3, tone: "green" },
-  { id: "telegram", name: "Telegram", count: 1, tone: "grey" },
-  { id: "sms", name: "SMS", count: 1, tone: "grey" },
-  { id: "web chat", name: "Web chat", count: 1, tone: "grey" },
-];
+/** The product's own names for the channels that are not a company. */
+const CHANNEL_LABEL_KEYS: Record<string, LabelKey> = {
+  web: "channel_web",
+  phone: "channel_phone",
+  sms: "channel_sms",
+  email: "channel_email",
+};
 
-const NAV: { label: LabelKey; items: Item[] }[] = [
-  {
-    label: "group_overview",
-    items: [
-      { id: "home", label: "nav_home", href: "/home", icon: "home" },
-      {
-        id: "calls",
-        label: "nav_calls",
-        href: "/calls",
-        icon: "phone",
-        kids: [
-          { id: "live", label: "nav_live", href: "/live", live: true, tone: "violet" },
-          { id: "archive", label: "nav_archive", href: "/calls", tone: "grey" },
-          { id: "campaigns", label: "nav_campaigns", href: "/campaigns", tone: "violet" },
-          { id: "consent", label: "nav_consent", href: "/consent", tone: "grey" },
-        ],
-      },
-      {
-        id: "conversations",
-        label: "nav_channels",
-        href: "/conversations",
-        icon: "message",
-        kids: CHANNELS.map((channel) => ({
-          id: channel.id,
-          name: channel.name,
-          count: channel.count,
-          tone: channel.tone,
-        })),
-      },
-      { id: "notifications", label: "nav_notifications", href: "/notifications", icon: "bell" },
-      { id: "calendar", label: "nav_calendar", href: "/calendar", icon: "calendar" },
-      { id: "contacts", label: "nav_contacts", href: "/contacts", icon: "users" },
-      { id: "assistants", label: "nav_assistants", href: "/assistants", icon: "bot" },
-      // Next to the assistant, because it is the assistant's reading.
-      { id: "knowledge", label: "nav_knowledge", href: "/knowledge", icon: "book" },
-    ],
-  },
-];
+/** WhatsApp is the one channel with a colour of its own; every other row is quiet. */
+const CHANNEL_TONE: Record<string, Tone> = { whatsapp: "green" };
+
+/**
+ * What one channel row is called, in the reader's language.
+ *
+ * A kind the core names has a key. Anything else - a community channel - is shown as
+ * the server named it, capitalised, rather than being dropped from the list.
+ */
+function channelName(t: ShellDictionary, channel: ConversationChannel): string {
+  const key = CHANNEL_LABEL_KEYS[channel.kind];
+  if (key) return t[key];
+  return channel.name ?? channel.kind.charAt(0).toUpperCase() + channel.kind.slice(1);
+}
+
+/** The nav, given the channels this workspace actually has. */
+function navigation(channels: Kid[]): { label: LabelKey; items: Item[] }[] {
+  return [
+    {
+      label: "group_overview",
+      items: [
+        { id: "home", label: "nav_home", href: "/home", icon: "home" },
+        {
+          id: "calls",
+          label: "nav_calls",
+          href: "/calls",
+          icon: "phone",
+          kids: [
+            { id: "live", label: "nav_live", href: "/live", live: true, tone: "violet" },
+            { id: "archive", label: "nav_archive", href: "/calls", tone: "grey" },
+            { id: "campaigns", label: "nav_campaigns", href: "/campaigns", tone: "violet" },
+            { id: "consent", label: "nav_consent", href: "/consent", tone: "grey" },
+          ],
+        },
+        {
+          id: "conversations",
+          label: "nav_channels",
+          href: "/conversations",
+          icon: "message",
+          // Only the channels the workspace has used. Nothing at all while the list
+          // is loading, or if it could not be fetched - the Channels row above still
+          // leads to the screen that says so properly.
+          kids: channels.length > 0 ? channels : undefined,
+        },
+        { id: "notifications", label: "nav_notifications", href: "/notifications", icon: "bell" },
+        { id: "calendar", label: "nav_calendar", href: "/calendar", icon: "calendar" },
+        { id: "contacts", label: "nav_contacts", href: "/contacts", icon: "users" },
+        { id: "assistants", label: "nav_assistants", href: "/assistants", icon: "bot" },
+        // Next to the assistant, because it is the assistant's reading.
+        { id: "knowledge", label: "nav_knowledge", href: "/knowledge", icon: "book" },
+      ],
+    },
+  ];
+}
 
 /** The note under each workspace in the switcher: the reader's role there. */
 const ROLE_KEY: Record<string, LabelKey> = {
@@ -150,6 +171,18 @@ export function Sidebar({
   // The shell renders on every screen, so this is one request per page, answered
   // from the same session cookie every other call already carries.
   const me = useResource<Me>(() => currentUser());
+
+  // The channel rows underneath "Channels" — the channels this workspace has
+  // conversations on, which is the only list that is true. They carry no number:
+  // the endpoint counts every conversation a channel has ever held, and a lifetime
+  // total in a sidebar badge reads as "waiting for you", which it is not.
+  const channels = useResource<ConversationChannel[]>(() => conversationChannels());
+  const channelKids: Kid[] = (channels.data ?? []).map((channel) => ({
+    id: channel.kind,
+    name: channelName(t, channel),
+    tone: CHANNEL_TONE[channel.kind] ?? "grey",
+  }));
+  const nav = navigation(channelKids);
   const workspaces = me.data?.workspaces ?? [];
   const storedId = me.data === null ? null : activeWorkspaceId();
   const current = workspaces.find((entry) => entry.id === storedId) ?? workspaces[0] ?? null;
@@ -223,7 +256,7 @@ export function Sidebar({
         </div>
 
         <nav className="flex min-h-0 flex-[1_1_auto] flex-col gap-[18px] overflow-auto">
-          {NAV.map((group) => (
+          {nav.map((group) => (
             <div key={group.label} className="flex flex-col gap-[2px]">
               <div className="p-[0_11px_6px] text-[10.5px] tracking-[.1em] uppercase text-[color:var(--od-faint-5)]">
                 {t[group.label]}
@@ -268,7 +301,9 @@ export function Sidebar({
                       <div className="my-[3px] flex flex-col gap-px ps-[21px]">
                         {item.kids.map((kid) => {
                           const id = kidId(kid);
-                          const count = kid.live ? liveCalls || null : (kid.count ?? null);
+                          // Only the live row carries a number, and only when
+                          // there is one to carry.
+                          const count = kid.live ? liveCalls || null : null;
                           return (
                             <Link
                               key={id}


### PR DESCRIPTION
Two changes to the shell sidebar, which every screen in the product renders.

**The channel list is real.** It listed four channels with invented unread counts — WhatsApp, Telegram, SMS and web chat — none of which exist except web chat. It now reads the workspace's own channels from `GET /api/conversations/meta/channels`. The rows carry no number: that endpoint counts every conversation a channel has ever held, and a lifetime total in a sidebar badge reads as work waiting for the reader, which it is not. The fetch degrades to nothing — while it loads, and if it fails or the browser is offline, the Channels row simply has no children rather than an error taking the screen down with it.

**The sidebar collapses to a rail.** A button in its header collapses it from 224px to a 56px rail of icons, and the choice is remembered: the inline script in the locale layout applies it before first paint. Pointing at a collapsed rail — or tabbing into it — brings the whole sidebar back over the page, so the labels are one hover away and nothing underneath moves. That is CSS on `:hover` and `:focus-within` rather than React state, because the width has to answer the mouse before a render could. The width itself is now `--od-shell-w`, which is why twenty-four screens are in the diff: each was holding the number 224 in two Tailwind classes.

Verified in the browser in `/en` and `/ar`, both directions. `tsc --noEmit`, `eslint`, `check-locales.mjs` and `check-placeholders.mjs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)