### PR TITLE
Send the webhooks the registry has only been recording

### DIFF
--- a/api/jobs/builtin.py
+++ b/api/jobs/builtin.py
@@ -201,6 +201,40 @@ async def _send_email(db: DbSession, payload: dict) -> None:
         raise RuntimeError("mail delivery failed")
 
 
+@job("webhook")
+async def _webhook(db: DbSession, payload: dict) -> None:
+    """Deliver one signed webhook, or raise so the runner tries again.
+
+    The hook is read at send time rather than carried in the payload: a secret rotated
+    while deliveries are waiting should rescue them, and a hook switched off during an
+    incident should stop them. Both are the same lookup.
+
+    A hook that has been deleted or switched off returns quietly. It is not a failure
+    to retry - there is nothing left to deliver to, and retrying until the attempts run
+    out would leave a permanently failed job for something the operator did on purpose.
+    """
+    import datetime as dt
+
+    from api import webhooks
+    from api.models import Webhook
+
+    hook = await db.get(Webhook, payload["webhook_id"])
+    if hook is None or not hook.enabled:
+        logger.info(
+            "webhook skipped: gone or switched off",
+            extra={"webhook_id": payload["webhook_id"], "event": payload["event"]},
+        )
+        return
+
+    await webhooks.send(
+        hook,
+        event=payload["event"],
+        data=payload["data"],
+        delivery_id=payload.get("delivery_id", 0),
+        now=dt.datetime.now(dt.UTC),
+    )
+
+
 async def last_task_status(db: DbSession) -> dict[str, dict[str, object]]:
     """What the scheduler last saw, for the health endpoint."""
     rows = (await db.execute(select(ScheduledTask))).scalars().all()

--- a/api/routes/public_chat.py
+++ b/api/routes/public_chat.py
@@ -38,7 +38,7 @@ from agent.providers.llm import LLMProvider
 from agent.providers.llm import Message as LlmMessage
 from agent.reply import reply as generate_reply
 from agent.tools import TakenMessage
-from api import llm
+from api import llm, webhooks
 from api.db import session_scope
 from api.errors import envelope_response
 from api.models import Channel, Conversation, Message
@@ -314,6 +314,50 @@ async def post_message(
             primary_action="open_conversation",
             action_payload={"conversation_id": conversation.id},
             conversation_id=conversation.id,
+        )
+
+    # Told to whatever the operator registered, and never at the visitor's expense.
+    # Queued rather than sent: a request that waits for somebody else's server is a
+    # request that inherits their outage, and the runner already knows how to retry.
+    #
+    # Swallowed for the same reason the tray's failures are: a widget that stops
+    # accepting messages because a webhook could not be written down is worse than a
+    # webhook nobody received.
+    try:
+        if started:
+            await webhooks.queue(
+                db,
+                workspace_id=channel.workspace_id,
+                event="conversation.started",
+                data={
+                    "conversation": conversation.external_id,
+                    "channel": "web",
+                    "started_at": conversation.started_at.isoformat()
+                    if conversation.started_at
+                    else None,
+                },
+            )
+        await webhooks.queue(
+            db,
+            workspace_id=channel.workspace_id,
+            event="message.received",
+            data={
+                "conversation": conversation.external_id,
+                "message_id": message.id,
+                "speaker": "caller",
+                # The visitor's own words, in full. This is the whole reason somebody
+                # registers this event, and trimming it here would make the hook
+                # useless for the case it exists for.
+                "text": message.text,
+                "ts_ms": message.ts_ms,
+            },
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        logger.exception(
+            "could not queue webhooks for an accepted message",
+            extra={"conversation_id": conversation.id},
         )
 
     logger.info(

--- a/api/webhooks.py
+++ b/api/webhooks.py
@@ -1,0 +1,169 @@
+"""Sending a webhook, and proving it came from here — G5.
+
+`api/routes/webhooks.py` has held the registry since it was written, and said so at the
+top: *"Nothing sends anything yet."* This is the part that sends.
+
+**Why a signature at all.** A webhook is a POST from an unauthenticated stranger as far
+as the receiver is concerned. Anybody who learns the URL — and a URL leaks through
+proxy logs, browser history, a screenshot in a ticket — can post whatever they like to
+it, and a receiver that acts on `conversation.ended` will act on a forged one. The
+shared secret is what makes the receiver able to tell.
+
+**The timestamp is inside the signed string, not beside it.** Signing only the body
+means a message captured once can be replayed for as long as the secret lives, and the
+signature stays valid because the body has not changed. Signing `timestamp.body` means
+the receiver can refuse anything older than a few minutes and know the timestamp was
+not edited on the way.
+
+**The envelope has a `data` key from the first delivery.** Not decoration: everything
+this ever sends is under it, so the day a field has to be added beside `event` there is
+somewhere to put it that does not move what a receiver is already reading. A payload
+whose top level is the data itself has no such place, and gains one only by breaking
+every receiver at once.
+
+**Delivery, retries and permanent failure are the background runner's**, which already
+does all three (`api/jobs/runner.py`). A hook that is briefly unreachable produces a
+webhook that arrives late rather than one that is lost, and the operator sees the
+failure on a job rather than in a log nobody reads.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import hmac
+import json
+import logging
+from typing import Any
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession as DbSession
+
+from api.models import Webhook
+
+logger = logging.getLogger("api.webhooks")
+
+# The receiver reads these. Named rather than inlined so the documented verification
+# recipe and the sender cannot drift apart.
+EVENT_HEADER = "X-Tel-Agent-Event"
+TIMESTAMP_HEADER = "X-Tel-Agent-Timestamp"
+SIGNATURE_HEADER = "X-Tel-Agent-Signature"
+# The job's id. A receiver that acts on a delivery keeps this and ignores a repeat:
+# retries mean the same event can arrive twice, and "at least once" is the only
+# promise a sender that retries can honestly make.
+DELIVERY_HEADER = "X-Tel-Agent-Delivery"
+
+# Prefixed with the algorithm so that adding a second one later is a new prefix rather
+# than a guess about which of two hashes a hex string is.
+SIGNATURE_PREFIX = "sha256="
+
+# Tight on purpose. A receiver that takes longer than this is a receiver whose reply
+# nobody is waiting for, and the runner will try again - holding a worker open for a
+# slow endpoint is how one bad receiver stops every other hook.
+TIMEOUT = httpx.Timeout(connect=5.0, read=10.0, write=5.0, pool=5.0)
+
+
+def sign(secret: str, *, timestamp: int, body: bytes) -> str:
+    """The value of the signature header for this body at this moment.
+
+    HMAC-SHA256 over `{timestamp}.{body}`, hex, behind its algorithm's name. The
+    documented recipe in `docs/SPEC.md` is this function in words; if one changes the
+    other has to.
+    """
+    signed = f"{timestamp}.".encode() + body
+    digest = hmac.new(secret.encode(), signed, hashlib.sha256).hexdigest()
+    return SIGNATURE_PREFIX + digest
+
+
+def envelope(event: str, data: dict[str, Any], *, sent_at: dt.datetime) -> bytes:
+    """The body, as bytes, because bytes are what gets signed.
+
+    Serialised once and both signed and sent, never serialised twice: two dumps of one
+    dictionary can differ in key order or spacing, and a signature over a different
+    byte string than the one delivered fails at the receiver for a reason nobody can
+    see from either end.
+    """
+    return json.dumps(
+        {"event": event, "sent_at": sent_at.isoformat(), "data": data},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+
+
+async def queue(db: DbSession, *, workspace_id: int, event: str, data: dict[str, Any]) -> int:
+    """Hand this event to every hook in the workspace that asked for it.
+
+    Returns how many were queued. Nothing is sent here: this runs inside a request, and
+    a request that waits for somebody else's server is a request that inherits their
+    outage. The caller commits.
+    """
+    from api.jobs.runner import enqueue
+
+    rows = (
+        (
+            await db.execute(
+                select(Webhook).where(
+                    Webhook.workspace_id == workspace_id, Webhook.enabled.is_(True)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    queued = 0
+    for hook in rows:
+        if event not in (hook.events or []):
+            continue
+        # The webhook's id, not its secret. A payload row is readable by anything that
+        # can read the database, and a queue is a strange second place for a credential
+        # to live; the handler reads the live one at send time, which also means
+        # rotating a secret rescues the deliveries already waiting.
+        await enqueue(db, "webhook", {"webhook_id": hook.id, "event": event, "data": data})
+        queued += 1
+
+    if queued:
+        logger.info("webhooks queued", extra={"event": event, "count": queued})
+    return queued
+
+
+async def send(
+    hook: Webhook,
+    *,
+    event: str,
+    data: dict[str, Any],
+    delivery_id: int,
+    now: dt.datetime,
+    client: httpx.AsyncClient | None = None,
+) -> None:
+    """POST one signed delivery. Raises on anything that is worth retrying.
+
+    A 2xx is success. Everything else raises, and the runner decides whether that
+    becomes a retry or a permanent failure - it already knows how many attempts this
+    delivery has had and this function does not.
+    """
+    body = envelope(event, data, sent_at=now)
+    timestamp = int(now.timestamp())
+    headers = {
+        "Content-Type": "application/json",
+        EVENT_HEADER: event,
+        TIMESTAMP_HEADER: str(timestamp),
+        SIGNATURE_HEADER: sign(hook.secret, timestamp=timestamp, body=body),
+        DELIVERY_HEADER: str(delivery_id),
+    }
+
+    async def post(http: httpx.AsyncClient) -> httpx.Response:
+        return await http.post(hook.url, content=body, headers=headers)
+
+    if client is not None:
+        response = await post(client)
+    else:
+        async with httpx.AsyncClient(timeout=TIMEOUT, follow_redirects=False) as http:
+            response = await post(http)
+
+    if response.status_code >= 300:
+        # Redirects included, deliberately. A signed POST that follows a redirect
+        # delivers the signature somewhere the operator never registered, and that is
+        # the one failure mode worth being noisy about rather than quietly obeying.
+        raise RuntimeError(f"{hook.url} answered {response.status_code}")

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -814,13 +814,17 @@ that string matter and both are deliberate:
 ```python
 import hashlib, hmac, time
 
+
 def verify(secret: str, headers, raw_body: bytes, tolerance: int = 300) -> bool:
     timestamp = int(headers["X-Tel-Agent-Timestamp"])
     if abs(time.time() - timestamp) > tolerance:
         return False
-    expected = "sha256=" + hmac.new(
-        secret.encode(), f"{timestamp}.".encode() + raw_body, hashlib.sha256
-    ).hexdigest()
+    expected = (
+        "sha256="
+        + hmac.new(
+            secret.encode(), f"{timestamp}.".encode() + raw_body, hashlib.sha256
+        ).hexdigest()
+    )
     # Constant time: a plain `==` leaks how much of the signature was right.
     return hmac.compare_digest(expected, headers["X-Tel-Agent-Signature"])
 ```

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -784,6 +784,52 @@ paths that spend real money.
 
 Each signed with a shared secret.
 
+**The names above are the phone-era set and are superseded in code.** §B5 decision 6
+made a call a conversation on a `phone` channel, so `api/models/webhook.py` sends
+`conversation.started`, `conversation.ended`, `message.received`, `assistant.changed`
+and `knowledge.changed`. This list should be rewritten against that when somebody
+settles what the remaining four become.
+
+### How a receiver verifies one
+
+Every delivery carries four headers:
+
+| Header | |
+|---|---|
+| `X-Tel-Agent-Event` | the event name |
+| `X-Tel-Agent-Timestamp` | unix seconds, and part of what is signed |
+| `X-Tel-Agent-Signature` | `sha256=` followed by the hex HMAC |
+| `X-Tel-Agent-Delivery` | the delivery's id — **keep it and ignore repeats** |
+
+The signature is `HMAC-SHA256(secret, f"{timestamp}.{raw_body}")`, hex. Two things about
+that string matter and both are deliberate:
+
+- **The timestamp is inside it.** Signing the body alone means a delivery captured once
+  can be replayed for as long as the secret lives, because the body has not changed.
+  Refuse anything whose timestamp is more than a few minutes old.
+- **`raw_body` is the bytes as they arrived**, before any parse. A framework that
+  re-serialises the JSON for you produces a different byte string, and the signature
+  over it will not match no matter how correct the code looks.
+
+```python
+import hashlib, hmac, time
+
+def verify(secret: str, headers, raw_body: bytes, tolerance: int = 300) -> bool:
+    timestamp = int(headers["X-Tel-Agent-Timestamp"])
+    if abs(time.time() - timestamp) > tolerance:
+        return False
+    expected = "sha256=" + hmac.new(
+        secret.encode(), f"{timestamp}.".encode() + raw_body, hashlib.sha256
+    ).hexdigest()
+    # Constant time: a plain `==` leaks how much of the signature was right.
+    return hmac.compare_digest(expected, headers["X-Tel-Agent-Signature"])
+```
+
+**Delivery is at least once.** A receiver that is briefly unreachable is retried with
+backoff, so the same event can arrive twice — act on `X-Tel-Agent-Delivery` once and
+ignore a repeat. **Redirects are not followed**: a signed POST that follows one delivers
+the signature somewhere the operator never registered.
+
 **Webhook in:** `POST /hooks/call` — start an outbound call from n8n or anything else.
 
 ## B7. Built-in tools

--- a/tests/test_public_chat.py
+++ b/tests/test_public_chat.py
@@ -1151,3 +1151,80 @@ async def test_half_a_configuration_never_reaches_the_visitor(
     assert GREETING.split(" ")[0] in body
     assert "API key" not in body
     assert "llm." not in body
+
+
+async def test_a_registered_hook_is_told_a_stranger_wrote_in(stage, configured_key) -> None:
+    """The other half of G5: a sender nothing calls is the same thing as no sender.
+
+    Queued rather than sent, because a request that waits for somebody else's server is
+    a request that inherits their outage - the runner does the delivering.
+    """
+    from api.models import BackgroundJob, Channel, Webhook
+
+    http, paths, db = stage
+    ours = await db.scalar(select(Channel).where(Channel.webhook_path == paths["ours"]))
+    db.add(
+        Webhook(
+            workspace_id=ours.workspace_id,
+            url="https://wagner-partner.test/hooks",
+            events=["conversation.started", "message.received"],
+            secret="a-shared-secret",  # noqa: S106
+            enabled=True,
+        )
+    )
+    await db.commit()
+
+    answer = await http.post(
+        f"/public/chat/{paths['ours']}/messages",
+        json={"text": "hallo"},
+        headers={"Origin": ALLOWED},
+    )
+    assert answer.status_code == 201
+
+    queued = (
+        await db.scalars(select(BackgroundJob).where(BackgroundJob.kind == "webhook"))
+    ).all()
+    # The first message of a thread is both: the thread beginning, and a line arriving.
+    assert sorted(job.payload["event"] for job in queued) == [
+        "conversation.started",
+        "message.received",
+    ]
+    text = next(j for j in queued if j.payload["event"] == "message.received")
+    assert text.payload["data"]["text"] == "hallo"
+
+
+async def test_a_second_line_is_not_a_second_conversation_starting(
+    stage, configured_key
+) -> None:
+    """`conversation.started` fires once per thread. A visitor typing five lines is one
+    arrival, and a receiver told five times opens five tickets."""
+    from api.models import BackgroundJob, Channel, Webhook
+
+    http, paths, db = stage
+    ours = await db.scalar(select(Channel).where(Channel.webhook_path == paths["ours"]))
+    db.add(
+        Webhook(
+            workspace_id=ours.workspace_id,
+            url="https://wagner-partner.test/hooks",
+            events=["conversation.started"],
+            secret="a-shared-secret",  # noqa: S106
+            enabled=True,
+        )
+    )
+    await db.commit()
+
+    first = await http.post(
+        f"/public/chat/{paths['ours']}/messages",
+        json={"text": "hallo"},
+        headers={"Origin": ALLOWED},
+    )
+    await http.post(
+        f"/public/chat/{paths['ours']}/messages",
+        json={"text": "noch etwas", "conversation": first.json()["conversation"]},
+        headers={"Origin": ALLOWED},
+    )
+
+    queued = (
+        await db.scalars(select(BackgroundJob).where(BackgroundJob.kind == "webhook"))
+    ).all()
+    assert [job.payload["event"] for job in queued] == ["conversation.started"]

--- a/tests/test_webhook_delivery.py
+++ b/tests/test_webhook_delivery.py
@@ -1,0 +1,238 @@
+"""Sending a webhook, and proving it came from here — G5.
+
+`api/routes/webhooks.py` said it at the top since it was written: *"Nothing sends
+anything yet."* These are about the part that sends.
+
+The one that matters most is the last: the signature is over the bytes that were
+delivered. A sender that serialises twice produces a body the receiver cannot verify,
+and the failure is invisible from both ends — the code looks right, the JSON looks
+right, and the hash does not match.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import hmac
+import json
+
+import httpx
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api import webhooks
+from api.models import BackgroundJob, Webhook, Workspace
+
+SECRET = "the-shared-secret-a-receiver-also-has"  # noqa: S105
+NOW = dt.datetime(2026, 8, 31, 10, 0, tzinfo=dt.UTC)
+
+
+@pytest.fixture
+async def workspace(migrated: AsyncSession) -> int:
+    row = Workspace(name="Wagner & Partner")
+    migrated.add(row)
+    await migrated.commit()
+    return row.id
+
+
+async def _hook(
+    db: AsyncSession, workspace_id: int, *, events: list[str], enabled: bool = True
+) -> Webhook:
+    row = Webhook(
+        workspace_id=workspace_id,
+        url="https://wagner-partner.test/hooks/tel-agent",
+        events=events,
+        secret=SECRET,
+        enabled=enabled,
+    )
+    db.add(row)
+    await db.commit()
+    return row
+
+
+# --- The signature ------------------------------------------------------------
+
+
+def test_the_timestamp_is_inside_what_is_signed() -> None:
+    """Signing the body alone leaves a delivery replayable for the life of the secret:
+    the capture is still valid because the body has not changed."""
+    body = b'{"event":"x"}'
+
+    assert webhooks.sign(SECRET, timestamp=1, body=body) != webhooks.sign(
+        SECRET, timestamp=2, body=body
+    )
+
+
+def test_the_recipe_in_the_specification_verifies_what_the_sender_produces() -> None:
+    """The documented recipe, written out by hand rather than by calling `sign`.
+
+    If this ever fails, either the sender changed or `docs/SPEC.md` did, and a receiver
+    that followed the published instructions is rejecting real deliveries.
+    """
+    body = webhooks.envelope("message.received", {"text": "hallo"}, sent_at=NOW)
+    timestamp = int(NOW.timestamp())
+
+    expected = (
+        "sha256="
+        + hmac.new(SECRET.encode(), f"{timestamp}.".encode() + body, hashlib.sha256).hexdigest()
+    )
+
+    assert webhooks.sign(SECRET, timestamp=timestamp, body=body) == expected
+
+
+def test_the_envelope_keeps_the_payload_under_data() -> None:
+    """So the day a field is added beside `event` there is somewhere to put it that
+    does not move what every receiver is already reading."""
+    body = json.loads(webhooks.envelope("message.received", {"text": "hallo"}, sent_at=NOW))
+
+    assert set(body) == {"event", "sent_at", "data"}
+    assert body["data"] == {"text": "hallo"}
+
+
+# --- Who gets told ------------------------------------------------------------
+
+
+async def test_only_the_hooks_that_asked_for_this_event(
+    migrated: AsyncSession, workspace: int
+) -> None:
+    await _hook(migrated, workspace, events=["message.received"])
+    await _hook(migrated, workspace, events=["conversation.ended"])
+
+    queued = await webhooks.queue(
+        migrated, workspace_id=workspace, event="message.received", data={}
+    )
+    await migrated.commit()
+
+    assert queued == 1
+
+
+async def test_a_switched_off_hook_is_not_queued(
+    migrated: AsyncSession, workspace: int
+) -> None:
+    await _hook(migrated, workspace, events=["message.received"], enabled=False)
+
+    assert (
+        await webhooks.queue(
+            migrated, workspace_id=workspace, event="message.received", data={}
+        )
+        == 0
+    )
+
+
+async def test_another_workspaces_hook_never_hears_about_this_one(
+    migrated: AsyncSession, workspace: int
+) -> None:
+    """The isolation that matters most here: a webhook is an export, so one business's
+    conversation reaching another's endpoint is the worst thing this can do."""
+    theirs = Workspace(name="Wolf Studio")
+    migrated.add(theirs)
+    await migrated.flush()
+    await _hook(migrated, theirs.id, events=["message.received"])
+
+    assert (
+        await webhooks.queue(
+            migrated, workspace_id=workspace, event="message.received", data={}
+        )
+        == 0
+    )
+
+
+async def test_the_secret_is_not_written_into_the_queue(
+    migrated: AsyncSession, workspace: int
+) -> None:
+    """A queued row is readable by anything that can read the database, and it is a
+    strange second home for a credential. The handler reads the live one, which is also
+    what makes rotating a secret rescue the deliveries already waiting.
+    """
+    await _hook(migrated, workspace, events=["message.received"])
+    await webhooks.queue(
+        migrated, workspace_id=workspace, event="message.received", data={"text": "hallo"}
+    )
+    await migrated.commit()
+
+    jobs = (await migrated.scalars(select(BackgroundJob))).all()
+    assert jobs, "nothing was queued, so this proves nothing"
+    assert SECRET not in json.dumps([job.payload for job in jobs], default=str)
+    # And what it does carry is the id, so the handler can read the live secret.
+    assert jobs[0].payload["webhook_id"]
+
+
+# --- The delivery -------------------------------------------------------------
+
+
+async def test_the_signature_covers_the_bytes_that_were_delivered(
+    migrated: AsyncSession, workspace: int
+) -> None:
+    """The failure this prevents is invisible from both ends.
+
+    Serialise once for the signature and again for the body and the two can differ in
+    key order or spacing. The code looks right, the JSON looks right, and every
+    delivery is rejected by a receiver following the published recipe.
+    """
+    hook = await _hook(migrated, workspace, events=["message.received"])
+    seen: dict[str, object] = {}
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        seen["body"] = request.content
+        seen["headers"] = dict(request.headers)
+        return httpx.Response(200)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+        await webhooks.send(
+            hook,
+            event="message.received",
+            data={"text": "hallo"},
+            delivery_id=7,
+            now=NOW,
+            client=client,
+        )
+
+    body = seen["body"]
+    headers = seen["headers"]
+    timestamp = int(headers["x-tel-agent-timestamp"])
+
+    # Verified exactly as a receiver would, against the bytes that arrived.
+    expected = (
+        "sha256="
+        + hmac.new(SECRET.encode(), f"{timestamp}.".encode() + body, hashlib.sha256).hexdigest()
+    )
+    assert headers["x-tel-agent-signature"] == expected
+    assert headers["x-tel-agent-event"] == "message.received"
+    assert headers["x-tel-agent-delivery"] == "7"
+
+
+async def test_a_refusal_is_raised_so_the_runner_retries(
+    migrated: AsyncSession, workspace: int
+) -> None:
+    """The runner already knows how many attempts this has had; this function does not,
+    so it reports and lets that decision be made where the count lives."""
+    hook = await _hook(migrated, workspace, events=["message.received"])
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _r: httpx.Response(500))
+    ) as client:
+        with pytest.raises(RuntimeError) as failed:
+            await webhooks.send(
+                hook, event="message.received", data={}, delivery_id=1, now=NOW, client=client
+            )
+
+    assert "500" in str(failed.value)
+
+
+async def test_a_redirect_is_a_failure_rather_than_somewhere_to_follow(
+    migrated: AsyncSession, workspace: int
+) -> None:
+    """A signed POST that follows a redirect delivers the signature to a host the
+    operator never registered."""
+    hook = await _hook(migrated, workspace, events=["message.received"])
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda _r: httpx.Response(302, headers={"Location": "https://elsewhere.test/"})
+        )
+    ) as client:
+        with pytest.raises(RuntimeError):
+            await webhooks.send(
+                hook, event="message.received", data={}, delivery_id=1, now=NOW, client=client
+            )

--- a/tests/test_webhook_delivery.py
+++ b/tests/test_webhook_delivery.py
@@ -26,6 +26,27 @@ from api.models import BackgroundJob, Webhook, Workspace
 
 SECRET = "the-shared-secret-a-receiver-also-has"  # noqa: S105
 NOW = dt.datetime(2026, 8, 31, 10, 0, tzinfo=dt.UTC)
+KEY_HEX = "aa" * 32
+
+
+@pytest.fixture(autouse=True)
+def _encryption_key(monkeypatch: pytest.MonkeyPatch):
+    """A webhook's secret is an encrypted column, so these tests need a key.
+
+    Autouse and not optional: without it every test that writes a `Webhook` fails with
+    `EncryptionKeyError`, and on a machine that happens to have a real `ENCRYPTION_KEY`
+    in `.env` it passes anyway - which is how this reached CI green locally and red
+    there.
+    """
+    from api.config import get_settings
+    from api.models.encrypted import reset_key_cache
+
+    monkeypatch.setenv("ENCRYPTION_KEY", KEY_HEX)
+    get_settings.cache_clear()
+    reset_key_cache()
+    yield
+    get_settings.cache_clear()
+    reset_key_cache()
 
 
 @pytest.fixture


### PR DESCRIPTION
G5. Independent of #116–#120 — branched from `main`, merge in any order.

Refs `internal/TASKS.md` G5, `docs/SPEC.md` §B6.

`api/routes/webhooks.py` has said it at the top since it was written: *"Nothing sends
anything yet."* This is the part that sends.

## No new table

The background runner already does attempts, backoff and permanent failure, and
`_send_email` is a working outbound job beside this one. So a delivery is a queued job,
and the machinery that turns "briefly unreachable" into "arrives late rather than lost"
is machinery that already works and is already tested.

## Four decisions worth reviewing

**The timestamp is inside the signed string.** Signing the body alone leaves a delivery
replayable for as long as the secret lives — the capture stays valid because the body
has not changed. Signed as `{timestamp}.{body}`, a receiver can refuse anything older
than a few minutes and know the timestamp was not edited on the way.

**The body is serialised once and both signed and sent.** Two dumps of one dictionary
can differ in key order or spacing, and a signature over different bytes than were
delivered fails for a reason **invisible from either end**: the code looks right, the
JSON looks right, the hash does not match. That is the test I would keep if I could
keep only one.

**`data` is in the envelope from the first delivery.** Everything sent lives under it,
so the day a field is added beside `event` there is somewhere to put it that does not
move what receivers already read. `locales/*/install.json` describes that exact break
as a future release note — *"the body is now under data"*. Built this way it never
happens.

**Redirects are a failure, not somewhere to follow.** A signed POST that follows one
delivers the signature to a host the operator never registered.

The queue carries the webhook's **id, never its secret**: a queued row is readable by
anything that can read the database, and reading the live secret at send time is also
what makes rotating one rescue the deliveries already waiting.

## A real caller

A sender nothing calls is the same thing as no sender — the criticism this PR makes of
the registry. So `conversation.started` and `message.received` are wired where the web
chat can honestly raise them: queued inside the request, never sent there, and their
failures swallowed for the same reason the tray's are.

There is a test that a second line does **not** re-raise `conversation.started` — a
receiver told five times opens five tickets.

## A stale entry in the specification, flagged not fixed

§B6 lists `call.started · call.ended · intent.detected · message.taken · tool.failed ·
system.degraded`. `api/models/webhook.py` has said `conversation.*` since D-017 and §B5
decision 6 made a call a conversation. I added a note saying the list is superseded and
left the names alone — **what the remaining four become is your decision, not a side
effect of this PR.**

## How this was tested

12 tests. One writes the published verification recipe out by hand rather than calling
`sign()`, so `docs/SPEC.md` and the sender cannot drift apart: if that fails, a receiver
following the published instructions is rejecting real deliveries.

`ruff check` · `ruff format --check` · `lint-imports` — green.

Full suite: 6 failures, **none from this change** — the same set every `main`-based
branch shows (3 local `test_recovery` SSH, absent in CI; 3 from the `.env` isolation gap
#116 fixes). CI has neither condition.

No by-hand browser pass on this one: nothing here is visible in the dashboard, and the
delivery path is exercised against a mock transport that asserts the exact bytes and
headers a receiver would see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
