### PR TITLE
Keep the port on this machine unless somebody says otherwise

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,18 @@ REQUEST_TIMEOUT_SECONDS=30
 # does afterwards takes it back. 31536000 is a year.
 HSTS_SECONDS=0
 
+# Where the server listens
+# ---------------------------------------------------------------------------
+# Loopback, so the port is not reachable from the network. The three supported
+# ways to reach an installation from elsewhere all talk to a server on
+# 127.0.0.1: a private network, a VPN, or a reverse proxy terminating TLS.
+#
+# Changing this exposes the port to everything that can route to this machine,
+# and `python -m api` says so in a warning when you do. There is no
+# authentication in front of it other than the product's own.
+BIND_HOST=127.0.0.1
+BIND_PORT=8000
+
 # ---------------------------------------------------------------------------
 # Scheduled tasks and background jobs
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -198,8 +198,10 @@ cable.
 
 ## Security notes
 
-- **Do not expose the port to the internet.** VPN, Tailscale, or a reverse proxy with
-  HTTPS are the supported paths.
+- **The port is not exposed by default.** The server listens on `127.0.0.1`, and
+  `python -m api` warns if you change that. The supported ways to reach an installation
+  from elsewhere — a private network, a VPN, or a reverse proxy terminating TLS — all
+  talk to a server on loopback, so none of them requires widening it.
 - **A password is required on first run.** There are no default credentials.
 - **API keys are encrypted at rest** and are never returned in full to the client.
 - **Recording announcements are on by default.** Austria requires both parties to be

--- a/api/__main__.py
+++ b/api/__main__.py
@@ -1,0 +1,81 @@
+"""Start the API — the entry point that honours where it is told to listen.
+
+    python -m api          # or `tel-agent`, once installed
+
+**Why this exists at all: a default only counts if something applies it.** The README
+has said "do not expose the port to the internet" since before there was a port, and
+nothing enforced it — the host came from whoever typed the `uvicorn` command, so a
+setting saying `127.0.0.1` would have been decoration. This module is the place the
+setting becomes the behaviour.
+
+§B9's supported paths are a private network, a VPN, or a reverse proxy terminating TLS.
+All three reach a process listening on loopback; none of them needs it listening on
+every interface. So loopback is the default and widening it is a decision somebody
+makes on purpose and sees a warning about.
+
+**What this cannot do, said plainly.** Running `uvicorn api.main:app --host 0.0.0.0` by
+hand still binds to every interface, and nothing here will know. That is why this is
+the documented way to start the server rather than one option among several — a
+default is only a default where it is the path of least effort. The application itself
+never logs which address it is on, because it cannot find out, and a line claiming
+loopback while the socket says otherwise would be worse than silence.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+
+from api.config import get_settings
+from api.logging import configure_logging
+
+logger = logging.getLogger("api")
+
+# Names that resolve to this machine and nowhere else. Checked before the numeric
+# parse, because `localhost` is not an address and would otherwise look like a
+# hostname somebody meant to expose.
+LOOPBACK_NAMES = frozenset({"localhost", "localhost.localdomain"})
+
+EXPOSED_WARNING = (
+    "Listening on %s, which is not loopback: this port is now reachable from the "
+    "network. The supported ways to reach an installation from elsewhere are a private "
+    "network, a VPN, or a reverse proxy terminating TLS - each of which talks to a "
+    "server on 127.0.0.1. Set BIND_HOST back unless you meant this."
+)
+
+
+def is_loopback(host: str) -> bool:
+    """Whether this address keeps the port on this machine."""
+    if host.lower() in LOOPBACK_NAMES:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        # A hostname that is not one of the two above. It is somebody's own name for a
+        # machine on a network, which is exactly the case worth warning about.
+        return False
+
+
+def main() -> None:
+    import uvicorn
+
+    settings = get_settings()
+    configure_logging(settings.log_level)
+
+    if not is_loopback(settings.bind_host):
+        logger.warning(EXPOSED_WARNING, settings.bind_host)
+
+    uvicorn.run(
+        "api.main:app",
+        host=settings.bind_host,
+        port=settings.bind_port,
+        # Off here on purpose. Reloading is a development convenience and it doubles
+        # the process count; `--reload` belongs on a command somebody types while
+        # working, not on the one an installation starts with.
+        reload=False,
+        log_config=None,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/api/config.py
+++ b/api/config.py
@@ -105,6 +105,13 @@ class Settings(BaseSettings):
     # no way to undo it from the server. Seconds; 31536000 is a year, which is what an
     # installation with TLS everywhere should eventually use.
     hsts_seconds: int = Field(default=0, ge=0, le=63072000)
+    # G3. Where the server listens, and it is loopback because §B9's three supported
+    # paths - a private network, a VPN, a reverse proxy terminating TLS - all reach a
+    # process on 127.0.0.1, and none of them needs one on every interface. Applied by
+    # `python -m api`, which is why that is the documented way to start it: a default
+    # nothing applies is decoration.
+    bind_host: str = "127.0.0.1"
+    bind_port: int = Field(default=8000, ge=1, le=65535)
 
     # Mail. Most installations have none, and that is a designed state rather than a
     # broken one: the `forgot` screen says so and points at a command on the machine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ dependencies = [
     "cryptography>=43.0",
 ]
 
+[project.scripts]
+# The documented way to start the API. It exists so that `bind_host` is applied rather
+# than suggested - see `api/__main__.py`.
+tel-agent = "api.__main__:main"
+
 [project.optional-dependencies]
 dev = [
     "ruff>=0.14",

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -1,0 +1,96 @@
+"""Where the server listens — G3.
+
+The README promised "do not expose the port" long before anything applied it. What is
+tested here is that the promise is now the default, that widening it is loud, and that
+`is_loopback` does not accidentally call somebody's own hostname safe.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from api.__main__ import EXPOSED_WARNING, is_loopback, main
+from api.config import Settings
+
+
+def test_the_default_keeps_the_port_on_this_machine() -> None:
+    """§B9's three supported paths - a private network, a VPN, a reverse proxy
+    terminating TLS - all reach a server on loopback. None needs one on every
+    interface, so none is a reason to make this the other way round."""
+    settings = Settings(_env_file=None)
+    assert settings.bind_host == "127.0.0.1"
+    assert settings.bind_port == 8000
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost", "LOCALHOST", "127.5.5.5"])
+def test_the_addresses_that_stay_on_this_machine(host: str) -> None:
+    assert is_loopback(host) is True
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "0.0.0.0",  # noqa: S104 - the string being tested, not a bind
+        "::",
+        "192.168.1.10",
+        "telagent.wagner-partner.local",
+        "",
+    ],
+)
+def test_the_addresses_that_do_not(host: str) -> None:
+    """A hostname is the case worth being strict about: it is somebody's own name for a
+    machine on a network, which is exactly the situation the warning is for."""
+    assert is_loopback(host) is False
+
+
+def test_widening_the_bind_is_said_out_loud(monkeypatch, caplog) -> None:
+    """A default nobody is told they left is a default that stops meaning anything."""
+    started: dict[str, object] = {}
+
+    def fake_run(app: str, **kwargs: object) -> None:
+        started.update(kwargs)
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+    monkeypatch.setenv("BIND_HOST", "0.0.0.0")  # noqa: S104 - the point of the test
+
+    from api.config import get_settings
+
+    get_settings.cache_clear()
+    try:
+        with caplog.at_level(logging.WARNING, logger="api"):
+            main()
+    finally:
+        get_settings.cache_clear()
+
+    assert started["host"] == "0.0.0.0"  # noqa: S104 - asserting what was asked for
+    # The message names what to do about it, not just that it happened.
+    assert EXPOSED_WARNING[:40] in caplog.text or "not loopback" in caplog.text
+    assert "reverse proxy" in caplog.text
+
+
+def test_the_default_start_says_nothing(monkeypatch, caplog) -> None:
+    """The warning has to be rare enough to read. An installation on loopback is the
+    ordinary case and gets no line at all."""
+
+    def fake_run(app: str, **kwargs: object) -> None:
+        return None
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+    monkeypatch.delenv("BIND_HOST", raising=False)
+
+    from api.config import get_settings
+
+    get_settings.cache_clear()
+    try:
+        with caplog.at_level(logging.WARNING, logger="api"):
+            main()
+    finally:
+        get_settings.cache_clear()
+
+    assert "not loopback" not in caplog.text


### PR DESCRIPTION
G3. Independent of #116, #117, #118 and #119 — branched from `main`, merge in any order.

Refs `internal/TASKS.md` G3, §B9.

## The gap was subtler than it looks

The README has promised *"Do not expose the port to the internet"* since before there
was a port — and **nothing applied it**. The host came from whoever typed the `uvicorn`
command, so a setting saying `127.0.0.1` would have been decoration. There was no such
setting either.

`python -m api` is the place the default becomes the behaviour. `[project.scripts]`
gives it the name `tel-agent`.

§B9's three supported paths — a private network, a VPN, a reverse proxy terminating TLS
— all reach a process listening on loopback. None of them needs one listening on every
interface, so widening it is a decision somebody makes on purpose and is warned about.

## What this cannot do, and why the module says so

Running `uvicorn api.main:app --host 0.0.0.0` by hand still binds everywhere and
nothing here will know. That is why this is *the documented way to start the server*
rather than one option among several — a default is only a default where it is the path
of least effort.

The application itself never logs which address it is on, because it cannot find out. A
line claiming loopback while the socket says otherwise would be worse than silence.

## How this was tested

5 tests. `ruff check` · `ruff format --check` · `lint-imports` — green, including
`test_crypto.py`'s check that `.env.example` cannot drift from the settings model.

Full suite: 6 failures, **none from this change** — the same set every `main`-based
branch shows: 3 pre-existing `test_recovery` SSH failures (absent in CI, see #116) and
3 from the `.env` isolation gap that #116 fixes. CI has neither condition.

### On a real socket, in both directions

| | |
|---|---|
| default | `127.0.0.1:8000` answers · `http://192.168.50.117:8000` **refused** (`000`) |
| `BIND_HOST=0.0.0.0` | the warning fires in full · the LAN address now answers |

**One thing worth knowing that this uncovered:** even with the bind widened, the LAN
address returned **400, not 200** — `TrustedHostMiddleware` is set to
`localhost,127.0.0.1` and refuses a `Host` header naming the network address. So
widening the bind alone does not serve the application to the network; `TRUSTED_HOSTS`
has to be widened too. That is a good existing second layer, and it means the mistake
this PR guards against was already half-caught.

The README's security note now describes what happens instead of what was hoped for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
