### PR TITLE
Say in the document how to get in, and what each group of routes is for

### DIFF
--- a/api/docs.py
+++ b/api/docs.py
@@ -1,0 +1,145 @@
+"""What the generated OpenAPI document cannot work out on its own — §B6.
+
+FastAPI writes the document from the code, which is why it cannot drift from it. Two
+things it has no way to know, and both of them are what a reader of `/docs` needs first:
+
+**How to authenticate.** Authorisation here lives in middleware, not in a dependency on
+each route (`api/middleware/auth.py`), and a middleware is invisible to the generator.
+So the document was silent on the subject: every operation looked as though it needed
+nothing. Declaring the schemes here is documentation and nothing else — the middleware
+is still the only thing that enforces anything, and it is unchanged.
+
+**What a group of routes is for.** A tag with no description is a heading; a tag with
+one is a map. Twenty tag groups were in use and one was described, so `/docs` listed
+eighty-six operations under nineteen unexplained words.
+
+Nothing in this module changes a response. `tests/test_openapi.py` asserts that it stays
+that way, and that a tag added to a route without a sentence here fails rather than
+quietly appearing as a bare word.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
+
+# The three credentials §B9.1 names, and the paths each one opens.
+#
+# They are separate schemes rather than one, because that is the specification's whole
+# point: a leak of one must not open the others. A document that showed a single
+# "Authorization" box would describe a product that does not exist.
+SECURITY_SCHEMES: dict[str, dict[str, Any]] = {
+    "session": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "telagent_session",
+        "description": (
+            "The dashboard's session. Created by `POST /api/auth/login`, stored as an "
+            "HttpOnly cookie, and revoked by signing out. It opens the `/api/…` routes "
+            "and **nothing else** — presented at a machine path it is refused. There is "
+            "no public signup: the first account is made by `POST /api/setup` and every "
+            "later one is invited (D-030)."
+        ),
+    },
+    "hooksToken": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": (
+            "A machine token of scope `hooks`, for software posting events to this "
+            "installation under `/hooks/…`. Minted from `POST /api/tokens`, shown once, "
+            "and stored only as a hash. It does not open `/mcp`, and presented there it "
+            "is refused with the same 401 an unknown token gets — a leak must not "
+            "confirm itself (§B9.1)."
+        ),
+    },
+    "mcpToken": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": (
+            "A machine token of scope `mcp`, for an external model calling this "
+            "installation's tools at `/mcp`. Same rules as `hooksToken`, and it does "
+            "not open `/hooks/…`. §B9 requires it precisely because a model that can "
+            "start real calls spends real money."
+        ),
+    },
+}
+
+# Reachable with no credential at all. Kept as a tuple of prefixes rather than derived
+# from `PUBLIC_PATHS`, because these are the *documented* public surface: the widget's
+# two routes and the things a monitor or a reverse proxy hits before anybody signs in.
+_NO_CREDENTIAL = (
+    "/health",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/public/",
+    "/widget/",
+    "/embed.js",
+)
+
+# The machine paths, and which scheme opens each. `api/security/machine_tokens.py` is
+# the enforcement; this is the sentence about it.
+_MACHINE = (("/hooks/", "hooksToken"), ("/mcp", "mcpToken"))
+
+# The first run and the sign-in routes: no credential yet, by definition.
+_UNAUTHENTICATED_API = (
+    "/api/setup",
+    "/api/auth/login",
+    "/api/auth/forgot",
+    "/api/auth/code/verify",
+    "/api/auth/key/challenge",
+    "/api/auth/key/verify",
+    "/api/auth/password/reset",
+    "/api/invites/",
+)
+
+
+def _requirement(path: str) -> list[dict[str, list[str]]]:
+    """Which scheme opens this path, said the way OpenAPI says it.
+
+    An empty list is meaningful in OpenAPI: it declares the operation open, rather than
+    leaving the reader to guess from silence. That distinction is the reason this
+    function exists instead of a dictionary.
+    """
+    if path.startswith(_NO_CREDENTIAL) or path.startswith(_UNAUTHENTICATED_API):
+        return []
+    for prefix, scheme in _MACHINE:
+        if path.startswith(prefix):
+            return [{scheme: []}]
+    return [{"session": []}]
+
+
+def describe(app: FastAPI, tags: list[dict[str, Any]]) -> None:
+    """Teach `app.openapi()` the two things the generator cannot see.
+
+    Installed as an override rather than written into each route: a `security` argument
+    repeated on eighty-six operations is eighty-six chances to write a different one,
+    and the rule it expresses is about paths, not about endpoints.
+    """
+
+    def openapi() -> dict[str, Any]:
+        if app.openapi_schema:
+            return app.openapi_schema
+
+        schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            description=app.description,
+            routes=app.routes,
+            tags=tags,
+            license_info=app.license_info,
+            contact=app.contact,
+        )
+        schema.setdefault("components", {})["securitySchemes"] = SECURITY_SCHEMES
+        for path, operations in schema["paths"].items():
+            requirement = _requirement(path)
+            for operation in operations.values():
+                if isinstance(operation, dict):
+                    operation["security"] = requirement
+
+        app.openapi_schema = schema
+        return schema
+
+    app.openapi = openapi  # type: ignore[method-assign]

--- a/api/main.py
+++ b/api/main.py
@@ -27,6 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.config import Settings, get_settings
 from api.db import check_database, create_engine, create_sessionmaker
+from api.docs import describe
 from api.errors import ErrorResponse, install_error_handlers
 from api.extensions.builtin import BUILTIN
 from api.extensions.registry import Registry, sync_catalogue
@@ -64,13 +65,164 @@ from api.routes import webhooks as webhook_routes
 from api.routes import widget as widget_routes
 from api.routes import workspaces as workspace_routes
 
+# One sentence per group, and each says what the group is *not* wherever that is the
+# thing a reader gets wrong. A tag with no description is a heading; a tag with one is a
+# map, and this document is the product's public surface (§B6).
+#
+# `tests/test_openapi.py` fails if a route uses a tag that is missing here, so a new
+# router cannot quietly add a nineteenth unexplained word.
 TAGS_METADATA = [
     {
         "name": "system",
         "description": (
             "Liveness and version. `/health` is the endpoint a reverse proxy, a "
-            "monitor or an operator hits first."
+            "monitor or an operator hits first, and it reports what it has actually "
+            "verified rather than that the process is running."
         ),
+    },
+    {
+        "name": "setup",
+        "description": (
+            "First run, and only first run. There is nobody to authenticate as before "
+            "this, so it is public and defends itself by refusing to run twice."
+        ),
+    },
+    {
+        "name": "authentication",
+        "description": (
+            "Signing in, signing out, the six-digit code, SSH-key sign-in and changing "
+            "a password. **No public signup** (D-030): the first account comes from "
+            "setup and every later one is invited."
+        ),
+    },
+    {
+        "name": "workspaces",
+        "description": (
+            "The tenant boundary (D-028), its members and their roles. Every other "
+            "route on this page is scoped by the active workspace, sent as "
+            "`X-Workspace-Id`; omitted, the caller's first workspace is assumed."
+        ),
+    },
+    {
+        "name": "invitations",
+        "description": (
+            "A one-time link by which an invited person names themselves (D-034). "
+            "Guarded by the token in the path rather than by a session, because the "
+            "caller has no account worth the name yet."
+        ),
+    },
+    {
+        "name": "conversations",
+        "description": (
+            "The transcript archive, every channel in one place — a phone call is a "
+            "conversation on a `phone` channel (D-017), not a separate kind of thing. "
+            "Includes whispering into one that is still running (§A6.7)."
+        ),
+    },
+    {
+        "name": "contacts",
+        "description": (
+            "The phonebook. It is what turns an identity the channel knows — a number, "
+            "a chat id — into a name on a screen, and nothing else reads it."
+        ),
+    },
+    {
+        "name": "rules",
+        "description": (
+            "Routing: who reaches the agent, who is refused, who goes straight "
+            "through. Decided from a channel identity, not from a phone number, so one "
+            "table serves every channel."
+        ),
+    },
+    {
+        "name": "numbers",
+        "description": (
+            "The registry of numbers this installation answers on. Adding, disabling "
+            "and releasing one; SIP credentials arrive with the SIP milestone, because "
+            "§B9.2 wants them encrypted and `sip_config` is plain JSON today."
+        ),
+    },
+    {
+        "name": "assistants",
+        "description": (
+            "Who the agent is: persona, instructions, and which tools it may use. This "
+            "is what the business says to its customers, which is why every change is "
+            "in the audit trail."
+        ),
+    },
+    {
+        "name": "knowledge",
+        "description": (
+            "What the agent is allowed to read before it answers. Adding a source "
+            "changes the answers a customer gets, so it is recorded like a change to "
+            "the assistant rather than like a file upload."
+        ),
+    },
+    {
+        "name": "catalogue",
+        "description": (
+            "Services and their prices. A price here is quoted to a customer by an "
+            "agent that cannot check it against anything, so who changed one and when "
+            "is the only record of why a caller was told a number."
+        ),
+    },
+    {
+        "name": "web chat",
+        "description": (
+            "The web chat channel and the widget it serves (§B14). The widget's own two "
+            "routes are the only unauthenticated ones in the product, guarded by an "
+            "origin allowlist, a captcha and a rate limit instead of by a session."
+        ),
+    },
+    {
+        "name": "webhooks",
+        "description": (
+            "Where this installation posts what happened, and the secret that signs it. "
+            "Rule 5 in `CLAUDE.md` is why this matters more than its size suggests: "
+            "everything outside Tel-Agent's column is reached through here."
+        ),
+    },
+    {
+        "name": "tokens",
+        "description": (
+            "Credentials for the machine paths — `/hooks/…` and `/mcp` — each separate "
+            "from the dashboard session and from each other (§B9.1). Shown once, stored "
+            "as a hash, rotatable in place."
+        ),
+    },
+    {
+        "name": "apps",
+        "description": (
+            'Extensions (D-031). A channel is an extension, which is what keeps "add '
+            'one more connector" from having no end.'
+        ),
+    },
+    {
+        "name": "settings",
+        "description": (
+            "Declared keys only, secrets encrypted and masked on read. Installation "
+            "secrets live in `.env` and never here; credentials a person types live "
+            "here and never in `.env` (§B9.2)."
+        ),
+    },
+    {
+        "name": "notifications",
+        "description": (
+            "What happened while nobody was watching, and what is waiting on a decision "
+            "only a person can make. The two are kept apart on purpose."
+        ),
+    },
+    {
+        "name": "backup",
+        "description": (
+            "Archive, verify by reading back, retention, and a staged restore. One "
+            "archive is every transcript on the installation, so downloading one is a "
+            "data export and is recorded as one."
+        ),
+    },
+    {
+        "name": "home",
+        "description": "The two counts the dashboard opens with (§A6.2). Nothing else.",
     },
 ]
 
@@ -228,6 +380,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     # Read back by `lifespan`, which is what actually opens the engine.
     app.state.settings = settings
+
+    # What the generator cannot see: how to authenticate, and what each tag is for.
+    describe(app, TAGS_METADATA)
 
     install_error_handlers(app)
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,124 @@
+"""The document this API is published as — §B6.
+
+"The dashboard consumes this same API, so it exists anyway; just make it public and
+documented." The generator writes it from the code, so it cannot describe a route that
+does not exist. What it *can* do is stay silent about the two things a reader needs
+first — how to authenticate, and what a group of routes is for — because neither is
+visible in a signature. These tests are about that silence.
+
+They deliberately assert on the generated document rather than on `api/docs.py`. A test
+that read the constants back would pass while the override was never installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from api.config import Settings
+from api.main import TAGS_METADATA, create_app
+
+
+@pytest.fixture(scope="module")
+def document() -> dict:
+    app = create_app(Settings(_env_file=None, jobs_enabled=False))
+    return app.openapi()
+
+
+def _tags_in_use(document: dict) -> set[str]:
+    return {tag for _, _, op in _operations(document) for tag in op.get("tags", [])}
+
+
+def _operations(document: dict) -> list[tuple[str, str, dict]]:
+    return [
+        (path, method, operation)
+        for path, methods in document["paths"].items()
+        for method, operation in methods.items()
+        if isinstance(operation, dict)
+    ]
+
+
+def test_every_tag_a_route_uses_is_explained(document: dict) -> None:
+    """A tag with no description is a heading; a tag with one is a map.
+
+    This is the test that keeps the sentence being written. A new router arrives with a
+    new tag, and without this the group appears in `/docs` as a bare word that reads
+    like a category and explains nothing.
+    """
+    described = {entry["name"] for entry in TAGS_METADATA}
+    used = _tags_in_use(document)
+
+    assert used <= described, (
+        f"these tags are on a route and described nowhere: {sorted(used - described)}. "
+        "Add a sentence to TAGS_METADATA in api/main.py."
+    )
+
+
+def test_no_tag_is_described_that_nothing_uses(document: dict) -> None:
+    """The other direction, which is how a description outlives the routes it described."""
+    described = {entry["name"] for entry in TAGS_METADATA}
+    used = _tags_in_use(document)
+
+    assert described <= used, (
+        f"these tags are described and used by nothing: {sorted(described - used)}. "
+        "A group that no longer exists should not still have a heading."
+    )
+
+
+def test_every_tag_description_is_a_sentence(document: dict) -> None:
+    for entry in TAGS_METADATA:
+        assert entry.get("description", "").strip(), f"{entry['name']} has an empty description"
+
+
+def test_the_three_credentials_are_declared_separately(document: dict) -> None:
+    """§B9.1's whole point, in the document a reader is handed.
+
+    One combined "Authorization" scheme would describe a product where a leak of one
+    credential opens the others, which is the arrangement the specification exists to
+    prevent.
+    """
+    schemes = document["components"]["securitySchemes"]
+    assert set(schemes) == {"session", "hooksToken", "mcpToken"}
+    assert schemes["session"]["in"] == "cookie"
+    assert schemes["hooksToken"]["scheme"] == "bearer"
+    assert schemes["mcpToken"]["scheme"] == "bearer"
+
+
+def test_every_operation_says_what_opens_it(document: dict) -> None:
+    """Including the open ones.
+
+    An empty `security` list is not the same as no `security` key: the first says "no
+    credential is needed" and the second says nothing at all. A reader cannot tell the
+    difference between an open route and an undocumented one from silence.
+    """
+    missing = [
+        f"{method.upper()} {path}"
+        for path, method, operation in _operations(document)
+        if "security" not in operation
+    ]
+    assert not missing, f"no security stated for: {missing}"
+
+
+def test_a_dashboard_route_is_opened_by_the_session_and_a_machine_path_is_not(
+    document: dict,
+) -> None:
+    by_path = {path: operation["security"] for path, _, operation in _operations(document)}
+    assert by_path["/api/conversations"] == [{"session": []}]
+    assert by_path["/api/tokens"] == [{"session": []}]
+    # Public by design: the widget's address travels in a stranger's HTML.
+    assert by_path["/public/chat/{path}/messages"] == []
+    assert by_path["/health"] == []
+    # And sign-in, which cannot need the thing it produces.
+    assert by_path["/api/auth/login"] == []
+
+
+def test_documenting_the_api_did_not_change_it(document: dict) -> None:
+    """The override adds description and must add nothing else.
+
+    `api/docs.py` rewrites the generated document. The failure worth guarding is the one
+    where it also, quietly, drops half of it — a schema that lost operations would still
+    render a plausible-looking page.
+    """
+    operations = _operations(document)
+    assert len(operations) > 80, f"only {len(operations)} operations survived the override"
+    assert "/api/conversations/{conversation_id}/whisper" in document["paths"]
+    assert document["info"]["title"] == "Tel-Agent"


### PR DESCRIPTION
Milestone 6's other half. §B6: *"the dashboard consumes this same API, so it exists
anyway; just make it public and documented."* The webhooks half landed in #121 and got
its screen in #124. This is the REST half — and it turned out to be documentation rather
than endpoints, which is exactly what that sentence promises.

## Measured before it was written

"Documented" invites guessing, so:

```
paths: 64 | operations: 86
tags in use: 20   ·   tags described: 1
securitySchemes: []
operations stating security: 0 of 86
```

## The document never said how to authenticate

Authorisation here lives in **middleware**, not in a dependency on each route, and a
middleware is invisible to the generator. So all eighty-six operations looked as though
they needed nothing — on the page that is meant to be this product's public surface.

**Three schemes, not one**, because that separation *is* §B9.1: the dashboard session, a
`hooks` bearer and an `mcp` bearer, each stating which paths it opens and which it does
not. A single "Authorization" box would describe a product where a leak of one opens the
others.

Every operation now states its requirement **including the open ones**. An empty list and
an absent key are different sentences in OpenAPI — "no credential is needed" versus
nothing at all — and a reader cannot tell an open route from an undocumented one by
silence.

## Nineteen groups had no description

`/docs` grouped eighty-six operations under bare words. Each of the twenty now has a
sentence, and each says what the group is *not* wherever that is the thing a reader gets
wrong — that a call is a conversation, that `.env` and the settings store are different
homes, that the widget's two routes are the only unauthenticated ones.

## The tests were checked against their own failure

Passing tests prove nothing until you have seen them fail:

```
without the override, securitySchemes present: False
without the override, operations stating security: 0 of 86
tag guard catches an undescribed tag: True
```

One of the seven guards the override itself: a schema that quietly lost half its
operations would still render a plausible-looking page.

## Verified on the running server, not only in a test

`/docs` now shows an **Authorize** control it did not have, each group carries its
description, and every operation shows a padlock — open on `/health`, closed on the rest.

## Not in this pull request

- **The ROADMAP marker is not moved.** It still reads `## 0 — Web chat · in progress`,
  which is accurate: Milestone 0 is one browser session from closed and that is the
  maintainer's line to move.
- **§B6's webhook event list is still the phone-era one** (`call.started`, …) while the
  code sends `conversation.*`. That list is now quoted in the `webhooks` group
  description too, so the contradiction is visible to anyone reading the public
  document — which is an argument for settling it, not something this pull request
  should decide.

## Checks

780 passed, 21 skipped on SQLite. `ruff check`, `ruff format --check`, import contracts
clean. No migration, no new setting, and `api/docs.py` changes no response.
