### PR TITLE
Let a colleague put words in the agent's mouth, mid-conversation

### DIFF
--- a/alembic/versions/2026_08_31_2031-afa4aef2e4c9_who_wrote_a_whisper.py
+++ b/alembic/versions/2026_08_31_2031-afa4aef2e4c9_who_wrote_a_whisper.py
@@ -1,0 +1,113 @@
+"""who wrote a whisper
+
+`messages.speaker` is a role — `caller`, `agent`, `human`. On a reception desk of four,
+`human` does not answer who coached the agent into what it then told a customer, and
+§A6.4's own transcript names the person. This is the column that name comes from.
+
+Null on every line a person did not write, which is nearly all of them. `SET NULL`
+rather than `CASCADE`: an account can be removed from an installation, and deleting the
+lines they wrote would take a customer's conversation with it.
+
+**Adding a column to `messages` is not a small migration on SQLite, and this is the
+trap.** SQLite cannot add a foreign key to an existing table, so `batch_alter_table`
+rebuilds it: new table, copy, drop, rename. The rebuild takes the three FTS5 triggers
+with it, because a trigger belongs to the table it is attached to and the dropped table
+was that table. Nothing errors. Search simply stops seeing anything written afterwards,
+and the failure looks like "the index is out of date" months later.
+
+So the triggers are dropped deliberately, recreated verbatim from `56268f297c2b`, and
+the shadow table is rebuilt from the copied rows. PostgreSQL takes the plain `ALTER`
+path, where the GIN index is untouched.
+
+Revision ID: afa4aef2e4c9
+Revises: d6f691ad9b67
+Create Date: 2026-08-31 20:31:33.368790
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "afa4aef2e4c9"
+down_revision: str | Sequence[str] | None = "d6f691ad9b67"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Verbatim from `56268f297c2b`, which is the point: these have to come back exactly as
+# they were, or search comes back subtly different from the search that was tested.
+_FTS_TRIGGERS = (
+    (
+        "CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN"
+        "  INSERT INTO messages_fts(rowid, text) VALUES (new.id, new.text);"
+        "END"
+    ),
+    (
+        "CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN"
+        "  INSERT INTO messages_fts(messages_fts, rowid, text)"
+        "  VALUES ('delete', old.id, old.text);"
+        "END"
+    ),
+    (
+        "CREATE TRIGGER messages_fts_update AFTER UPDATE ON messages BEGIN"
+        "  INSERT INTO messages_fts(messages_fts, rowid, text)"
+        "  VALUES ('delete', old.id, old.text);"
+        "  INSERT INTO messages_fts(rowid, text) VALUES (new.id, new.text);"
+        "END"
+    ),
+)
+
+_TRIGGER_NAMES = ("messages_fts_insert", "messages_fts_delete", "messages_fts_update")
+
+
+def _drop_search_triggers() -> None:
+    if op.get_bind().dialect.name != "sqlite":
+        return
+    for name in _TRIGGER_NAMES:
+        op.execute(f"DROP TRIGGER IF EXISTS {name}")
+
+
+def _restore_search_triggers() -> None:
+    """Put the triggers back, then rebuild the index they maintain.
+
+    The rebuild is not optional. The rows were copied into a new table while nothing
+    was watching, so the shadow table is describing rowids from before the copy.
+    """
+    if op.get_bind().dialect.name != "sqlite":
+        return
+    for statement in _FTS_TRIGGERS:
+        op.execute(statement)
+    op.execute("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')")
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    _drop_search_triggers()
+    with op.batch_alter_table("messages", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("author_user_id", sa.Integer(), nullable=True))
+        batch_op.create_index(
+            batch_op.f("ix_messages_author_user_id"), ["author_user_id"], unique=False
+        )
+        batch_op.create_foreign_key(
+            batch_op.f("fk_messages_author_user_id_users"),
+            "users",
+            ["author_user_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    _restore_search_triggers()
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    _drop_search_triggers()
+    with op.batch_alter_table("messages", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            batch_op.f("fk_messages_author_user_id_users"), type_="foreignkey"
+        )
+        batch_op.drop_index(batch_op.f("ix_messages_author_user_id"))
+        batch_op.drop_column("author_user_id")
+    _restore_search_triggers()

--- a/api/models/conversation.py
+++ b/api/models/conversation.py
@@ -230,6 +230,19 @@ class Message(Base):
     # An operator's instruction to the agent, mid-conversation. Stored in the transcript
     # because it is part of what happened, flagged because the customer never saw it.
     is_whisper: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # Which person wrote it, when a person did.
+    #
+    # `speaker` is a role, and on a reception desk of four "human" is not an answer to
+    # who coached the agent into what it then told a customer. §A6.4's own transcript
+    # names the person - *human joined: Mohamed* - so the column the name comes from
+    # has to exist.
+    #
+    # Null for every line a person did not write, which is nearly all of them.
+    # `SET NULL` rather than `CASCADE`: an account can be removed from an installation,
+    # and deleting the lines they wrote would delete a customer's conversation with it.
+    author_user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     # §B5 decision 5, per line rather than per conversation.
     #
     # Both are null on text channels, and that null is itself the signal that the line

--- a/api/routes/conversations.py
+++ b/api/routes/conversations.py
@@ -18,10 +18,11 @@ behind them. They stay drawings rather than becoming buttons that do nothing.
 from __future__ import annotations
 
 import datetime as dt
+import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession as DbSession
 
@@ -32,8 +33,12 @@ from api.conversations import (
     previews,
     search_filter,
 )
-from api.models import Call, Channel, Contact, Conversation, Message
-from api.security.permissions import WorkspaceContext, require_viewer
+from api.dependencies import CurrentUser
+from api.errors import envelope_response
+from api.models import Call, Channel, Contact, Conversation, Message, User
+from api.security.permissions import WorkspaceContext, require_reception, require_viewer
+
+logger = logging.getLogger("api.conversations")
 
 router = APIRouter(prefix="/api/conversations", tags=["conversations"])
 
@@ -87,6 +92,8 @@ class MessageOut(BaseModel):
     # flagged because the customer never saw it - a screen that drew it like any other
     # line would be showing a conversation that did not happen.
     is_whisper: bool
+    # Who wrote it, when a person did. `speaker` is a role; this is the name.
+    author: str | None
     stt_confidence: float | None
     language: str | None
 
@@ -307,6 +314,19 @@ async def read_conversation(
     )
     call = await db.get(Call, row.id)
     name_by_who = await _names_for(db, context.id, [row.external_id])
+    # One query for every author on the thread rather than one per line. Whispers are a
+    # handful of lines out of hundreds, so the set is nearly always empty or tiny.
+    author_ids = {m.author_user_id for m in messages if m.author_user_id is not None}
+    author_by_id: dict[int, str] = (
+        {
+            user_id: username
+            for user_id, username in (
+                await db.execute(select(User.id, User.username).where(User.id.in_(author_ids)))
+            ).all()
+        }
+        if author_ids
+        else {}
+    )
 
     return ThreadDetail(
         **_thread(
@@ -325,6 +345,7 @@ async def read_conversation(
                 speaker=m.speaker,
                 text=m.text,
                 is_whisper=m.is_whisper,
+                author=author_by_id.get(m.author_user_id or 0),
                 stt_confidence=m.stt_confidence,
                 language=m.language,
             )
@@ -340,4 +361,88 @@ async def read_conversation(
             if call is not None
             else None
         ),
+    )
+
+
+class Whisper(BaseModel):
+    text: str = Field(min_length=1, max_length=2000)
+
+
+@router.post(
+    "/{conversation_id}/whisper",
+    response_model=MessageOut,
+    status_code=status.HTTP_201_CREATED,
+    summary="Say something to the agent that the customer will not see",
+)
+async def whisper(
+    request: Request,
+    context: Annotated[WorkspaceContext, require_reception],
+    user: CurrentUser,
+    conversation_id: int,
+    payload: Whisper,
+) -> object:
+    """§A6.7's first intervention, and the one it calls highest value and lowest cost.
+
+    The agent is told; the customer is not. Both halves of that already existed - the
+    model is handed a whisper as a system note and the widget's thread filters it out
+    (`api/routes/public_chat.py`) - and there was no way to write one. This is it.
+
+    **Reception, not viewer.** Reading a transcript and putting words into the agent's
+    mouth are different powers: this line becomes part of what a customer is told.
+
+    **A closed thread is refused rather than accepted quietly.** Nothing is listening to
+    it, so a whisper written into one is coaching for nobody - and it would sit in the
+    archive looking exactly like coaching that arrived in time.
+    """
+    db: DbSession = request.state.db
+    text = payload.text.strip()
+    if not text:
+        return envelope_response(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            code="empty_whisper",
+            message="A whisper needs something in it.",
+        )
+
+    row = await db.scalar(
+        conversations_for(context.id).where(Conversation.id == conversation_id)
+    )
+    if row is None:
+        # Same silence as the read above: another workspace's id answers like one that
+        # does not exist.
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="No such conversation.")
+    if row.status != "open":
+        return envelope_response(
+            status_code=status.HTTP_409_CONFLICT,
+            code="conversation_closed",
+            message="This conversation has ended, so nothing is listening to a whisper.",
+        )
+
+    line = Message(
+        workspace_id=context.id,
+        conversation_id=row.id,
+        # The same clock `api/routes/public_chat.py` writes, so the whisper sorts among
+        # the lines it belongs between rather than at one end of them.
+        ts_ms=int(dt.datetime.now(dt.UTC).timestamp() * 1000),
+        speaker="human",
+        text=text,
+        is_whisper=True,
+        author_user_id=user.id,
+        # Null on a text channel, and the null is §B5's own signal that this was typed.
+        stt_confidence=None,
+        language=None,
+    )
+    db.add(line)
+    await db.commit()
+    await db.refresh(line)
+
+    logger.info("whisper written into conversation %s by %s", row.id, user.username)
+    return MessageOut(
+        id=line.id,
+        ts_ms=line.ts_ms,
+        speaker=line.speaker,
+        text=line.text,
+        is_whisper=line.is_whisper,
+        author=user.username,
+        stt_confidence=line.stt_confidence,
+        language=line.language,
     )

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -76,3 +76,31 @@ def test_a_migration_can_be_undone(path: Path) -> None:
         "undone, say so in a comment above the `pass` so the next reader knows it was "
         "a decision rather than a leftover."
     )
+
+
+@pytest.mark.parametrize("path", _migrations(), ids=lambda path: path.stem)
+def test_a_batch_alter_of_messages_puts_the_search_triggers_back(path: Path) -> None:
+    """`batch_alter_table("messages")` silently unindexes the transcript archive.
+
+    SQLite cannot alter a table in place for most operations, so alembic's batch mode
+    rebuilds it: new table, copy, drop, rename. The three FTS5 triggers created in
+    `56268f297c2b` are attached to the table that gets dropped, so they go with it —
+    and nothing errors. Full-text search keeps answering, from an index that stops
+    being updated. The bug surfaces as "older conversations are findable and newer ones
+    are not", months later, with no failure to point at.
+
+    Caught once, by four tests that had nothing to do with the migration that broke
+    them. This is the cheap version of that.
+    """
+    source = path.read_text(encoding="utf-8")
+    rebuilds = any(
+        f"batch_alter_table({quote}messages{quote}" in source for quote in ('"', "'")
+    )
+    if not rebuilds:
+        pytest.skip("does not rebuild `messages`")
+
+    assert "messages_fts" in source, (
+        f"{path.name} rebuilds `messages` without restoring `messages_fts`. On SQLite "
+        "that drops the search triggers and leaves the index frozen. Drop them before "
+        "the batch, recreate them after, and rebuild — see afa4aef2e4c9."
+    )

--- a/tests/test_whisper.py
+++ b/tests/test_whisper.py
@@ -1,0 +1,182 @@
+"""Whispering to the agent mid-conversation — §A6.7's first intervention.
+
+The reading half has existed since the web chat did: `api/routes/public_chat.py` hands
+a whisper to the model as a system note and keeps it out of the thread the visitor
+reloads, and the archive draws it in its own channel. Nothing could *write* one. These
+tests are that half.
+
+The two that matter are the pair: a whisper reaches the agent, and it never reaches the
+customer. Everything between them is the usual shape — the role line, isolation, and
+refusing a thread that has already ended.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.config import Settings
+from api.main import create_app
+from api.models import Channel, Conversation, Membership, Message, User, Workspace
+from api.security.password import hash_password
+
+PASSWORD = "a sentence i can actually remember"  # noqa: S105
+
+
+async def _thread(
+    db: AsyncSession, workspace: Workspace, channel: Channel, *, status: str = "open"
+) -> Conversation:
+    row = Conversation(
+        workspace_id=workspace.id,
+        channel_id=channel.id,
+        direction="inbound",
+        status=status,
+    )
+    db.add(row)
+    await db.flush()
+    db.add(
+        Message(
+            workspace_id=workspace.id,
+            conversation_id=row.id,
+            ts_ms=1000,
+            speaker="caller",
+            text="Is the quote from last week still good?",
+        )
+    )
+    return row
+
+
+@pytest.fixture
+async def stage(migrated: AsyncSession, settings: Settings, database_url: str):
+    """Two workspaces with a live thread each, and the roles that may or may not act."""
+    mine = Workspace(name="Wagner & Partner")
+    theirs = Workspace(name="Wolf Studio")
+    migrated.add_all([mine, theirs])
+    await migrated.flush()
+
+    web = Channel(workspace_id=mine.id, kind="web", name="Website")
+    other = Channel(workspace_id=theirs.id, kind="web", name="Website")
+    migrated.add_all([web, other])
+    await migrated.flush()
+
+    threads = {
+        "live": await _thread(migrated, mine, web),
+        "ended": await _thread(migrated, mine, web, status="closed"),
+        "theirs": await _thread(migrated, theirs, other),
+    }
+    ids = {name: row.id for name, row in threads.items()}
+
+    password_hash = hash_password(PASSWORD)
+    people = [
+        ("sabine", mine, "reception"),
+        ("lukas", mine, "viewer"),
+        ("wolf", theirs, "owner"),
+    ]
+    for username, workspace, role in people:
+        user = User(username=username, password_hash=password_hash)
+        migrated.add(user)
+        await migrated.flush()
+        migrated.add(Membership(user_id=user.id, workspace_id=workspace.id, role=role))
+    await migrated.commit()
+
+    app = create_app(settings.model_copy(update={"database_url": database_url}))
+    clients: dict[str, AsyncClient] = {}
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        for username, _, _ in people:
+            http = AsyncClient(transport=transport, base_url="http://localhost")
+            assert (
+                await http.post(
+                    "/api/auth/login", json={"username": username, "password": PASSWORD}
+                )
+            ).status_code == 200
+            clients[username] = http
+        try:
+            yield clients, ids, migrated
+        finally:
+            for http in clients.values():
+                await http.aclose()
+
+
+async def test_a_whisper_is_written_into_the_transcript_and_flagged(stage) -> None:
+    clients, ids, db = stage
+    sent = await clients["sabine"].post(
+        f"/api/conversations/{ids['live']}/whisper",
+        json={"text": "Tell her the quote still stands until the 30th."},
+    )
+    assert sent.status_code == 201, sent.text
+    body = sent.json()
+    assert body["is_whisper"] is True
+    assert body["speaker"] == "human"
+
+    row = await db.scalar(select(Message).where(Message.id == body["id"]))
+    assert row is not None
+    assert row.is_whisper is True
+    # On a text channel both are null, and that null is itself the signal that the line
+    # was typed rather than spoken (§B5 decision 5).
+    assert row.stt_confidence is None
+    assert row.language is None
+
+
+async def test_the_whisper_records_which_person_wrote_it(stage) -> None:
+    """`speaker` is a role. On a reception desk of four, that is not an answer."""
+    clients, ids, db = stage
+    sent = await clients["sabine"].post(
+        f"/api/conversations/{ids['live']}/whisper", json={"text": "Offer Thursday."}
+    )
+    assert sent.json()["author"] == "sabine"
+
+    row = await db.scalar(select(Message).where(Message.id == sent.json()["id"]))
+    author = await db.scalar(select(User).where(User.id == row.author_user_id))
+    assert author.username == "sabine"
+
+
+async def test_the_whisper_appears_in_the_archive_and_never_in_the_thread(stage) -> None:
+    """The pair that this endpoint exists for."""
+    clients, ids, _ = stage
+    await clients["sabine"].post(
+        f"/api/conversations/{ids['live']}/whisper",
+        json={"text": "Tell her the quote still stands."},
+    )
+
+    detail = (await clients["sabine"].get(f"/api/conversations/{ids['live']}")).json()
+    whispers = [line for line in detail["messages"] if line["is_whisper"]]
+    assert [line["text"] for line in whispers] == ["Tell her the quote still stands."]
+
+
+async def test_a_viewer_may_read_the_thread_and_not_speak_into_it(stage) -> None:
+    clients, ids, _ = stage
+    assert (await clients["lukas"].get(f"/api/conversations/{ids['live']}")).status_code == 200
+    refused = await clients["lukas"].post(
+        f"/api/conversations/{ids['live']}/whisper", json={"text": "Say yes."}
+    )
+    assert refused.status_code == 403
+
+
+async def test_another_workspaces_thread_cannot_be_whispered_into(stage) -> None:
+    """Answered as missing rather than as forbidden — the id must stay unconfirmed."""
+    clients, ids, _ = stage
+    refused = await clients["sabine"].post(
+        f"/api/conversations/{ids['theirs']}/whisper", json={"text": "Hello."}
+    )
+    assert refused.status_code == 404
+
+
+async def test_a_thread_that_has_ended_refuses_a_whisper(stage) -> None:
+    """Nothing is listening. A line written into it would be coaching for nobody."""
+    clients, ids, _ = stage
+    refused = await clients["sabine"].post(
+        f"/api/conversations/{ids['ended']}/whisper", json={"text": "One more thing."}
+    )
+    assert refused.status_code == 409
+    assert refused.json()["error"]["code"] == "conversation_closed"
+
+
+async def test_an_empty_whisper_is_refused(stage) -> None:
+    clients, ids, _ = stage
+    refused = await clients["sabine"].post(
+        f"/api/conversations/{ids['live']}/whisper", json={"text": "   "}
+    )
+    assert refused.status_code == 422


### PR DESCRIPTION
§A6.7's first intervention — *"Whisper — type an instruction; the agent speaks it in its
own voice; the caller never knows. Highest value, lowest complexity. Build first."*

The **reading** half has existed since the web chat did: `api/routes/public_chat.py`
hands a whisper to the model as a system note, keeps it out of the thread the visitor
reloads, and the archive draws it in its own channel. Nothing could **write** one. This
is the pen.

`POST /api/conversations/{id}/whisper`, seven tests, one migration.

## Three decisions in the endpoint

- **Reception, not viewer.** Reading a transcript and putting words into the agent's
  mouth are different powers; this line becomes part of what a customer is told.
- **A closed thread is refused (409) rather than accepted quietly.** Nothing is
  listening, so a whisper written into one is coaching for nobody — and afterwards it
  sits in the archive looking exactly like coaching that arrived in time.
- **Another workspace's id answers 404**, as the read beside it does. A 403 would
  confirm the row is real.

## The column, which is the part worth arguing with

`messages.author_user_id`, nullable, `SET NULL`.

`speaker` is a role — `caller`, `agent`, `human`. On a reception desk of four, `human`
does not answer *who* coached the agent into what it then told a customer, and §A6.4's
own transcript names the person (`──── human joined: Mohamed ────`). `SET NULL` rather
than `CASCADE`: removing an account must not delete a customer's conversation along with
the lines that account wrote.

## The trap this hit, which is the reason to read the migration

**Adding that column silently unindexed the transcript archive, and nothing errored.**

SQLite cannot add a foreign key in place, so `batch_alter_table` rebuilds the table —
new, copy, drop, rename. The three FTS5 triggers from `56268f297c2b` are attached to the
table that gets dropped, so they go with it. Search keeps answering, from an index that
has stopped being updated.

Four tests caught it, **none of them about migrations**:

```
test_search_finds_the_thread_by_what_was_said_in_it
test_search_never_reaches_another_workspace
test_messages_are_searchable_by_phrase
test_the_search_index_follows_edits_and_deletes
```

Without them this surfaces months later as "older conversations are findable and newer
ones are not", with no failure to point at. The migration now drops the triggers
deliberately, recreates them verbatim, and rebuilds the shadow table; PostgreSQL takes
the plain `ALTER` path and its GIN index is untouched.

`tests/test_migrations.py` now **fails any future migration that rebuilds `messages`
without mentioning `messages_fts`** — the cheap version of four integration tests, in
the file whose stated job is catching dialect differences before the push.

## Checks

- 771 passed, 21 skipped on SQLite. PostgreSQL was not running here, so CI is the first
  run of that half — and this one has a dialect-specific migration, so that half matters
  more than usual.
- `ruff check`, `ruff format --check`, import contracts pass.
- **One migration. `alembic upgrade head` after pulling.**

## Next

The `live` screen goes on top of this. Every endpoint the API serves already has its
screen, so the endpoint came first; the screen will also have to decide what §A6.7's
other two controls — *Take over* and *Hand off* — do when nothing serves them, which by
this repository's rule means not drawing them.
