### PR TITLE
Stop handing a web visitor's resume handle to every reader of the archive

### DIFF
--- a/api/routes/conversations.py
+++ b/api/routes/conversations.py
@@ -66,6 +66,9 @@ class ThreadOut(BaseModel):
     ended_at: str | None
     # Whoever is on the other end, as the channel knows them. For a call this is the
     # caller's number; for a messaging channel the channel's own thread identifier.
+    # Whoever is on the other end, as the channel knows them — a caller's number, a
+    # chat id. **Null on `web`**, and that is a security answer rather than a missing
+    # value: see `_who`.
     who: str | None
     # And as the phonebook knows them, when it does - matched on the number at read
     # time. Null is the honest answer for a caller nobody has named yet.
@@ -112,6 +115,24 @@ class ThreadDetail(ThreadOut):
     call: CallOut | None
 
 
+# Channels whose `external_id` is a credential rather than an identity.
+#
+# On the web channel it is the visitor's resume handle: the widget sends it to continue
+# the same conversation, and possession of it is the whole authorisation
+# (`api/routes/public_chat.py`). Returning it as `who` put it on a screen, into any
+# screenshot of that screen, and into the hands of a `viewer` — the role that may only
+# read — who could then post as that visitor.
+#
+# A number on a `phone` thread is the opposite: it *is* how the person is identified, it
+# is what the phonebook is keyed by, and it stays.
+_HANDLE_IS_A_SECRET = frozenset({"web"})
+
+
+def _who(row: Conversation, channel_kind: str) -> str | None:
+    """The other end's identity, or nothing when the id is a credential."""
+    return None if channel_kind in _HANDLE_IS_A_SECRET else row.external_id
+
+
 def _thread(
     row: Conversation,
     channel_kind: str,
@@ -129,7 +150,7 @@ def _thread(
         intent=row.intent,
         started_at=_utc(row.started_at) or "",
         ended_at=_utc(row.ended_at),
-        who=row.external_id,
+        who=_who(row, channel_kind),
         who_name=who_name,
         preview=preview,
         message_count=count,

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.config import Settings
@@ -294,3 +295,43 @@ async def test_the_static_path_is_declared_before_the_parameterised_one() -> Non
     assert paths.index("/api/conversations/meta/channels") < paths.index(
         "/api/conversations/{conversation_id}"
     )
+
+
+async def test_a_web_visitors_resume_handle_never_leaves_the_server(stage, migrated) -> None:
+    """`external_id` is a credential on the web channel, and `who` is not the place for it.
+
+    On `web` the handle is what the widget sends to continue a thread: possession is the
+    whole authorisation, and `api/routes/public_chat.py` treats it that way. Returning it
+    as `who` put it on a screen, in a screenshot and in any support ticket that quotes
+    one - and gave a `viewer`, the role that may only read, everything needed to post as
+    that visitor.
+
+    A number on a `phone` thread is the opposite: it *is* how the person is identified,
+    and it stays.
+    """
+    workspace = await migrated.scalar(
+        select(Workspace).where(Workspace.name == "Wagner & Partner")
+    )
+    web = await migrated.scalar(
+        select(Channel).where(Channel.workspace_id == workspace.id, Channel.kind == "web")
+    )
+    handle = "an-unguessable-resume-handle"
+    thread = await _thread(migrated, workspace, web, [("caller", "Hello there.")])
+    thread.external_id = handle
+    await migrated.commit()
+
+    clients = stage
+    listed = (await clients["sabine"].get("/api/conversations")).json()
+    assert handle not in str(listed)
+    mine = next(row for row in listed["threads"] if row["id"] == thread.id)
+    assert mine["who"] is None
+
+    detail = (await clients["sabine"].get(f"/api/conversations/{thread.id}")).json()
+    assert handle not in str(detail)
+
+
+async def test_a_callers_number_is_still_the_headline(stage) -> None:
+    """The fix must not blank the one channel where `who` is a real identity."""
+    clients = stage
+    listed = (await clients["sabine"].get("/api/conversations?channel=phone")).json()
+    assert [row["who"] for row in listed["threads"]] == ["+4366412345678"]


### PR DESCRIPTION
`_thread` returned `external_id` as `who` for every channel. On `web`, that value is the
visitor's **resume handle** — the widget sends it to continue the same conversation, and
possession of it is the whole authorisation. `api/routes/public_chat.py` looks a thread
up by it and by nothing else.

So the archive was printing a credential as a name.

## What that actually exposed

- It reached the screen, and from there every screenshot of that screen and every
  support ticket quoting one.
- It reached a **`viewer`** — the role whose entire definition is that it may only read
  — who could then post into that visitor's conversation *as the visitor*.

## The fix

```python
_HANDLE_IS_A_SECRET = frozenset({"web"})
```

Written as the one channel where the id is a secret rather than as a blanket, because a
number on a `phone` thread is the opposite of this: it **is** how the person is
identified, it is what the phonebook is keyed by, and it stays. A second test guards
exactly that, so the fix cannot quietly blank the channel where `who` is real.

The test that fails without the change fails on the string itself:

```
'an-unguessable-resume-handle' is contained here:
{'threads': [{... 'who': 'an-unguessable-resume-handle' ...}]}
```

## No screen changes

`who_name ?? who ?? visitor` already falls through to "website visitor" the moment `who`
is null — which is the right label, and the one a web thread should always have had.

## Checks

- 773 passed, 21 skipped on SQLite; `ruff check`, `ruff format --check` clean.
- No migration, no new setting.

Found while wiring the live screen (#126) — which is why that screen already refuses to
print it. Belt and braces, and still correct after this.
