### PR TITLE
Stop the web chat stream leaking a database connection

### DIFF
--- a/api/routes/public_chat.py
+++ b/api/routes/public_chat.py
@@ -33,6 +33,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession as DbSession
 
 from agent.reply import reply as generate_reply
+from api.db import session_scope
 from api.errors import envelope_response
 from api.models import Channel, Conversation, Message
 from api.notifications import raise_notification
@@ -353,18 +354,27 @@ async def _reply_stream(
     if not whole:
         return
 
-    db: DbSession = request.state.db
-    stored = Message(
-        workspace_id=channel.workspace_id,
-        conversation_id=conversation.id,
-        ts_ms=int(dt.datetime.now(dt.UTC).timestamp() * 1000),
-        speaker="agent",
-        text=whole,
-    )
-    db.add(stored)
-    await db.commit()
-    await db.refresh(stored)
-    yield _event({"done": True, "message_id": stored.id})
+    # **Its own session, not `request.state.db`.** That one belongs to
+    # `AuthenticationMiddleware`, which opens it, hands the response object back, and
+    # closes it - and a streaming body only starts running *after* the response object
+    # has been handed back. Writing the reply through it therefore takes a connection
+    # out of the pool with nobody left to return it: one leaked connection per answer,
+    # until the pool is empty and the widget stops replying. On PostgreSQL the leaked
+    # connection also keeps its locks, which is how it stopped a test suite dead.
+    async with session_scope(request.app.state.sessionmaker) as db:
+        stored = Message(
+            workspace_id=channel.workspace_id,
+            conversation_id=conversation.id,
+            ts_ms=int(dt.datetime.now(dt.UTC).timestamp() * 1000),
+            speaker="agent",
+            text=whole,
+        )
+        db.add(stored)
+        await db.commit()
+        await db.refresh(stored)
+        message_id = stored.id
+
+    yield _event({"done": True, "message_id": message_id})
 
 
 @router.get("/{path}/stream", summary="The agent's reply, as it is produced")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ dev = [
     "ruff>=0.14",
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
+    # A test that waits forever is what killed three CI runs in a row: the job was
+    # cancelled at its twenty-minute cap with no output naming the test, because a
+    # hung test never prints its own name. This makes a hang a normal failure with a
+    # stack trace in it.
+    "pytest-timeout>=2.3",
     "import-linter>=2.1",
     "httpx>=0.28",
 ]
@@ -95,5 +100,10 @@ ban-relative-imports = "all"
 testpaths = ["tests"]
 asyncio_mode = "auto"
 addopts = "-q --strict-markers"
+# No test in this suite has ever taken longer than a few seconds; the whole file of
+# them runs in well under a minute. Two minutes is therefore not a budget, it is the
+# line past which a test is not slow but stuck - and pytest-timeout prints the stack
+# of every thread when it fires, which is the one thing a cancelled CI job cannot.
+timeout = 120
 # Note: pytest exits 5 on an empty suite, which CI reads as a failure. There is
 # therefore always at least one real test - see tests/test_packages.py.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ import pytest
 from alembic.config import Config
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text as sa_text
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from alembic import command
@@ -93,18 +94,58 @@ async def running_app(settings: Settings) -> AsyncIterator[AsyncClient]:
 POSTGRES_URL = os.environ.get("TEST_POSTGRES_URL")
 
 
+async def _open_sessions(url: str) -> str:
+    """Every other connection to this database, and what it is doing.
+
+    Read only when the reset below has already failed. A `DROP SCHEMA` that cannot get
+    its lock is never the fault of the test that ran into it - it is the fault of the
+    one before, which finished without closing something. This is the line that names
+    it.
+    """
+    engine = create_engine(Settings(_env_file=None, database_url=url))
+    try:
+        async with engine.connect() as connection:
+            rows = await connection.execute(
+                sa_text(
+                    "SELECT pid, state, wait_event_type, wait_event, state_change, query "
+                    "FROM pg_stat_activity "
+                    "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+                )
+            )
+            return "\n".join(f"  {row}" for row in rows) or "  (none)"
+    except Exception as reading_failed:  # pragma: no cover - diagnostics only
+        return f"  (could not be read: {reading_failed!r})"
+    finally:
+        await engine.dispose()
+
+
 async def _reset_postgres(url: str) -> None:
     """Give each test an empty schema.
 
     Dropping and recreating `public` rather than deleting rows: a migration test has to
     start from nothing, and a leftover table from a previous test would make the next
     one pass for the wrong reason.
+
+    **`lock_timeout` is what keeps a leak from reading as an infinite test.** `DROP
+    SCHEMA` waits for its lock with no deadline, so one connection left open by an
+    earlier test stops the suite dead - and CI cancels the job twenty minutes later
+    having printed nothing about where it stopped. That happened on three consecutive
+    runs. Ten seconds is orders of magnitude longer than the drop needs when the
+    schema is free, so this only fires on a real leak, and when it does it says which
+    connection is still holding on.
     """
     engine = create_engine(Settings(_env_file=None, database_url=url))
     try:
         async with engine.begin() as connection:
+            await connection.execute(sa_text("SET lock_timeout = '10s'"))
             await connection.execute(sa_text("DROP SCHEMA public CASCADE"))
             await connection.execute(sa_text("CREATE SCHEMA public"))
+    except DBAPIError as blocked:
+        still_connected = await _open_sessions(url)
+        raise RuntimeError(
+            "Could not reset the PostgreSQL schema - a connection from an earlier test "
+            f"is still holding it.\nStill connected:\n{still_connected}"
+        ) from blocked
     finally:
         await engine.dispose()
 

--- a/tests/test_public_chat.py
+++ b/tests/test_public_chat.py
@@ -568,6 +568,45 @@ async def test_the_reply_answers_the_message_that_was_stored(stage) -> None:
     assert rows[0].text == "the real question"
 
 
+async def test_the_stream_gives_its_connection_back(stage, settings, database_url) -> None:
+    """A reply that streams must cost the pool nothing once it has ended.
+
+    The session on `request.state.db` belongs to `AuthenticationMiddleware`, and the
+    middleware has already let go of it by the time a streaming body runs - a
+    `BaseHTTPMiddleware` returns the response object, and only then is the body
+    consumed. A generator that writes its row through that session therefore takes a
+    connection nobody is left to return, and the pool loses one per reply. On SQLite
+    that is a warning from the garbage collector; on PostgreSQL it is a live backend
+    holding locks, which is what stopped three CI runs dead at the twenty-minute cap.
+
+    The application is built here rather than taken from `stage` so the engine whose
+    pool is being counted is reachable without private attributes.
+    """
+    _, paths, _ = stage
+
+    app = create_app(settings.model_copy(update={"database_url": database_url}))
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://localhost") as http:
+            first = (
+                await http.post(
+                    f"/public/chat/{paths['ours']}/messages",
+                    json={"text": "Do you open on Saturday?"},
+                    headers={"Origin": ALLOWED},
+                )
+            ).json()
+
+            answer = await http.get(
+                f"/public/chat/{paths['ours']}/stream",
+                params={"conversation": first["conversation"]},
+                headers={"Origin": ALLOWED},
+            )
+            assert answer.status_code == 200
+            assert "done" in answer.text
+
+            assert app.state.engine.sync_engine.pool.checkedout() == 0
+
+
 @pytest.mark.parametrize(
     ("origin", "conversation", "because"),
     [


### PR DESCRIPTION
CI has been dying at its twenty-minute cap on three of the last four runs on `main`, and the job printed nothing about where. This is the reason, and it is not a test problem.

## What was wrong

`_reply_stream` in `api/routes/public_chat.py` stored the agent's reply through `request.state.db`. That session belongs to `AuthenticationMiddleware`, which opens it, hands the response object back, and closes it — and a streaming body only begins running *after* the response object has been handed back. The write therefore took a connection out of the pool with nobody left to return it.

**One leaked connection per web chat answer.** On a real installation the pool empties and the widget stops replying. On SQLite it is a garbage-collector warning. On PostgreSQL the leaked connection keeps its locks, so the next test's `DROP SCHEMA public CASCADE` waits for a lock that is never released — which is the hang.

## How it was found

- The dots in the CI log say how many tests finished. Matching that count against the collection order names the test each run died in: all three were a `[on-postgresql]` test or the one straight after it.
- Locally the suite emits `SAWarning: The garbage collector is trying to clean up non-checked-in connection`. Forcing `gc.collect()` in teardown attributes it to exactly three tests, all of which stream a reply.
- The background job loop was ruled out: `JOBS_ENABLED=false` leaves the leak count unchanged.

## The change

1. **The fix** — the stream opens its own session with `session_scope(request.app.state.sessionmaker)`, so the connection it uses is one it owns and returns. Test first: `test_the_stream_gives_its_connection_back` fails with `assert 1 == 0` against the old code.
2. **The gap that hid it** — `pytest-timeout` fails a test that runs past two minutes and dumps every thread's stack, and the PostgreSQL reset now takes its lock with a ten-second `lock_timeout` and prints the sessions still connected instead of waiting forever.

Locally: the whole suite passes on SQLite with no warnings at all, `ruff format`, `ruff check` and `lint-imports` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)