### PR TITLE
Let the agent take a message, and the widget come back to its thread

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -41,7 +41,8 @@ the database and publishes events; it does not serve the UI.
 
 Milestone 0. The model interface exists and has one implementation behind it - an
 OpenAI-compatible `/chat/completions` endpoint, streaming - and `reply.py` is what the
-web chat route consumes. `stt/`, `tts/`, `session/`, `routing/` and `tools/` are still
+web chat route consumes. `tools/` holds the first built-in tool, `take_message`, which
+the model is offered on every turn. `stt/`, `tts/`, `session/` and `routing/` are still
 empty: this structure is where that code goes as it grows, not an instruction to build
 it all now.
 

--- a/agent/providers/llm/base.py
+++ b/agent/providers/llm/base.py
@@ -1,9 +1,16 @@
 """The interface every language model sits behind — §B3.
 
+    LLMProvider → stream(messages, tools) -> token stream + tool calls
+
 One method, and it is a stream. Not a convenience: a provider that returns a finished
 string cannot be put on a call, because the caller hears silence for the length of the
 generation and then a paragraph (Rule 3). Writing the interface this way means the
 second implementation cannot quietly be the blocking kind.
+
+**Two kinds of thing come out of one stream.** Text to say, and calls to make. They are
+separate types rather than a string with a marker in it, because the day a model emits
+something that looks like a marker mid-sentence is the day a customer is read a
+function call out loud.
 
 **`cancel()` is the generator's own `aclose()`.** The specification lists `cancel()` on
 the TTS interface, where audio is queued ahead of the listener and has to be thrown
@@ -16,25 +23,64 @@ manager rather than collecting first.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
-from typing import Literal, Protocol, TypedDict
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol, TypedDict
+
+from agent.tools import Tool
 
 
-class Message(TypedDict):
-    """One turn. The vocabulary every chat model shares, and nothing beyond it."""
+class Message(TypedDict, total=False):
+    """One turn, in the vocabulary every chat model shares.
 
-    role: Literal["system", "user", "assistant"]
+    `role` is always present. `content` is absent on the turn where the model only
+    called a tool, and `tool_call_id` is present only on the turn that answers one -
+    which is why this is `total=False` rather than four separate types for what the
+    wire treats as one list.
+    """
+
+    role: str
     content: str
+    tool_calls: list[dict[str, Any]]
+    tool_call_id: str
+    name: str
+
+
+@dataclass(frozen=True)
+class TextDelta:
+    """A piece of the answer, to be shown as it is."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """The model asking for something to be run before it finishes.
+
+    `arguments` is the raw JSON text the model produced, not a parsed object: it is
+    parsed where it is validated, and a half-streamed argument list that never
+    completed must not look like an empty one that did.
+    """
+
+    id: str
+    name: str
+    arguments: str
+
+
+Event = TextDelta | ToolCall
 
 
 class LLMProvider(Protocol):
-    """Streams a reply to a conversation."""
+    """Streams a reply to a conversation, and the calls it wants made."""
 
-    def stream(self, messages: list[Message]) -> AsyncIterator[str]:
+    def stream(
+        self, messages: list[Message], tools: Sequence[Tool] | None = None
+    ) -> AsyncIterator[Event]:
         """The reply, in the pieces it becomes available in.
 
-        Yields text fragments as the model produces them, in order. An empty stream is
-        a valid answer to "say nothing"; an error is raised rather than yielded, so a
-        caller cannot mistake a failure for a short reply.
+        Yields text as the model produces it, in order, and a `ToolCall` for each tool
+        the model asks for. An empty stream is a valid answer to "say nothing"; an
+        error is raised rather than yielded, so a caller cannot mistake a failure for a
+        short reply.
         """
         ...

--- a/agent/providers/llm/openai_compatible.py
+++ b/agent/providers/llm/openai_compatible.py
@@ -9,18 +9,26 @@ being a rewrite. `LLM_BASE_URL` is the whole of that swap.
 **Every token is yielded from inside the open response.** Collecting the stream and
 returning it would satisfy the type and break Rule 3; worse, it would make cancellation
 impossible, because there would be nothing left to close when the visitor leaves.
+
+**A tool call is the one thing here that cannot be streamed through.** Its arguments
+arrive as JSON in fragments, and half of a JSON object is not a smaller JSON object -
+so those fragments are joined and the call is emitted once it is whole. Text is never
+held back for it: an answer that mentions taking a message is said while the call to
+take it is still being assembled.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
+from typing import Any
 
 import httpx
 
 from agent.config import LlmSettings
-from agent.providers.llm.base import Message
+from agent.providers.llm.base import Event, Message, TextDelta, ToolCall
+from agent.tools import Tool
 
 logger = logging.getLogger("agent.llm")
 
@@ -36,7 +44,7 @@ DONE = "[DONE]"
 
 
 class OpenAICompatibleLLM:
-    """Streams tokens from a chat-completions endpoint."""
+    """Streams tokens and tool calls from a chat-completions endpoint."""
 
     def __init__(
         self, settings: LlmSettings, *, client: httpx.AsyncClient | None = None
@@ -47,32 +55,41 @@ class OpenAICompatibleLLM:
         # client is how a shared connection pool dies halfway through a call.
         self._client = client
 
-    async def stream(self, messages: list[Message]) -> AsyncIterator[str]:
-        """The model's reply, token by token, in the order it is produced."""
-        payload = {
+    async def stream(
+        self, messages: list[Message], tools: Sequence[Tool] | None = None
+    ) -> AsyncIterator[Event]:
+        """The model's reply, in the order it is produced."""
+        payload: dict[str, Any] = {
             "model": self._settings.model,
             "messages": messages,
             "stream": True,
         }
+        if tools:
+            payload["tools"] = [tool.as_schema() for tool in tools]
+
         headers = {"Authorization": f"Bearer {self._settings.api_key}"}
         url = f"{self._settings.base_url}/chat/completions"
 
         if self._client is not None:
-            async for chunk in self._read(self._client, url, payload, headers):
-                yield chunk
+            async for event in self._read(self._client, url, payload, headers):
+                yield event
             return
 
         async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-            async for chunk in self._read(client, url, payload, headers):
-                yield chunk
+            async for event in self._read(client, url, payload, headers):
+                yield event
 
     async def _read(
         self,
         client: httpx.AsyncClient,
         url: str,
-        payload: dict,
+        payload: dict[str, Any],
         headers: dict[str, str],
-    ) -> AsyncIterator[str]:
+    ) -> AsyncIterator[Event]:
+        # Keyed by the index the wire uses, because a model may assemble two calls at
+        # once and the fragments of one carry no other way of telling them apart.
+        pending: dict[int, dict[str, str]] = {}
+
         async with client.stream("POST", url, json=payload, headers=headers) as response:
             if response.status_code >= 400:
                 # The body has to be read before it can be quoted: on a streaming
@@ -86,19 +103,51 @@ class OpenAICompatibleLLM:
                 response.raise_for_status()
 
             async for line in response.aiter_lines():
-                fragment = _fragment(line)
-                if fragment is None:
+                delta = _delta(line)
+                if delta is None:
                     continue
-                if fragment == "":
-                    # A chunk that carries a role and no text - the opening one usually
-                    # does. Skipping it keeps "a chunk arrived" meaning "there is
-                    # something to show".
-                    continue
-                yield fragment
+
+                content = delta.get("content")
+                if isinstance(content, str) and content:
+                    # A chunk carrying only a role - the opening one usually does -
+                    # falls through here, which keeps "an event arrived" meaning "there
+                    # is something to show".
+                    yield TextDelta(content)
+
+                for fragment in delta.get("tool_calls") or []:
+                    _accumulate(pending, fragment)
+
+        for call in pending.values():
+            if call["name"]:
+                yield ToolCall(id=call["id"], name=call["name"], arguments=call["arguments"])
 
 
-def _fragment(line: str) -> str | None:
-    """The text in one server-sent event, or `None` when the line carries none.
+def _accumulate(pending: dict[int, dict[str, str]], fragment: Any) -> None:
+    """Join one fragment of a tool call onto the call it belongs to."""
+    if not isinstance(fragment, dict):
+        return
+    index = fragment.get("index", 0)
+    if not isinstance(index, int):
+        return
+
+    call = pending.setdefault(index, {"id": "", "name": "", "arguments": ""})
+    identifier = fragment.get("id")
+    if isinstance(identifier, str) and identifier:
+        call["id"] = identifier
+
+    function = fragment.get("function")
+    if not isinstance(function, dict):
+        return
+    name = function.get("name")
+    if isinstance(name, str) and name:
+        call["name"] = name
+    arguments = function.get("arguments")
+    if isinstance(arguments, str):
+        call["arguments"] += arguments
+
+
+def _delta(line: str) -> dict[str, Any] | None:
+    """The delta object in one server-sent event, or `None` when it carries none.
 
     Kept apart from the reading loop because this is the part that differs between
     services claiming the same format - and a parser that returns `None` for anything
@@ -123,8 +172,4 @@ def _fragment(line: str) -> str | None:
         return None
 
     delta = choices[0].get("delta")
-    if not isinstance(delta, dict):
-        return None
-
-    content = delta.get("content")
-    return content if isinstance(content, str) else None
+    return delta if isinstance(delta, dict) else None

--- a/agent/reply.py
+++ b/agent/reply.py
@@ -24,10 +24,14 @@ is the honest state of a fresh install rather than a placeholder left behind.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 
 from agent.providers.llm import Message, configured_provider
+from agent.providers.llm.base import TextDelta, ToolCall
+from agent.tools import BUILTIN, BY_NAME, TakenMessage, ToolError
+from agent.tools import parse as parse_taken_message
 
 logger = logging.getLogger("agent.reply")
 
@@ -43,6 +47,17 @@ SYSTEM_PROMPT = (
     "Never invent prices, opening hours, availability or anything else specific to "
     "this business. When you do not know, say so plainly and offer to take a message."
 )
+
+# How many times the model may call tools before the turn ends. Three is two more than
+# any answer has needed: it is a ceiling on a loop that a confused model can otherwise
+# ride forever, at the visitor's expense and the account's.
+MAX_TOOL_ROUNDS = 3
+
+# What is done with a taken message differs per channel - a tray for web chat, and at
+# Milestone 11 something a person hears about while the caller is still on the line. So
+# the agent produces the value and the caller decides, which is also what keeps this
+# package free of `api/`.
+MessageTaken = Callable[[TakenMessage], Awaitable[None]]
 
 # Roughly a word at a time, which is what a model emits and what a person reads.
 GREETING = (
@@ -77,7 +92,45 @@ def _conversation(text: str, history: Sequence[Message] | None) -> list[Message]
     return messages
 
 
-async def reply(text: str, *, history: Sequence[Message] | None = None) -> AsyncIterator[str]:
+async def _run(call: ToolCall, on_message_taken: MessageTaken | None) -> str:
+    """One tool call, and the sentence the model is handed back.
+
+    Every failure is answered rather than raised. A model that is told "that is not a
+    tool" or "name is required" asks the visitor the question it skipped; a model whose
+    turn ends in a traceback leaves somebody mid-conversation with a broken page.
+    """
+    tool = BY_NAME.get(call.name)
+    if tool is None:
+        logger.warning("the model called a tool that does not exist", extra={"tool": call.name})
+        return f"There is no tool called {call.name!r}."
+
+    try:
+        arguments = json.loads(call.arguments or "{}")
+    except json.JSONDecodeError:
+        return "Those arguments were not valid JSON. Try the call again."
+    if not isinstance(arguments, dict):
+        return "Arguments must be an object."
+
+    try:
+        answer = await tool.run(arguments)
+    except ToolError as refused:
+        return str(refused)
+
+    if tool.name == "take_message" and on_message_taken is not None:
+        # Parsed a second time on purpose: the tool validated the arguments for itself,
+        # and this is the value the caller stores. Sharing a mutable result between the
+        # two would make the tool's contract depend on who called it.
+        await on_message_taken(parse_taken_message(arguments))
+
+    return answer
+
+
+async def reply(
+    text: str,
+    *,
+    history: Sequence[Message] | None = None,
+    on_message_taken: MessageTaken | None = None,
+) -> AsyncIterator[str]:
     """The agent's answer, in the pieces it becomes available in.
 
     `history` is the thread so far in the model's own vocabulary - `user` for the
@@ -91,8 +144,52 @@ async def reply(text: str, *, history: Sequence[Message] | None = None) -> Async
             yield word
         return
 
-    # Deliberately not caught here. A model that fails mid-sentence must not leave half
-    # an answer behind: the route stores the reply only when the stream ends normally,
-    # so letting this raise is what keeps a broken generation out of the transcript.
-    async for chunk in provider.stream(_conversation(text, history)):
-        yield chunk
+    messages = _conversation(text, history)
+
+    for _round in range(MAX_TOOL_ROUNDS):
+        spoken: list[str] = []
+        calls: list[ToolCall] = []
+
+        # Deliberately not caught. A model that fails mid-sentence must not leave half
+        # an answer behind: the route stores the reply only when the stream ends
+        # normally, so letting this raise keeps a broken generation out of the
+        # transcript.
+        async for event in provider.stream(messages, BUILTIN):
+            if isinstance(event, TextDelta):
+                spoken.append(event.text)
+                yield event.text
+            else:
+                calls.append(event)
+
+        if not calls:
+            return
+
+        # The turn the model just took, tool calls and all, has to go back to it or the
+        # answers below have nothing to answer.
+        asked: Message = {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": call.id,
+                    "type": "function",
+                    "function": {"name": call.name, "arguments": call.arguments},
+                }
+                for call in calls
+            ],
+        }
+        if spoken:
+            asked["content"] = "".join(spoken)
+        messages.append(asked)
+
+        for call in calls:
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": await _run(call, on_message_taken),
+                }
+            )
+
+    logger.warning(
+        "the model kept calling tools; the turn was ended", extra={"text": text[:80]}
+    )

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -1,1 +1,16 @@
-"""The built-in tools the model can invoke."""
+"""Built-in tools the model can invoke."""
+
+from __future__ import annotations
+
+from agent.tools.base import Tool, ToolError
+from agent.tools.take_message import TAKE_MESSAGE, TakenMessage, parse
+
+# The tools every conversation is offered. A list rather than a registry with
+# registration calls: v1 has one, and a list of one is honest about that. When a channel
+# needs a different set, this becomes a function of the channel and the call sites do
+# not change, because they already ask for "the tools" rather than naming them.
+BUILTIN: list[Tool] = [TAKE_MESSAGE]
+
+BY_NAME: dict[str, Tool] = {tool.name: tool for tool in BUILTIN}
+
+__all__ = ["BUILTIN", "BY_NAME", "TAKE_MESSAGE", "TakenMessage", "Tool", "ToolError", "parse"]

--- a/agent/tools/base.py
+++ b/agent/tools/base.py
@@ -1,0 +1,50 @@
+"""What a tool is, and how the model is told about it.
+
+A tool is three things: a name, a description the model reads to decide whether this is
+the moment, and a JSON Schema for its arguments. The fourth - what it actually does -
+is a coroutine, and it lives here rather than in `api/` because the model loop calls it
+mid-sentence and the loop is the agent's.
+
+**A tool never reaches the database from this package.** `agent/` does not import
+`api/`, and at Milestone 11 this code runs in a process that may have no API server
+beside it. What a tool produces is a value; the caller that has a session decides what
+that value means - see `on_message_taken` in `agent.reply`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Tool:
+    """One thing the model may do, and the words it decides that by."""
+
+    name: str
+    # Read by the model, not by a person. It is the whole of what makes a tool fire at
+    # the right moment, which is why it says when *not* to as well.
+    description: str
+    parameters: dict[str, Any]
+    run: Callable[[dict[str, Any]], Awaitable[str]]
+
+    def as_schema(self) -> dict[str, Any]:
+        """The shape a chat-completions endpoint expects to be handed."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+
+class ToolError(ValueError):
+    """The model called a tool with arguments it cannot be run with.
+
+    Raised rather than guessed at: a message taken under the wrong name is worse than
+    no message, because somebody rings the wrong person back and the real one is never
+    called. The loop turns this into a sentence the model can act on and try again.
+    """

--- a/agent/tools/take_message.py
+++ b/agent/tools/take_message.py
@@ -1,0 +1,136 @@
+"""Take a message — Milestone 0 step 6.
+
+The one thing an agent must be able to do on the day it is switched on, before it knows
+a single opening hour: find out who is asking and what about, and hand that to a person.
+Every other tool is an improvement on this one.
+
+**Two required fields and nothing else.** A form with six boxes is a form the visitor
+abandons and a tool the model fills with guesses; a name and a reason are what somebody
+ringing back actually needs. `callback` is optional because the channel usually already
+knows how to reach them, and `urgent` is optional because the model should not be
+deciding it unprompted.
+
+**The result is a value, not a row.** What is done with a taken message - a
+notification, a row in the tray, an email - belongs to whoever called the agent, and
+differs between a web chat and a phone call at Milestone 11.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from agent.tools.base import Tool, ToolError
+
+logger = logging.getLogger("agent.tools")
+
+# Long enough for "the boiler in the upstairs flat is leaking again since Tuesday" and
+# short enough that a model which decides to summarise the whole conversation into this
+# field is truncated rather than believed.
+REASON_MAX = 500
+NAME_MAX = 120
+CALLBACK_MAX = 120
+
+
+@dataclass(frozen=True)
+class TakenMessage:
+    """Who called, what about, and how to reach them."""
+
+    name: str
+    reason: str
+    callback: str | None = None
+    urgent: bool = False
+
+
+SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "The caller's name, as they gave it.",
+        },
+        "reason": {
+            "type": "string",
+            "description": "What they want, in their own words where possible.",
+        },
+        "callback": {
+            "type": "string",
+            "description": (
+                "A phone number or email address they gave for the call back. "
+                "Omit it rather than inventing one."
+            ),
+        },
+        "urgent": {
+            "type": "boolean",
+            "description": "Only when they said it cannot wait.",
+        },
+    },
+    "required": ["name", "reason"],
+    "additionalProperties": False,
+}
+
+DESCRIPTION = (
+    "Take a message for a person to answer later. Call this once you know both who is "
+    "asking and what about - ask for whichever is missing first, in the visitor's own "
+    "language. Do not call it for a question you have already answered, and do not "
+    "invent a name: if they will not give one, ask once and then take the message "
+    "without it."
+)
+
+
+def _text(arguments: dict[str, Any], field: str, limit: int) -> str:
+    value = arguments.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ToolError(f"{field} is required, as text the caller actually gave.")
+    return value.strip()[:limit]
+
+
+def parse(arguments: dict[str, Any]) -> TakenMessage:
+    """The model's arguments, or a refusal it can act on.
+
+    Validated here rather than trusted: the arguments are a language model's output,
+    which means they are a suggestion. A message stored under a name the model invented
+    sends somebody to ring the wrong person while the real one waits.
+    """
+    callback = arguments.get("callback")
+    if callback is not None and not isinstance(callback, str):
+        raise ToolError("callback must be a phone number or an email address, as text.")
+
+    return TakenMessage(
+        name=_text(arguments, "name", NAME_MAX),
+        reason=_text(arguments, "reason", REASON_MAX),
+        callback=(callback.strip()[:CALLBACK_MAX] or None)
+        if isinstance(callback, str)
+        else None,
+        urgent=bool(arguments.get("urgent", False)),
+    )
+
+
+async def _run(arguments: dict[str, Any]) -> str:
+    """What the model is told once the message is taken.
+
+    Short and certain: a model handed a paragraph here repeats it to the visitor, and
+    the visitor is owed a confirmation rather than a receipt.
+    """
+    taken = parse(arguments)
+    # Rule 4's habit, applied to a tool: this is the line that says the step works,
+    # printed as a structured record rather than as prose.
+    logger.info(
+        "message taken",
+        extra={
+            "caller_name": taken.name,
+            "reason": taken.reason,
+            "callback": taken.callback,
+            "urgent": taken.urgent,
+        },
+    )
+    return "The message was taken. Confirm it briefly and say somebody will come back to them."
+
+
+TAKE_MESSAGE = Tool(
+    name="take_message",
+    description=DESCRIPTION,
+    parameters=SCHEMA,
+    run=_run,
+)

--- a/api/routes/public_chat.py
+++ b/api/routes/public_chat.py
@@ -73,6 +73,26 @@ class Accepted(BaseModel):
     message_id: int
 
 
+class Line(BaseModel):
+    """One turn of a thread, as a stranger may read it back.
+
+    Three fields, and none of them is an id from this installation: a visitor holding
+    the handle is allowed to see their own conversation, not to learn how many
+    conversations exist or which workspace this is.
+    """
+
+    speaker: str
+    text: str
+    ts_ms: int
+
+
+class Thread(BaseModel):
+    """A conversation as its own visitor sees it after a reload."""
+
+    conversation: str
+    messages: list[Line]
+
+
 def _too_many() -> object:
     """The one refusal that says what it is.
 
@@ -467,6 +487,91 @@ async def _reply_stream(
         message_id = stored.id
 
     yield _event({"done": True, "message_id": message_id})
+
+
+# What a visitor is handed back after a reload. Long enough that a real exchange
+# survives, short enough that the handle is not a way to pull an archive.
+THREAD_MAX = 50
+
+# What a stranger may see of who said what. `human` - a colleague who took the thread
+# over - is folded into the agent on purpose: the visitor was talking to the business,
+# and which desk answered is the business's own business.
+_VISIBLE_SPEAKERS = {"caller": "visitor", "agent": "agent", "human": "agent"}
+
+
+@router.get(
+    "/{path}/messages",
+    response_model=Thread,
+    summary="The thread so far, for a visitor who reloaded the page",
+)
+async def read_thread(
+    request: Request,
+    path: str,
+    conversation: str,
+    origin: str | None = Header(default=None),
+) -> object:
+    """Milestone 0's *thread survives a page reload*, from the visitor's side.
+
+    Without this the widget comes back empty after a refresh while the server still
+    holds the thread - so the visitor asks again, and the agent answers a question it
+    was already asked, referring to things the visitor can no longer see.
+
+    **The handle is the whole of the authorisation, and that is deliberate.** It is
+    unguessable, issued only to somebody who passed every check on the message that
+    created it, and scoped to one channel - the same reasoning that guards the reply
+    stream. What it does not do is widen: the guards below are the stream's own, in the
+    same order, and what comes back carries nothing the stream does not.
+    """
+    db: DbSession = request.state.db
+
+    channel = await _channel(db, path)
+    if channel is None:
+        return _refused()
+
+    settings = channel.settings_json or {}
+    refusal = check_origin(
+        origin,
+        settings.get("allowed_origins"),
+        own=str(request.base_url).rstrip("/"),
+        require_header=False,
+    )
+    if refusal is not None:
+        logger.info("web chat thread refused", extra={"reason": refusal.reason})
+        return _refused()
+
+    thread = await db.scalar(
+        select(Conversation).where(
+            Conversation.external_id == conversation,
+            Conversation.channel_id == channel.id,
+            Conversation.status == "open",
+        )
+    )
+    if thread is None:
+        # A handle that has been closed, or was never on this channel, is a handle that
+        # does not exist. The widget starts a new thread rather than showing an error a
+        # visitor cannot act on.
+        return _refused()
+
+    rows = (
+        (
+            await db.execute(
+                select(Message)
+                .where(Message.conversation_id == thread.id)
+                .order_by(Message.ts_ms.desc(), Message.id.desc())
+                .limit(THREAD_MAX)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return Thread(
+        conversation=conversation,
+        messages=[
+            Line(speaker=_VISIBLE_SPEAKERS[row.speaker], text=row.text, ts_ms=row.ts_ms)
+            for row in reversed(rows)
+            if row.speaker in _VISIBLE_SPEAKERS
+        ],
+    )
 
 
 @router.get("/{path}/stream", summary="The agent's reply, as it is produced")

--- a/api/routes/public_chat.py
+++ b/api/routes/public_chat.py
@@ -35,6 +35,7 @@ from sqlalchemy.ext.asyncio import AsyncSession as DbSession
 
 from agent.providers.llm import Message as LlmMessage
 from agent.reply import reply as generate_reply
+from agent.tools import TakenMessage
 from api.db import session_scope
 from api.errors import envelope_response
 from api.models import Channel, Conversation, Message
@@ -380,13 +381,45 @@ async def _reply_stream(
     is stored, and no further tokens are produced - which is what Rule 3 means by
     `cancel()` not being optional, in the only shape that survives being retrofitted.
     """
+
+    async def took(taken: TakenMessage) -> None:
+        """A message the model took, put where a person will see it.
+
+        Its own session, for the same reason the reply's write below has one: the
+        middleware let go of the request's session when the response object was
+        returned, and this runs long after that.
+
+        Raised while the visitor is still reading the confirmation, not after the
+        stream ends - somebody who closes the tab on that sentence has still had their
+        message taken, and the promise the agent just made is already kept.
+        """
+        async with session_scope(request.app.state.sessionmaker) as db:
+            await raise_notification(
+                db,
+                workspace_id=channel.workspace_id,
+                category="review",
+                message_key="message_taken",
+                params={"name": taken.name, "reason": _preview(taken.reason)},
+                # A person has to ring back. That is the whole point of a taken
+                # message, and it is what puts this in the waiting list rather than
+                # in the log with everything else that merely happened.
+                needs_decision=True,
+                primary_action="open_conversation",
+                action_payload={"conversation_id": conversation.id},
+                conversation_id=conversation.id,
+            )
+        logger.info(
+            "web chat message taken",
+            extra={"conversation_id": conversation.id, "urgent": taken.urgent},
+        )
+
     pieces: list[str] = []
     # Rule 4: measured from the first call, not from the first complaint. Time to first
     # token is the number the phone milestone lives or dies on (~250 ms of an 800 ms
     # budget), and a text channel is where it is cheap to start watching it.
     started = time.perf_counter()
     try:
-        async for chunk in generate_reply(text, history=history):
+        async for chunk in generate_reply(text, history=history, on_message_taken=took):
             if await request.is_disconnected():
                 logger.info(
                     "web chat reply cancelled by the visitor",

--- a/api/routes/widget.py
+++ b/api/routes/widget.py
@@ -200,7 +200,33 @@ def _page(path: str) -> str:
   var log = document.getElementById("log");
   var form = document.getElementById("form");
   var text = document.getElementById("text");
+  // The thread has to survive a reload, or a visitor who refreshes asks their
+  // question again and the agent answers one it was already asked, referring to
+  // things that are no longer on the screen. The handle is kept per channel, and in
+  // this iframe's own storage - the page embedding the widget cannot read it, which
+  // is the same wall the iframe exists for.
+  var HANDLE_KEY = "tel-agent:chat:" + PATH;
   var conversation = null;
+  try {{
+    conversation = localStorage.getItem(HANDLE_KEY) || null;
+  }} catch (error) {{
+    // A browser with storage switched off still chats; it just starts fresh each
+    // time, which is what happened before this existed.
+  }}
+
+  function remember(handle) {{
+    conversation = handle;
+    try {{
+      localStorage.setItem(HANDLE_KEY, handle);
+    }} catch (error) {{}}
+  }}
+
+  function forget() {{
+    conversation = null;
+    try {{
+      localStorage.removeItem(HANDLE_KEY);
+    }} catch (error) {{}}
+  }}
 
   function resize(open) {{
     parent.postMessage({{ telAgent: "resize", open: open }}, "*");
@@ -219,6 +245,27 @@ def _page(path: str) -> str:
     line.textContent = body;
     log.appendChild(line);
     log.scrollTop = log.scrollHeight;
+  }}
+
+  // What was said before the reload, drawn before the visitor types anything. A
+  // refused handle - closed, or from a channel this is not - is dropped rather than
+  // shown as an error: the next message simply starts a new thread.
+  async function restore() {{
+    if (!conversation) return;
+    try {{
+      var answer = await fetch(
+        "/public/chat/" + encodeURIComponent(PATH) + "/messages?conversation=" +
+        encodeURIComponent(conversation)
+      );
+      if (!answer.ok) {{ forget(); return; }}
+      var thread = await answer.json();
+      thread.messages.forEach(function (line) {{
+        say(line.text, line.speaker === "visitor" ? "me" : "them");
+      }});
+    }} catch (error) {{
+      // Offline, or the server is down. The handle is kept: the thread is still
+      // there, and the next message continues it.
+    }}
   }}
 
   bubble.addEventListener("click", function () {{ show(true); }});
@@ -273,7 +320,7 @@ def _page(path: str) -> str:
         body: JSON.stringify({{ text: body, conversation: conversation }})
       }});
       if (answer.ok) {{
-        conversation = (await answer.json()).conversation;
+        remember((await answer.json()).conversation);
         await listen();
       }} else {{
         // One sentence for every refusal, because the server gives one. A visitor
@@ -287,6 +334,8 @@ def _page(path: str) -> str:
       text.focus();
     }}
   }});
+
+  restore();
 }})();
 </script>
 </body></html>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -132,6 +132,12 @@ somebody while the caller is still on the line. A bad call is answered as a sent
 model can act on, never raised - a traceback there ends the turn and leaves a visitor
 looking at a broken page.
 
+**The thread survives a page reload**, which is one of the three things this milestone
+says it measures. The widget keeps its handle in the iframe's own storage - the page
+embedding it cannot read that - and asks for the thread back when it loads. Proven in a
+browser against a throwaway installation: two exchanges, a full reload, both bubbles
+still there, and one conversation row behind them rather than two.
+
 Step 5 is not a nicety. It is the whole of what the old phone-first order was
 protecting: an agent that composes a complete answer and then sends it is an agent that
 can never be put on a phone. Cancellation is proven here, in the easy case, while it is

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,6 +123,15 @@ stops the generation rather than only the delivery: the route stops pulling, the
 generator unwinds, the provider's response closes. Time to first token is logged from
 here on, which is the number Milestone 11 lives on.
 
+Step 6 is the first tool: `take_message`, offered to the model on every turn. The
+arguments it comes back with are validated rather than believed - a message stored
+under a name a model invented sends somebody to ring the wrong person while the real
+one waits. What comes out is a structured value: the web chat route turns it into a row
+in the tray that a person has to act on, and at Milestone 11 the same value reaches
+somebody while the caller is still on the line. A bad call is answered as a sentence the
+model can act on, never raised - a traceback there ends the turn and leaves a visitor
+looking at a broken page.
+
 Step 5 is not a nicety. It is the whole of what the old phone-first order was
 protecting: an agent that composes a complete answer and then sends it is an agent that
 can never be put on a phone. Cancellation is proven here, in the easy case, while it is

--- a/locales/ar/notifications.json
+++ b/locales/ar/notifications.json
@@ -35,6 +35,7 @@
   "msg_backup_no_target": "لا توجد وجهة للنسخ الاحتياطي، فلا تُؤخذ أي نسخة إطلاقاً.",
   "msg_backup_unverified": "كُتبت نسخة احتياطية، لكن إعادة قراءتها للتحقق أخفقت.",
   "msg_mail_failed": "تعذّر إرسال بريد إلكتروني.",
+  "msg_message_taken": "ترك {name} رسالة: {reason}",
   "msg_restore_staged": "استرجاع من {taken_at} مُسجَّل وسينفَّذ عند إعادة التشغيل القادمة.",
   "msg_task_failed": "فشلت المهمة المجدولة {task}.",
   "msg_web_chat_started": "بدأ أحدهم محادثة على موقعك: «{preview}»",

--- a/locales/de/notifications.json
+++ b/locales/de/notifications.json
@@ -35,6 +35,7 @@
   "msg_backup_no_target": "Es ist kein Sicherungsziel gesetzt, also wird gar nicht gesichert.",
   "msg_backup_unverified": "Eine Sicherung wurde geschrieben, aber das Zurücklesen zur Prüfung schlug fehl.",
   "msg_mail_failed": "Eine E-Mail konnte nicht gesendet werden.",
+  "msg_message_taken": "{name} hat eine Nachricht hinterlassen: {reason}",
   "msg_restore_staged": "Eine Wiederherstellung vom {taken_at} ist vorgemerkt und läuft beim nächsten Neustart.",
   "msg_task_failed": "Die geplante Aufgabe {task} ist fehlgeschlagen.",
   "msg_web_chat_started": "Jemand hat auf Ihrer Website einen Chat begonnen: „{preview}“",

--- a/locales/en/notifications.json
+++ b/locales/en/notifications.json
@@ -35,6 +35,7 @@
   "msg_backup_no_target": "No backup target is set, so no backup is being taken at all.",
   "msg_backup_unverified": "A backup was written, but reading it back to check it failed.",
   "msg_mail_failed": "An email could not be sent.",
+  "msg_message_taken": "{name} left a message: {reason}",
   "msg_restore_staged": "A restore from {taken_at} is staged and will run on the next restart.",
   "msg_task_failed": "The scheduled task {task} failed.",
   "msg_web_chat_started": "Somebody started a chat on your website: “{preview}”",

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -17,6 +17,7 @@ import pytest
 from agent import reply as reply_module
 from agent.config import ConfigurationError, LlmSettings, llm_settings
 from agent.providers.llm import Message, configured_provider, provider_for
+from agent.providers.llm.base import TextDelta
 from agent.providers.llm.openai_compatible import OpenAICompatibleLLM
 
 SETTINGS = LlmSettings(
@@ -44,11 +45,11 @@ async def test_the_tokens_arrive_in_the_order_the_model_produced_them() -> None:
         lambda request: httpx.Response(200, content=_stream_body("Guten ", "Tag", "."))
     ) as client:
         provider = OpenAICompatibleLLM(SETTINGS, client=client)
-        chunks = [chunk async for chunk in provider.stream([{"role": "user", "content": "hi"}])]
+        events = [event async for event in provider.stream([{"role": "user", "content": "hi"}])]
 
     # Three pieces, not one string: a provider that buffered would pass an equality
     # check on the joined text and fail this line, which is the point of it.
-    assert chunks == ["Guten ", "Tag", "."]
+    assert [event.text for event in events] == ["Guten ", "Tag", "."]
 
 
 async def test_the_request_carries_the_model_the_key_and_the_turns() -> None:
@@ -64,7 +65,7 @@ async def test_the_request_carries_the_model_the_key_and_the_turns() -> None:
     ]
     async with _client(handler) as client:
         provider = OpenAICompatibleLLM(SETTINGS, client=client)
-        [chunk async for chunk in provider.stream(turns)]
+        [event async for event in provider.stream(turns)]
 
     request = seen[0]
     assert str(request.url) == "https://model.test/v1/chat/completions"
@@ -79,7 +80,7 @@ async def test_a_refusal_is_raised_rather_than_returned_as_a_short_reply() -> No
     async with _client(lambda request: httpx.Response(401, json={"error": "no"})) as client:
         provider = OpenAICompatibleLLM(SETTINGS, client=client)
         with pytest.raises(httpx.HTTPStatusError):
-            [chunk async for chunk in provider.stream([{"role": "user", "content": "hi"}])]
+            [event async for event in provider.stream([{"role": "user", "content": "hi"}])]
 
 
 async def test_a_chunk_that_makes_no_sense_shortens_the_reply_rather_than_breaking_it() -> None:
@@ -93,9 +94,9 @@ async def test_a_chunk_that_makes_no_sense_shortens_the_reply_rather_than_breaki
 
     async with _client(lambda request: httpx.Response(200, content=body)) as client:
         provider = OpenAICompatibleLLM(SETTINGS, client=client)
-        chunks = [chunk async for chunk in provider.stream([{"role": "user", "content": "hi"}])]
+        events = [event async for event in provider.stream([{"role": "user", "content": "hi"}])]
 
-    assert chunks == ["still ", "here"]
+    assert [event.text for event in events] == ["still ", "here"]
 
 
 async def test_stopping_the_consumer_closes_the_stream() -> None:
@@ -114,7 +115,7 @@ async def test_stopping_the_consumer_closes_the_stream() -> None:
         first = await anext(stream)
         await stream.aclose()
 
-    assert first == "one"
+    assert first == TextDelta("one")
 
 
 async def test_no_model_configured_still_answers(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -174,9 +175,9 @@ async def test_the_reply_asks_the_model_to_answer_in_the_visitors_language() -> 
     asked: list[list[Message]] = []
 
     class Recorder:
-        async def stream(self, messages: list[Message]) -> AsyncIterator[str]:
+        async def stream(self, messages: list[Message], tools=None) -> AsyncIterator[TextDelta]:
             asked.append(messages)
-            yield "servus"
+            yield TextDelta("servus")
 
     reply_module_provider = Recorder()
     original = reply_module.configured_provider

--- a/tests/test_public_chat.py
+++ b/tests/test_public_chat.py
@@ -618,6 +618,64 @@ async def test_the_second_question_is_asked_with_the_first_still_attached(
     ]
 
 
+async def test_a_visitor_who_reloads_gets_the_thread_back(stage) -> None:
+    """Milestone 0's *the thread survives a page reload*, from the visitor's side.
+
+    Without this the widget comes back empty while the server still holds the thread,
+    so the visitor asks again and the agent answers a question it was already asked,
+    referring to things no longer on the screen.
+    """
+    http, paths, _ = stage
+    first = (
+        await http.post(
+            f"/public/chat/{paths['ours']}/messages",
+            json={"text": "seid ihr am Samstag offen?"},
+            headers={"Origin": ALLOWED},
+        )
+    ).json()
+    await http.get(
+        f"/public/chat/{paths['ours']}/stream",
+        params={"conversation": first["conversation"]},
+        headers={"Origin": ALLOWED},
+    )
+
+    answer = await http.get(
+        f"/public/chat/{paths['ours']}/messages",
+        params={"conversation": first["conversation"]},
+        headers={"Origin": ALLOWED},
+    )
+    assert answer.status_code == 200
+    body = answer.json()
+
+    assert body["conversation"] == first["conversation"]
+    assert [line["speaker"] for line in body["messages"]] == ["visitor", "agent"]
+    assert body["messages"][0]["text"] == "seid ihr am Samstag offen?"
+    # Nothing that belongs to this installation rather than to this visitor.
+    assert set(body["messages"][0]) == {"speaker", "text", "ts_ms"}
+
+
+async def test_a_thread_is_only_readable_from_a_page_that_may_use_the_chat(stage) -> None:
+    http, paths, _ = stage
+    first = (
+        await http.post(
+            f"/public/chat/{paths['ours']}/messages",
+            json={"text": "hallo"},
+            headers={"Origin": ALLOWED},
+        )
+    ).json()
+
+    # The neighbour's widget, and a page nobody allowed: the same refusal as everywhere
+    # else, and it says nothing about whether the thread exists.
+    for path, origin in ((paths["theirs"], ALLOWED), (paths["ours"], "https://evil.test")):
+        answer = await http.get(
+            f"/public/chat/{path}/messages",
+            params={"conversation": first["conversation"]},
+            headers={"Origin": origin},
+        )
+        assert answer.status_code == 403
+        assert answer.json()["error"]["code"] == "origin_not_allowed"
+
+
 async def test_a_visitor_who_leaves_stops_the_generation(stage, monkeypatch) -> None:
     """Milestone 0 step 5, in the half that is not about the wire.
 

--- a/tests/test_public_chat.py
+++ b/tests/test_public_chat.py
@@ -581,7 +581,7 @@ async def test_the_second_question_is_asked_with_the_first_still_attached(
 
     asked: list[tuple[str, list]] = []
 
-    async def recording_reply(text: str, *, history=None):
+    async def recording_reply(text: str, *, history=None, **_unused):
         asked.append((text, list(history or [])))
         yield "ja"
 
@@ -630,7 +630,7 @@ async def test_a_visitor_who_leaves_stops_the_generation(stage, monkeypatch) -> 
 
     produced: list[str] = []
 
-    async def endless_reply(text: str, *, history=None):
+    async def endless_reply(text: str, *, history=None, **_unused):
         for index in range(50):
             produced.append(f"chunk-{index}")
             yield f"chunk-{index} "

--- a/tests/test_take_message.py
+++ b/tests/test_take_message.py
@@ -1,0 +1,187 @@
+"""Taking a message — Milestone 0 step 6.
+
+The step's own words are "it asks for name and reason, prints a structured result". The
+asking is the model's, and a test that asserted on it would be testing the model. What
+is this repository's - and what these tests are about - is that the result is
+structured, that it is validated rather than believed, and that a failure comes back to
+the model as a sentence it can act on instead of as a traceback in front of a visitor.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import pytest
+
+from agent import reply as reply_module
+from agent.providers.llm.base import Message, TextDelta, ToolCall
+from agent.tools import BY_NAME, TakenMessage, ToolError, parse
+
+
+class Script:
+    """A model that says what it was told to, in the rounds it was told to."""
+
+    def __init__(self, *rounds: list[TextDelta | ToolCall]) -> None:
+        self._rounds = list(rounds)
+        self.seen: list[list[Message]] = []
+        self.tools_offered: list[str] = []
+
+    async def stream(self, messages: list[Message], tools=None) -> AsyncIterator[object]:
+        # Copied, because the loop keeps appending to the same list and a reference
+        # would show every round the same final state.
+        self.seen.append([dict(message) for message in messages])
+        self.tools_offered = [tool.name for tool in tools or []]
+        for event in self._rounds.pop(0) if self._rounds else []:
+            yield event
+
+
+def _call(arguments: dict | str, name: str = "take_message") -> ToolCall:
+    body = arguments if isinstance(arguments, str) else json.dumps(arguments)
+    return ToolCall(id="call-1", name=name, arguments=body)
+
+
+def _run_with(provider) -> None:
+    reply_module.configured_provider = lambda: provider  # type: ignore[assignment]
+
+
+@pytest.fixture(autouse=True)
+def _restore_provider():
+    original = reply_module.configured_provider
+    yield
+    reply_module.configured_provider = original  # type: ignore[assignment]
+
+
+def test_the_arguments_are_validated_rather_than_believed() -> None:
+    """A model's arguments are a suggestion, and this one is refused.
+
+    A message stored under a name the model invented sends somebody to ring the wrong
+    person while the real one waits, which is worse than no message at all.
+    """
+    with pytest.raises(ToolError):
+        parse({"reason": "the boiler is leaking"})
+    with pytest.raises(ToolError):
+        parse({"name": "  ", "reason": "the boiler is leaking"})
+
+
+def test_what_the_caller_gave_survives_and_what_they_did_not_stays_empty() -> None:
+    taken = parse({"name": " Anna Gruber ", "reason": " leaking boiler ", "urgent": True})
+    assert taken == TakenMessage(
+        name="Anna Gruber", reason="leaking boiler", callback=None, urgent=True
+    )
+
+
+def test_a_model_that_writes_an_essay_into_the_reason_is_trimmed() -> None:
+    taken = parse({"name": "Anna", "reason": "x" * 900})
+    assert len(taken.reason) == 500
+
+
+async def test_taking_a_message_hands_the_caller_a_structured_result() -> None:
+    """The step's check: a structured result, not a sentence to be read back later."""
+    taken: list[TakenMessage] = []
+
+    async def remember(message: TakenMessage) -> None:
+        taken.append(message)
+
+    _run_with(
+        Script(
+            [
+                TextDelta("Einen Moment"),
+                _call(
+                    {"name": "Anna Gruber", "reason": "Heizung tropft", "callback": "0664 1"}
+                ),
+            ],
+            [TextDelta("Danke, jemand meldet sich.")],
+        )
+    )
+
+    said = "".join(
+        [
+            chunk
+            async for chunk in reply_module.reply(
+                "Die Heizung tropft", on_message_taken=remember
+            )
+        ]
+    )
+
+    assert taken == [
+        TakenMessage(
+            name="Anna Gruber", reason="Heizung tropft", callback="0664 1", urgent=False
+        )
+    ]
+    # Both rounds reached the visitor: what the model said before the call, and the
+    # confirmation after it.
+    assert said == "Einen MomentDanke, jemand meldet sich."
+
+
+async def test_the_model_is_told_what_the_tool_answered() -> None:
+    """Without the answer going back, the model confirms a message it never took."""
+    provider = Script(
+        [_call({"name": "Anna", "reason": "Heizung"})],
+        [TextDelta("Danke.")],
+    )
+    _run_with(provider)
+
+    [chunk async for chunk in reply_module.reply("Die Heizung tropft")]
+
+    second_round = provider.seen[1]
+    assert second_round[-2]["role"] == "assistant"
+    assert second_round[-2]["tool_calls"][0]["function"]["name"] == "take_message"
+    answer = second_round[-1]
+    assert answer["role"] == "tool"
+    assert answer["tool_call_id"] == "call-1"
+    assert "message was taken" in answer["content"]
+
+
+async def test_the_tool_is_offered_to_the_model_at_all() -> None:
+    provider = Script([TextDelta("hallo")])
+    _run_with(provider)
+
+    [chunk async for chunk in reply_module.reply("hallo")]
+
+    assert provider.tools_offered == ["take_message"]
+    assert "take_message" in BY_NAME
+
+
+@pytest.mark.parametrize(
+    ("call", "expected"),
+    [
+        (_call({"reason": "only a reason"}), "name is required"),
+        (_call("{not json", "take_message"), "not valid JSON"),
+        (_call({}, "book_a_flight"), "no tool called"),
+    ],
+    ids=["missing argument", "broken arguments", "no such tool"],
+)
+async def test_a_bad_call_comes_back_as_a_sentence_the_model_can_act_on(
+    call: ToolCall, expected: str
+) -> None:
+    """A traceback here would end the turn and leave a visitor on a broken page.
+
+    Answered instead, the model asks the visitor the question it skipped - which is the
+    behaviour a person at a desk has when they realise they never got the name.
+    """
+    taken: list[TakenMessage] = []
+
+    async def remember(message: TakenMessage) -> None:
+        taken.append(message)
+
+    provider = Script([call], [TextDelta("Wie war noch Ihr Name?")])
+    _run_with(provider)
+
+    said = "".join(
+        [chunk async for chunk in reply_module.reply("Hilfe", on_message_taken=remember)]
+    )
+
+    assert taken == []
+    assert said == "Wie war noch Ihr Name?"
+    assert expected in provider.seen[1][-1]["content"]
+
+
+async def test_a_model_that_only_calls_tools_forever_is_stopped() -> None:
+    """The ceiling exists because the alternative is billed by the token."""
+    provider = Script(*[[_call({"name": "Anna", "reason": "again"})] for _ in range(10)])
+    _run_with(provider)
+
+    [chunk async for chunk in reply_module.reply("hallo")]
+
+    assert len(provider.seen) == reply_module.MAX_TOOL_ROUNDS


### PR DESCRIPTION
The last two of Milestone 0's six checks, on top of #111.

## Step 6 — take a message

The tool loop the specification asks for — `stream(messages, tools) -> token stream + tool calls` — and one tool behind it: `take_message`, offered on every turn.

Two things come out of one stream now, as **separate types** rather than text with a marker in it. The day a model emits something that looks like a marker mid-sentence is the day a customer is read a function call out loud. Text is never held back for a call either: arguments arrive as JSON fragments and half an object is not a smaller object, so the call is assembled while the answer is already being said.

**The arguments are validated, not believed.** They are a model's output, which makes them a suggestion — and a message stored under a name a model invented sends somebody to ring the wrong person while the real one waits. A missing name is refused *to the model*, as a sentence it can act on, and it then asks the visitor the question it skipped. A traceback there would end the turn and leave somebody looking at a broken page.

**What comes out is a value, not a row.** `agent/` cannot reach the database and should not: what a taken message means differs per channel. The web chat route turns it into a notification a person has to act on, raised while the visitor is still reading the confirmation — somebody who closes the tab on that sentence has still had their message taken. At Milestone 11 the same value reaches somebody while the caller is on the line.

Three rounds of tool calls end the turn; the alternative is a confused model looping at the visitor's expense.

## The thread survives a page reload

Milestone 0 says it measures this. It did not hold: the widget kept its handle in a variable, so a refresh started a new conversation while the server still had the old one — and the visitor, seeing an empty panel, asked their question again to an agent that had already answered it.

The handle now lives in the iframe's own storage, which the embedding page cannot read, and the widget asks for its thread back on load. Reading a thread back is a new public endpoint carrying the reply stream's guards in the stream's order: live channel, allowed origin, conversation belonging to that channel and open. What comes back is three fields, none of them an id belonging to this installation.

**Proven in a browser** against a throwaway installation, not only in tests: two exchanges, a full reload, both bubbles still there, one conversation row behind them, and one arrival in the tray rather than two.

The whole suite passes (`ruff format`, `ruff check`, `lint-imports` too). Steps 3–6 remain built rather than proven end to end: that waits on a model key, deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)