### PR TITLE
Put a ceiling on one request, so a mistake cannot stop the process

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,6 +172,20 @@ CORS_ORIGINS=http://localhost:3000
 TRUSTED_HOSTS=localhost,127.0.0.1
 
 # ---------------------------------------------------------------------------
+# Request limits
+# ---------------------------------------------------------------------------
+# Ceilings on one request, against a mistake rather than an attacker: an
+# unbounded body and an unbounded handler are each a denial of service that
+# nobody has to intend. Nothing in this API accepts an upload, so a megabyte is
+# far above every body it takes.
+MAX_BODY_BYTES=1048576
+
+# Measured to the *first byte* of the response, never to the last: a stream is
+# then free to run for as long as somebody is reading it. Raising this does not
+# make a slow query fast; it makes the process wait longer before saying so.
+REQUEST_TIMEOUT_SECONDS=30
+
+# ---------------------------------------------------------------------------
 # Scheduled tasks and background jobs
 # ---------------------------------------------------------------------------
 # The installation's own clock, run inside the API process: housekeeping,

--- a/api/config.py
+++ b/api/config.py
@@ -85,6 +85,19 @@ class Settings(BaseSettings):
     # Echoes every statement. Useful once, noisy always - off unless asked for.
     database_echo: bool = False
 
+    # G2. Ceilings on one request, against a mistake rather than an attacker: an
+    # unbounded body and an unbounded handler are each a denial of service that nobody
+    # has to intend. A megabyte is far above every body this API accepts - nothing here
+    # takes an upload - and thirty seconds is far above every handler, so both are a
+    # backstop rather than a budget anything runs near.
+    #
+    # The timeout is measured to the first byte of the response, never to the last:
+    # `api/middleware/limits.py` cancels it when the response starts, because a wall
+    # clock over a whole response would cut off exactly the streamed replies Rule 3
+    # exists to make possible.
+    max_body_bytes: int = Field(default=1_048_576, ge=1024, le=104_857_600)
+    request_timeout_seconds: int = Field(default=30, ge=1, le=300)
+
     # Mail. Most installations have none, and that is a designed state rather than a
     # broken one: the `forgot` screen says so and points at a command on the machine.
     # `smtp_host` being unset is what puts the API into that answer.

--- a/api/main.py
+++ b/api/main.py
@@ -36,6 +36,7 @@ from api.jobs.runner import loop as job_loop
 from api.logging import configure_logging
 from api.middleware.auth import AuthenticationMiddleware
 from api.middleware.csrf import CsrfMiddleware
+from api.middleware.limits import RequestLimitsMiddleware
 from api.middleware.request_id import RequestIdMiddleware
 from api.middleware.ws_auth import WebSocketAuthMiddleware
 from api.routes import apps as apps_routes
@@ -257,6 +258,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # scopes, so without this every websocket route would bypass authentication.
     app.add_middleware(WebSocketAuthMiddleware)
     app.add_middleware(CsrfMiddleware)
+    # Between CSRF and the request id on purpose: a refusal here still carries an id the
+    # dashboard can quote, and an oversized body is dropped before authentication,
+    # session lookup and routing have been paid for.
+    app.add_middleware(
+        RequestLimitsMiddleware,
+        max_body_bytes=settings.max_body_bytes,
+        timeout_seconds=settings.request_timeout_seconds,
+    )
     app.add_middleware(RequestIdMiddleware)
     app.add_middleware(
         CORSMiddleware,

--- a/api/middleware/limits.py
+++ b/api/middleware/limits.py
@@ -1,0 +1,170 @@
+"""Ceilings on what one request may cost — G2.
+
+**The threat is a mistake, not an attacker.** An unbounded request body and an
+unbounded handler are both a denial of service that nobody has to intend: a loop that
+posts a growing payload, a query that turns out to be quadratic on a database somebody
+let grow. The point of a ceiling is that the failure is one refused request instead of
+a process that stops answering.
+
+Two limits live here, and one deliberately does not.
+
+**Body size** is checked twice. `Content-Length` refuses the honest oversized request
+before a single byte is read, and the body is then read here, up to the ceiling and no
+further — a chunked request declares no length at all, so a header check on its own is
+a limit any client can opt out of by not mentioning it.
+
+Reading it here rather than counting as the handler reads is not a preference. An
+exception raised on the receive channel is swallowed on the way out: the framework is
+parsing a body at that moment, so what reaches the client is "could not parse the
+body", a 400 that blames the caller's JSON for a limit they exceeded. Buffering is
+bounded by the ceiling itself — that is what the ceiling is — and it makes the refusal
+the one the caller can act on.
+
+**Time is measured to the first byte of the response, not to the last.** This is the
+subtle one, and getting it wrong would break the product's central rule: an agent
+streams its answer, so a wall clock over the whole response would cut off exactly the
+long replies Rule 3 exists to make possible. The deadline is therefore cancelled the
+moment `http.response.start` goes out, which covers routing, authorisation and the
+handler's own work, and leaves a stream to run for as long as somebody is reading it.
+
+**Page size is not enforced here.** A cap belongs on the endpoint that knows what a
+page of its own rows costs, declared as `Query(le=...)` so it is in the OpenAPI
+document and refused by validation with the same envelope. A middleware guessing a
+number for every list at once would be a number that is wrong for all of them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from api.errors import envelope_response
+
+logger = logging.getLogger("api.limits")
+
+
+def _content_length(scope: Scope) -> int | None:
+    for name, value in scope.get("headers") or []:
+        if name == b"content-length":
+            try:
+                return int(value)
+            except ValueError:
+                # A malformed length is not a length. `_read` measures the body
+                # either way, so this falls through to being counted rather than
+                # trusted.
+                return None
+    return None
+
+
+class RequestLimitsMiddleware:
+    """Refuse a request that is too large, or one that takes too long to answer."""
+
+    def __init__(self, app: ASGIApp, *, max_body_bytes: int, timeout_seconds: int) -> None:
+        self.app = app
+        self.max_body_bytes = max_body_bytes
+        self.timeout_seconds = timeout_seconds
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Websockets are exempt from both. A handshake carries no body, and a
+        # connection that is open for an hour is what a websocket is for - a deadline
+        # here would close every live transcript at thirty seconds.
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        declared = _content_length(scope)
+        if declared is not None and declared > self.max_body_bytes:
+            # Refused without reading a byte. Reading the body first to find out how
+            # big it is would be paying the exact cost the limit exists to avoid.
+            await self._refuse(scope, send, oversized=True, path=scope.get("path"))
+            return
+
+        body, oversized = await self._read(receive)
+        if oversized:
+            await self._refuse(scope, send, oversized=True, path=scope.get("path"))
+            return
+
+        # The body, replayed once. Everything after it is the disconnect channel, which
+        # the application still needs in order to notice a visitor who closed the tab -
+        # that is how cancellation reaches a stream.
+        replayed = False
+
+        async def replaying_receive() -> Message:
+            nonlocal replayed
+            if not replayed:
+                replayed = True
+                return {"type": "http.request", "body": body, "more_body": False}
+            return await receive()
+
+        started = False
+
+        try:
+            async with asyncio.timeout(self.timeout_seconds) as deadline:
+
+                async def watching_send(message: Message) -> None:
+                    nonlocal started
+                    if message["type"] == "http.response.start":
+                        started = True
+                        # The answer has begun, so the handler met its deadline. What
+                        # follows is a body being read at the reader's pace, and it is
+                        # not this middleware's business how long that takes.
+                        deadline.reschedule(None)
+                    await send(message)
+
+                await self.app(scope, replaying_receive, watching_send)
+        except TimeoutError:
+            # Only reachable before the response started - the deadline is gone by
+            # then. The handler's task has been cancelled, so its `finally` has run and
+            # nothing is left half-written.
+            if not started:
+                await self._refuse(scope, send, oversized=False, path=scope.get("path"))
+
+    async def _read(self, receive: Receive) -> tuple[bytes, bool]:
+        """The body, or the moment it passed the ceiling.
+
+        Stops at the first byte over, rather than draining the rest to find out how
+        much over it was: the caller has already been told the answer is no.
+        """
+        chunks: list[bytes] = []
+        seen = 0
+        while True:
+            message = await receive()
+            if message["type"] != "http.request":
+                # A disconnect before the body finished. Nothing to refuse and nothing
+                # to hand on; the empty body lets the application see the disconnect.
+                return b"", False
+            chunks.append(message.get("body", b""))
+            seen += len(chunks[-1])
+            if seen > self.max_body_bytes:
+                return b"", True
+            if not message.get("more_body"):
+                return b"".join(chunks), False
+
+    async def _refuse(
+        self, scope: Scope, send: Send, *, oversized: bool, path: str | None
+    ) -> None:
+        if oversized:
+            logger.warning("request body over the limit", extra={"path": path})
+            response = envelope_response(
+                status_code=413,
+                code="body_too_large",
+                message=f"That request body is larger than this installation accepts "
+                f"({self.max_body_bytes} bytes).",
+            )
+        else:
+            logger.warning("request timed out before answering", extra={"path": path})
+            response = envelope_response(
+                status_code=504,
+                code="request_timeout",
+                message=f"This request took longer than {self.timeout_seconds} seconds "
+                "to answer and was stopped.",
+            )
+        # Sent through the plain channel: the body was never consumed on the refused
+        # path, and the response does not read one.
+        await response(scope, _no_body, send)
+
+
+async def _no_body() -> Message:
+    return {"type": "http.request", "body": b"", "more_body": False}

--- a/api/routes/notifications.py
+++ b/api/routes/notifications.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import datetime as dt
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Request, status
+from fastapi import APIRouter, Query, Request, status
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession as DbSession
@@ -26,6 +26,12 @@ from api.dependencies import CurrentUser
 from api.errors import envelope_response
 from api.models import Notification
 from api.security.permissions import CurrentWorkspace, WorkspaceContext, require_reception
+
+# G2. The ceiling on one page, so `?limit=100000000` is a refusal rather than a query
+# that reads the table into memory. Declared here rather than in a middleware: a cap
+# belongs on the endpoint that knows what a page of its own rows costs, and this way it
+# is in the OpenAPI document and refused by validation with the standard envelope.
+PAGE = 200
 
 router = APIRouter(prefix="/api/notifications", tags=["notifications"])
 
@@ -97,7 +103,7 @@ async def list_notifications(
     request: Request,
     context: CurrentWorkspace,
     category: str | None = None,
-    limit: int = 50,
+    limit: Annotated[int, Query(ge=1, le=PAGE)] = 50,
 ) -> NotificationList:
     db: DbSession = request.state.db
 

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,0 +1,130 @@
+"""Ceilings on one request — G2.
+
+Built against a throwaway application rather than the real one, because what is being
+tested is the middleware: making a real route slow enough to time out would mean
+shipping a slow route. The last two tests are the ones that would actually hurt if the
+middleware were wrong — a chunked body escaping the limit, and a stream being cut off
+by a deadline meant for the handler.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from httpx import ASGITransport, AsyncClient
+
+from api.errors import install_error_handlers
+from api.middleware.limits import RequestLimitsMiddleware
+
+LIMIT = 2048
+
+
+def _app(*, max_body_bytes: int = LIMIT, timeout_seconds: int = 30) -> FastAPI:
+    app = FastAPI()
+    install_error_handlers(app)
+    app.add_middleware(
+        RequestLimitsMiddleware,
+        max_body_bytes=max_body_bytes,
+        timeout_seconds=timeout_seconds,
+    )
+
+    @app.post("/echo")
+    async def echo(payload: dict) -> dict:
+        return {"seen": len(payload.get("text", ""))}
+
+    @app.get("/slow")
+    async def slow() -> dict:
+        await asyncio.sleep(5)
+        return {"never": True}
+
+    @app.get("/stream")
+    async def stream() -> StreamingResponse:
+        async def body() -> AsyncIterator[bytes]:
+            # The first chunk is what ends the deadline. Everything after it arrives
+            # long past the timeout, which is the point.
+            yield b"first"
+            await asyncio.sleep(1.2)
+            yield b"-last"
+
+        return StreamingResponse(body(), media_type="text/plain")
+
+    return app
+
+
+@pytest.fixture
+async def client():
+    app = _app()
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://localhost") as http:
+        yield http
+
+
+async def test_a_body_within_the_limit_is_ordinary(client) -> None:
+    answer = await client.post("/echo", json={"text": "x" * 100})
+    assert answer.status_code == 200
+    assert answer.json() == {"seen": 100}
+
+
+async def test_a_declared_oversized_body_is_refused_in_the_standard_envelope(client) -> None:
+    """Refused on `Content-Length`, before a byte is read. Reading it first to find out
+    how big it is would be paying the exact cost the limit exists to avoid."""
+    answer = await client.post("/echo", json={"text": "x" * (LIMIT * 2)})
+
+    assert answer.status_code == 413
+    body = answer.json()["error"]
+    assert body["code"] == "body_too_large"
+    # The same shape as every other refusal: the dashboard was promised one.
+    assert set(body) == {"code", "message", "details", "request_id"}
+
+
+async def test_a_chunked_body_cannot_opt_out_of_the_limit(client) -> None:
+    """The test that justifies counting at all.
+
+    A chunked request declares no `Content-Length`, so a header check on its own is a
+    limit any client can skip by not mentioning it.
+    """
+
+    async def oversized() -> AsyncIterator[bytes]:
+        for _ in range(8):
+            yield b"x" * 512
+
+    answer = await client.post(
+        "/echo",
+        content=oversized(),
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert "content-length" not in {name.lower() for name in answer.request.headers}
+    assert answer.status_code == 413
+    assert answer.json()["error"]["code"] == "body_too_large"
+
+
+async def test_a_handler_that_never_answers_is_stopped(client) -> None:
+    app = _app(timeout_seconds=1)
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://localhost") as http:
+        answer = await http.get("/slow")
+
+    assert answer.status_code == 504
+    assert answer.json()["error"]["code"] == "request_timeout"
+
+
+async def test_a_stream_is_not_cut_off_by_the_handlers_deadline() -> None:
+    """The one that protects Rule 3.
+
+    The agent streams its answer, so a wall clock over the whole response would cut off
+    exactly the long replies the product is built to make possible. The deadline covers
+    the handler; it ends when the first byte does.
+    """
+    app = _app(timeout_seconds=1)
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://localhost") as http:
+        answer = await http.get("/stream")
+
+    assert answer.status_code == 200
+    # The second chunk arrives 1.2s in, well past the one-second deadline.
+    assert answer.text == "first-last"


### PR DESCRIPTION
G2. Independent of [#116](https://github.com/Dpro-at/Tel-Agent/pull/116) and
[#117](https://github.com/Dpro-at/Tel-Agent/pull/117) — branched from `main`, merge in
any order.

Refs `internal/TASKS.md` G2.

## Three gaps, one of them live

- **No body size limit anywhere.** Any request of any size was read in full.
- **`GET /api/notifications` took `limit` with no cap at all** — `?limit=100000000`
  read the table into memory. Every other list is either capped (`conversations`,
  `system`) or uses a constant (`contacts`); this was the only caller-controlled one.
- **No deadline on any handler.**

The threat is a mistake, not an attacker: an unbounded body and an unbounded handler
are each a denial of service nobody has to intend.

## The body ceiling is checked twice

`Content-Length` refuses the honest oversized request before a byte is read. The body
is then read in the middleware up to the ceiling and no further — a chunked request
declares no length at all, so a header check alone is a limit any client opts out of by
not mentioning it.

**Reading it there rather than counting as the handler reads is not a preference.** My
first version raised on the receive channel, and the framework swallowed it: it is
parsing a body at that moment, so what reached the client was a **400 "could not parse
the body"** — blaming the caller's JSON for a limit they exceeded. Buffering is bounded
by the ceiling itself, which is what a ceiling is.

## The deadline is measured to the first byte, never to the last

This is the part that would have broken the product. The agent streams its answer, so a
wall clock over a whole response would cut off exactly the long replies Rule 3 exists to
make possible. It is cancelled when `http.response.start` goes out — covering routing,
authorisation and the handler — and a stream then runs as long as somebody is reading
it. Websockets are exempt entirely.

## Page size stays on the endpoints

A cap belongs where the cost of a page of those rows is known, declared as
`Query(le=...)` so it is in the OpenAPI document and refused by validation with the same
envelope. A middleware guessing one number for every list would be wrong for all of them.

## How this was tested

5 tests, the two that matter being a chunked body that cannot opt out of the limit, and
a stream that is **not** cut off by the handler's deadline (first chunk immediately,
second at 1.2s, deadline 1s — the whole body arrives).

`ruff check` · `ruff format --check` · `lint-imports` — green.

**Full suite: 6 failures, none of them from this change.**

| Failure | Why |
|---|---|
| `test_recovery.py` ×3 | Pre-existing on `main`. `ssh_keys.verify_signature` returns `False` for a signature it just produced — looks like `ssh-keygen -Y verify` behaviour on Windows. Verified by stashing. |
| `test_settings_store` / `test_web_channel` / `test_webhooks` ×3 | The `.env` isolation gap that **#116 fixes**. This branch is off `main`, which does not have that fix yet. Proved by parking the file: all three pass with `.env` absent, fail with it present. |

Every test that exercises the real application now goes through this middleware and
passes.

### By hand, against the real API

Not the throwaway app the unit tests use:

- ordinary sign-in → 200, unchanged
- 2 MB body with `Content-Length` → **413 `body_too_large`**, request id in the envelope
- the same body **chunked**, no `Content-Length` → **413**
- `?limit=100000000` → **422**, naming the field: *"Input should be less than or equal
  to 200"*; `?limit=10` → 200
- **the SSE reply stream** → arrives chunk by chunk through the new deadline

The web chat channel was switched on to exercise the stream and switched back off
afterwards.

## Not in here

G1 (security headers) and G3 (do not expose the port by default) are separate. G3 in
particular changes how the project is launched — there is no bind setting today, the
host comes from whoever runs `uvicorn` — so it touches the README, the launch files and
CI, which is more than "easy" implies and more than belongs in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
