### PR TITLE
Give every response its security headers, without unembedding the widget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -185,6 +185,14 @@ MAX_BODY_BYTES=1048576
 # make a slow query fast; it makes the process wait longer before saying so.
 REQUEST_TIMEOUT_SECONDS=30
 
+# Strict-Transport-Security
+# ---------------------------------------------------------------------------
+# Seconds, and 0 means the header is not sent. Leave it at 0 unless this
+# installation is reached over TLS and always will be: a browser that sees this
+# header refuses plain HTTP to the host for that long, and nothing the server
+# does afterwards takes it back. 31536000 is a year.
+HSTS_SECONDS=0
+
 # ---------------------------------------------------------------------------
 # Scheduled tasks and background jobs
 # ---------------------------------------------------------------------------

--- a/api/config.py
+++ b/api/config.py
@@ -98,6 +98,14 @@ class Settings(BaseSettings):
     max_body_bytes: int = Field(default=1_048_576, ge=1024, le=104_857_600)
     request_timeout_seconds: int = Field(default=30, ge=1, le=300)
 
+    # G1. Off unless an operator sets it, and the default is not timidity. Most
+    # installations are a machine on a business network reached over plain HTTP, and a
+    # Strict-Transport-Security header sent to one of those makes the dashboard
+    # unreachable from every browser that saw it, for as long as the header said, with
+    # no way to undo it from the server. Seconds; 31536000 is a year, which is what an
+    # installation with TLS everywhere should eventually use.
+    hsts_seconds: int = Field(default=0, ge=0, le=63072000)
+
     # Mail. Most installations have none, and that is a designed state rather than a
     # broken one: the `forgot` screen says so and points at a command on the machine.
     # `smtp_host` being unset is what puts the API into that answer.

--- a/api/main.py
+++ b/api/main.py
@@ -38,6 +38,7 @@ from api.middleware.auth import AuthenticationMiddleware
 from api.middleware.csrf import CsrfMiddleware
 from api.middleware.limits import RequestLimitsMiddleware
 from api.middleware.request_id import RequestIdMiddleware
+from api.middleware.security_headers import SecurityHeadersMiddleware
 from api.middleware.ws_auth import WebSocketAuthMiddleware
 from api.routes import apps as apps_routes
 from api.routes import assistants as assistant_routes
@@ -254,6 +255,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # `RequestIdMiddleware`, so it is not logged under an id. A preflight carries no
     # application meaning, so that is the right thing to give up.
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=settings.trusted_hosts)
+    # Innermost of the application's own middleware, so it sees the response every
+    # route produced - including the ones that set a policy of their own, which it
+    # then leaves alone. See the module docstring: overwriting the widget's
+    # `frame-ancestors` would unembed every customer's chat bubble.
+    app.add_middleware(SecurityHeadersMiddleware, hsts_seconds=settings.hsts_seconds)
     app.add_middleware(AuthenticationMiddleware)
     # The websocket twin of the gate above: BaseHTTPMiddleware never sees websocket
     # scopes, so without this every websocket route would bypass authentication.

--- a/api/middleware/security_headers.py
+++ b/api/middleware/security_headers.py
@@ -1,0 +1,106 @@
+"""The headers every response carries — G1.
+
+Four of them are unconditional and one is not, and the difference is the point of this
+module.
+
+**Nothing here overwrites a header a route already set.** That is not politeness, it is
+what keeps the product working: `api/routes/widget.py` serves the embeddable chat page
+with its own `Content-Security-Policy`, whose `frame-ancestors` is the entire mechanism
+deciding which sites may embed a customer's widget (§B14). A middleware that replaced
+it with a stricter policy would make the web chat unembeddable everywhere, and the
+failure would appear as an empty iframe on a customer's site rather than as anything in
+a log here.
+
+**`X-Frame-Options` is decided by the same question**, and it is the trap that is easy
+to miss: it is a separate mechanism from `frame-ancestors`, so a browser that honours a
+blanket `DENY` refuses the embed even when the CSP allows it.
+
+The rule is therefore not "is there a `frame-ancestors`" but "does it **permit**
+anything". A policy that names an origin is a decision to be embeddable, and `DENY`
+would overrule it. A policy of `frame-ancestors 'none'` is the same refusal said in the
+newer language, and the old header belongs beside it for browsers that read only that
+one.
+
+**The policy is chosen by content type.** A JSON response can never legitimately load
+anything, so `default-src 'none'` is always correct for it. HTML is left alone: the
+documentation loads its viewer from elsewhere and the widget loads its own inline
+script, and a middleware guessing one policy for both would break whichever it guessed
+against.
+
+**HSTS is off unless asked for, and that is deliberate.** Most installations of this
+product are a machine on a business network reached over plain HTTP; sending them a
+Strict-Transport-Security header would make the dashboard unreachable from every
+browser that saw it, for as long as the header said, with no way to undo it from the
+server. It is also unusable on the recommended deployment without a decision this code
+cannot make: TLS is terminated by a reverse proxy, so the request arrives as plain
+HTTP, and inferring otherwise means trusting a forwarded header from whatever sent it.
+An operator who has TLS everywhere sets the number and means it.
+"""
+
+from __future__ import annotations
+
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# What a JSON response is allowed to do, which is nothing. It is data; a browser that
+# is somehow persuaded to render it as a document must not be able to fetch, frame or
+# execute anything from it.
+JSON_POLICY = "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'"
+
+
+def _permits_framing(policy: str) -> bool:
+    """Does this policy let anybody frame the response?
+
+    `frame-ancestors 'none'` is a refusal, so it does not count - the old header says
+    the same thing to older browsers and belongs beside it. Anything else named there
+    is a deliberate decision to be embeddable, and `X-Frame-Options: DENY` would
+    overrule it in exactly the browsers that still read it.
+    """
+    for directive in policy.split(";"):
+        name, _, value = directive.strip().partition(" ")
+        if name.lower() == "frame-ancestors":
+            return value.strip().lower() not in ("", "'none'")
+    return False
+
+
+class SecurityHeadersMiddleware:
+    """Add the headers a response does not already carry."""
+
+    def __init__(self, app: ASGIApp, *, hsts_seconds: int = 0) -> None:
+        self.app = app
+        self.hsts_seconds = hsts_seconds
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def with_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+
+                # No sniffing, ever. A JSON body a browser decides to treat as HTML is
+                # the shape half of the old reflected-XSS bugs took.
+                headers.setdefault("x-content-type-options", "nosniff")
+                # Nothing this API answers is worth telling the next site about, and
+                # a path here can carry a conversation handle.
+                headers.setdefault("referrer-policy", "no-referrer")
+
+                content_type = headers.get("content-type", "")
+                if "content-security-policy" not in headers and content_type.startswith(
+                    "application/json"
+                ):
+                    headers["content-security-policy"] = JSON_POLICY
+
+                if not _permits_framing(headers.get("content-security-policy", "")):
+                    headers.setdefault("x-frame-options", "DENY")
+
+                if self.hsts_seconds > 0:
+                    headers.setdefault(
+                        "strict-transport-security",
+                        f"max-age={self.hsts_seconds}; includeSubDomains",
+                    )
+
+            await send(message)
+
+        await self.app(scope, receive, with_headers)

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,120 @@
+"""The headers every response carries — G1.
+
+The first three are ordinary. The last two are the ones worth having a test for: a
+middleware that stamps `X-Frame-Options: DENY` on everything, or replaces a policy a
+route set on purpose, unembeds every customer's chat widget — and that failure shows up
+as an empty iframe on somebody else's website, not as anything in a log here.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Response
+from httpx import ASGITransport, AsyncClient
+
+from api.middleware.security_headers import JSON_POLICY, SecurityHeadersMiddleware
+
+
+def _app(*, hsts_seconds: int = 0) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware, hsts_seconds=hsts_seconds)
+
+    @app.get("/data")
+    async def data() -> dict:
+        return {"ok": True}
+
+    @app.get("/embeddable")
+    async def embeddable() -> Response:
+        """A route that has already decided who may frame it — the widget's shape."""
+        return Response(
+            content="<p>hello</p>",
+            media_type="text/html",
+            headers={
+                "Content-Security-Policy": (
+                    "frame-ancestors https://wagner-partner.test; default-src 'none'"
+                )
+            },
+        )
+
+    @app.get("/page")
+    async def page() -> Response:
+        """HTML with no policy of its own — the documentation's shape."""
+        return Response(content="<p>hello</p>", media_type="text/html")
+
+    return app
+
+
+async def _get(path: str, **kwargs):
+    transport = ASGITransport(app=_app(**kwargs), raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://localhost") as http:
+        return await http.get(path)
+
+
+async def test_a_json_answer_may_do_nothing_at_all() -> None:
+    """It is data. A browser talked into rendering it as a document must not be able to
+    fetch, frame or execute anything from it."""
+    answer = await _get("/data")
+
+    assert answer.headers["x-content-type-options"] == "nosniff"
+    assert answer.headers["referrer-policy"] == "no-referrer"
+    assert answer.headers["content-security-policy"] == JSON_POLICY
+    assert answer.headers["x-frame-options"] == "DENY"
+
+
+async def test_a_policy_a_route_set_is_left_alone() -> None:
+    """The one that keeps the product working.
+
+    `frame-ancestors` on the widget page is the entire mechanism deciding which sites
+    may embed a customer's chat (§B14). Replacing it with something stricter would
+    unembed every one of them.
+    """
+    answer = await _get("/embeddable")
+
+    assert answer.headers["content-security-policy"] == (
+        "frame-ancestors https://wagner-partner.test; default-src 'none'"
+    )
+
+
+async def test_a_page_that_says_who_may_frame_it_gets_no_x_frame_options() -> None:
+    """The trap next to it.
+
+    `X-Frame-Options` is a separate mechanism from `frame-ancestors`, so a blanket
+    `DENY` is honoured by browsers that read it and refuses the embed the CSP allowed.
+    """
+    answer = await _get("/embeddable")
+
+    assert "x-frame-options" not in answer.headers
+
+
+async def test_html_with_no_policy_is_framed_by_nobody_and_given_no_policy() -> None:
+    """The documentation's case: it loads its viewer from elsewhere, so a policy
+    guessed here would break it. Refusing to frame it is still right."""
+    answer = await _get("/page")
+
+    assert answer.headers["x-frame-options"] == "DENY"
+    assert "content-security-policy" not in answer.headers
+
+
+async def test_hsts_is_not_sent_unless_somebody_asked_for_it() -> None:
+    """A machine on a business network reached over plain HTTP that receives this
+    header becomes unreachable from every browser that saw it, for as long as the
+    header said, and nothing the server does afterwards takes it back."""
+    assert "strict-transport-security" not in (await _get("/data")).headers
+
+
+async def test_hsts_is_sent_when_it_is() -> None:
+    answer = await _get("/data", hsts_seconds=31536000)
+    assert answer.headers["strict-transport-security"] == (
+        "max-age=31536000; includeSubDomains"
+    )
+
+
+async def test_a_policy_that_refuses_framing_still_gets_the_older_header() -> None:
+    """The distinction the rule turns on.
+
+    `frame-ancestors 'none'` is a refusal, not a permission, so the old header says the
+    same thing to browsers that read only that one. It is `frame-ancestors <origin>` -
+    a deliberate decision to be embeddable - that `DENY` must not overrule.
+    """
+    answer = await _get("/data")
+    assert "frame-ancestors 'none'" in answer.headers["content-security-policy"]
+    assert answer.headers["x-frame-options"] == "DENY"

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,8 +1,63 @@
 import path from "node:path";
 import type { NextConfig } from "next";
 
+// Where the dashboard's own requests go. The API is a separate origin - a different
+// port in development, often a different host behind a reverse proxy - so `connect-src`
+// has to name it or every request the dashboard makes is blocked by its own policy.
+// This is the line that makes a CSP here worth testing in a browser rather than
+// asserting: get it wrong and the screens render perfectly and load nothing.
+const API_ORIGIN = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+/**
+ * G1. What this page is allowed to load, and who may frame it.
+ *
+ * `'unsafe-inline'` on scripts is not a shortcut taken for convenience. The honest
+ * alternative is a nonce, and a nonce has to be generated per request - which means
+ * every page becomes dynamically rendered, and this app is deliberately prerendered
+ * static across three locales. The inline scripts it covers are the ones the framework
+ * emits to hydrate; the application adds none of its own. Styles need it for the same
+ * reason and one more: the utility classes compile to a stylesheet, but a handful of
+ * computed colours are set as inline style attributes.
+ *
+ * Development additionally needs `'unsafe-eval'`, which the refresh runtime uses. It is
+ * added only there - shipping it would give away most of what the policy is for.
+ */
+function contentSecurityPolicy(): string {
+  const development = process.env.NODE_ENV !== "production";
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'unsafe-inline'${development ? " 'unsafe-eval'" : ""}`,
+    "style-src 'self' 'unsafe-inline'",
+    // `data:` covers the inlined icons; `blob:` the object URLs a download builds.
+    "img-src 'self' data: blob:",
+    "font-src 'self' data:",
+    `connect-src 'self' ${API_ORIGIN}${development ? " ws: wss:" : ""}`,
+    // The dashboard is never framed by anything. The widget is the embeddable
+    // surface, and it is served by the API with a policy of its own.
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+  ].join("; ");
+}
+
 const config: NextConfig = {
   reactStrictMode: true,
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "Content-Security-Policy", value: contentSecurityPolicy() },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "no-referrer" },
+          // Belt and braces with `frame-ancestors` above, for browsers that honour
+          // only this one.
+          { key: "X-Frame-Options", value: "DENY" },
+        ],
+      },
+    ];
+  },
   // On now that every screen in `docs/SPEC.md` §A6 exists: a link to a route that is
   // not there is a type error rather than a 404 found by clicking.
   typedRoutes: true,


### PR DESCRIPTION
G1. Independent of [#116](https://github.com/Dpro-at/Tel-Agent/pull/116),
[#117](https://github.com/Dpro-at/Tel-Agent/pull/117) and
[#118](https://github.com/Dpro-at/Tel-Agent/pull/118) — branched from `main`, merge in
any order.

Refs `internal/TASKS.md` G1.

Neither the API nor the dashboard sent a single security header before this.

## The trap this is written around

`api/routes/widget.py` serves the embeddable chat page with its own
`Content-Security-Policy`, and its `frame-ancestors` is the **entire mechanism**
deciding which sites may embed a customer's widget (§B14). A middleware that replaced
it with something stricter would make web chat unembeddable everywhere — and that
failure appears as an empty iframe on somebody else's website, not as anything in a log
here.

So: **nothing overwrites a header a route already set.**

`X-Frame-Options` is the trap beside it, because it is a *separate* mechanism from
`frame-ancestors` — a blanket `DENY` is honoured by browsers that read it and refuses
the embed the policy allowed. The rule is therefore not *"is there a `frame-ancestors`"*
but *"does it permit anything"*:

| Policy | `X-Frame-Options` |
|---|---|
| `frame-ancestors https://customer.test` | not sent — a deliberate decision to be embeddable |
| `frame-ancestors 'none'` | **sent** — the same refusal in newer language; the old header belongs beside it |
| no policy | sent |

My first version got this wrong and a test caught it: JSON answers lost their
`X-Frame-Options`, because their own policy says `'none'`. Denial is not permission.

## HSTS is off unless an operator sets it

Most installations are a machine on a business network reached over plain HTTP. One
such header makes the dashboard **unreachable from every browser that saw it**, for as
long as it said, with nothing the server can do to take it back. It is also unusable on
the recommended deployment without a decision this code cannot make: TLS is terminated
in front, so the request arrives as plain HTTP, and inferring otherwise means trusting
a forwarded header from whatever sent it.

## The dashboard's policy

In `next.config.ts`, where `connect-src` has to name the API's origin — a different
port in development, often a different host behind a proxy. **That one line is why the
task says to test this in a browser rather than assert it**: get it wrong and every
screen renders perfectly and loads nothing.

`'unsafe-inline'` on scripts is not convenience. The alternative is a nonce, a nonce
must be generated per request, and that makes every page dynamically rendered — while
this app is deliberately prerendered static across three locales. It covers the
framework's hydration scripts; the application adds none of its own. `'unsafe-eval'` is
added in development only, for the refresh runtime.

## How this was tested

7 tests. `ruff check` · `ruff format --check` · `lint-imports` · `next build` — green.

Full suite: 6 failures, **none from this change** — the same set as #118 on a
`main`-based branch: 3 pre-existing `test_recovery` SSH failures (absent in CI, see
#116) and 3 from the `.env` isolation gap that #116 fixes. CI has neither condition.

### In a browser, against the real dashboard and the real widget

- **API, JSON answer:** `nosniff` · `no-referrer` · `default-src 'none'; frame-ancestors
  'none'; base-uri 'none'; form-action 'none'` · `X-Frame-Options: DENY` · no HSTS
- **The real widget page:** keeps `frame-ancestors https://wagner-partner.test`, gets
  **no** `X-Frame-Options` — still embeddable — and gains `nosniff`
- **The dashboard:** full policy served, **zero CSP violations in the console**, and
  every cross-origin API call returned 200 (`/api/conversations`,
  `/api/conversations/meta/channels`, `/api/auth/me`, …) — which is the `connect-src`
  line proving itself

The web chat channel was switched on to check the widget headers and switched back off
afterwards.

## Not in here

G3 (do not expose the port by default) is separate — there is no bind setting today,
the host comes from whoever runs `uvicorn`, so it touches the README, the launch files
and CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
