### PR TITLE
Make `ts_ms` mean what the column says it means

### DIFF
--- a/alembic/versions/2026_09_01_1334-3fdebcd16757_positions_not_clocks.py
+++ b/alembic/versions/2026_09_01_1334-3fdebcd16757_positions_not_clocks.py
@@ -1,0 +1,99 @@
+"""positions, not clocks
+
+`messages.ts_ms` is documented as milliseconds since the conversation started, and both
+screens that render it read it that way — the archive adds it to `started_at`, the call
+detail draws it as `mm:ss` into the recording. Every writer wrote epoch milliseconds
+instead.
+
+Nothing failed, because ordering is unaffected: every row on a thread used the same
+clock. Only a rendered timestamp showed it, and it showed a message sent on 2026-08-31 as
+**2083-05-01** in the archive and as **29803424:52** on a call.
+
+The writers are fixed in this same change. This migration is the rows already stored, and
+it converts them by the only evidence available: a value at or above `10**12` is a wall
+clock — about fifty-six years of milliseconds, and no conversation runs that long — so it
+becomes `ts_ms - started_at`, floored at zero. A value below that is already a position
+and is left alone, which is what makes the migration safe to run twice.
+
+**Order within a thread is preserved exactly**, because every row on it is shifted by the
+same `started_at`. That is the property the column exists for, and the one a backfill
+could plausibly break.
+
+Irreversible on purpose, and the downgrade says so rather than pretending: the original
+epoch value cannot be recovered from a position without trusting the same `started_at`
+the upgrade already used, and a downgrade that re-derived it would be guessing at data it
+had itself rewritten.
+
+Revision ID: 3fdebcd16757
+Revises: afa4aef2e4c9
+Create Date: 2026-09-01 13:34:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3fdebcd16757"
+down_revision: str | Sequence[str] | None = "afa4aef2e4c9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Milliseconds. Anything at or above this is a wall clock rather than a position.
+EPOCH_SCALE = 10**12
+
+
+def upgrade() -> None:
+    """Turn stored wall clocks into positions."""
+    dialect = op.get_bind().dialect.name
+
+    # The same statement in two dialects, because epoch milliseconds are derived
+    # differently and D-029 requires both. SQLite has no EXTRACT and PostgreSQL has no
+    # `strftime`; neither has a portable "milliseconds since 1970" for a timestamp.
+    # **Rounded, not truncated, and that is not fussiness.** SQLite's `julianday` is a
+    # float, and a truncating cast of the product loses the last millisecond: a line
+    # seven seconds in came back as 6999. A double carries these values to about a
+    # twentieth of a millisecond, so rounding is exact at the resolution stored.
+    if dialect == "postgresql":
+        started_ms = "ROUND(EXTRACT(EPOCH FROM c.started_at) * 1000)"
+    else:
+        started_ms = "ROUND((julianday(c.started_at) - 2440587.5) * 86400000)"
+
+    # `MAX` in SQLite is `GREATEST` in PostgreSQL when it takes two scalars — the same
+    # floor, spelled differently.
+    floor = "MAX" if dialect == "sqlite" else "GREATEST"
+
+    # `BIGINT` rather than `INTEGER`: on PostgreSQL the latter is 32 bits, which caps
+    # a position at about twenty-four days and would raise on anything longer rather
+    # than storing it wrong. SQLite reads `BIGINT` as integer affinity, so one word
+    # serves both. The column is a BigInteger either way.
+
+    # Every interpolated part is a module constant or one of the two strings chosen
+    # above. Nothing on this page comes from a request, which is what S608 cannot see.
+    statement = f"""
+        UPDATE messages
+           SET ts_ms = CAST(
+                   {floor}(
+                       0,
+                       ts_ms - (
+                           SELECT {started_ms}
+                             FROM conversations c
+                            WHERE c.id = messages.conversation_id
+                       )
+                   ) AS BIGINT
+               )
+         WHERE ts_ms >= {EPOCH_SCALE}
+    """  # noqa: S608
+
+    op.execute(statement)
+
+
+def downgrade() -> None:
+    """Deliberately nothing.
+
+    A position cannot be turned back into the wall clock it was without re-deriving it
+    from the `started_at` this migration already used — which would be inventing data
+    rather than restoring it. The forward direction is safe to repeat, so an installation
+    that needs to go back and forward again loses nothing.
+    """

--- a/api/conversations.py
+++ b/api/conversations.py
@@ -22,6 +22,7 @@ message — fast on a laptop with fifty rows and catastrophic on a year of trans
 
 from __future__ import annotations
 
+import datetime as dt
 import re
 from typing import Any
 
@@ -38,6 +39,29 @@ PAGE = 50
 # line per thread; sending the whole transcript so the browser can trim it would move
 # megabytes to render kilobytes.
 PREVIEW = 160
+
+
+def position_ms(started_at: dt.datetime, at: dt.datetime | None = None) -> int:
+    """Where a line sits in its conversation, which is what `messages.ts_ms` holds.
+
+    Milliseconds from the start of the conversation, not a wall clock. The column has
+    said so since the first migration and gives the reason: on a call the position
+    within the recording is what a transcript is read against, and a clock adjustment
+    mid-call must not be able to reorder the lines.
+
+    Every writer used to call `datetime.now().timestamp()` instead, which is why this
+    function exists rather than the expression being repeated a fourth time. The two
+    screens that render it were always right; the writers were the deviation.
+
+    **Never negative.** `started_at` is a server default, so the database's clock and
+    this process's clock are not the same clock, and the first line of a conversation
+    can be written a hair "before" it began. A floor at zero costs nothing and keeps
+    `mm:ss` from having to render a negative number.
+    """
+    now = at or dt.datetime.now(dt.UTC)
+    # SQLite hands back naive datetimes for a column written aware; PostgreSQL does not.
+    started = started_at if started_at.tzinfo else started_at.replace(tzinfo=dt.UTC)
+    return max(0, int((now - started).total_seconds() * 1000))
 
 
 def is_postgres(db: DbSession) -> bool:

--- a/api/routes/conversations.py
+++ b/api/routes/conversations.py
@@ -30,6 +30,7 @@ from api.conversations import (
     PAGE,
     conversations_for,
     message_counts,
+    position_ms,
     previews,
     search_filter,
 )
@@ -441,9 +442,9 @@ async def whisper(
     line = Message(
         workspace_id=context.id,
         conversation_id=row.id,
-        # The same clock `api/routes/public_chat.py` writes, so the whisper sorts among
-        # the lines it belongs between rather than at one end of them.
-        ts_ms=int(dt.datetime.now(dt.UTC).timestamp() * 1000),
+        # A position in the conversation, like every other line, so the whisper sorts
+        # among the ones it belongs between rather than at one end of them.
+        ts_ms=position_ms(row.started_at),
         speaker="human",
         text=text,
         is_whisper=True,

--- a/api/routes/public_chat.py
+++ b/api/routes/public_chat.py
@@ -20,7 +20,6 @@ endpoint stores and acknowledges, and says nothing that implies otherwise.
 from __future__ import annotations
 
 import asyncio
-import datetime as dt
 import json
 import logging
 import secrets
@@ -39,6 +38,7 @@ from agent.providers.llm import Message as LlmMessage
 from agent.reply import reply as generate_reply
 from agent.tools import TakenMessage
 from api import llm, webhooks
+from api.conversations import position_ms
 from api.db import session_scope
 from api.errors import envelope_response
 from api.models import Channel, Conversation, Message
@@ -271,10 +271,16 @@ async def post_message(
         db.add(conversation)
         await db.flush()
 
+    # `started_at` is a server default, so on a conversation created a moment ago it is
+    # not on the object until the row is read back. Refreshing is what makes the first
+    # line of a thread sit at zero instead of raising on an unloaded attribute.
+    if started:
+        await db.refresh(conversation)
+
     message = Message(
         workspace_id=channel.workspace_id,
         conversation_id=conversation.id,
-        ts_ms=int(dt.datetime.now(dt.UTC).timestamp() * 1000),
+        ts_ms=position_ms(conversation.started_at),
         speaker="caller",
         text=payload.text,
         # Null language is the honest value until something detects it. On a text
@@ -536,7 +542,7 @@ async def _reply_stream(
         stored = Message(
             workspace_id=channel.workspace_id,
             conversation_id=conversation.id,
-            ts_ms=int(dt.datetime.now(dt.UTC).timestamp() * 1000),
+            ts_ms=position_ms(conversation.started_at),
             speaker="agent",
             text=whole,
         )

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -1,0 +1,236 @@
+"""`messages.ts_ms` is a position in the conversation, not a clock.
+
+The column has said so since the first migration: *"Milliseconds since the conversation
+started, not a wall clock. On a call the position within the recording is what a
+transcript is read against, and a clock adjustment mid-call must not be able to reorder
+the lines."* Two screens read it that way — the archive adds it to `started_at`, and the
+call detail renders it as `mm:ss` into the recording.
+
+Every writer wrote epoch milliseconds instead, and nothing failed: ordering is unaffected
+because every row on a thread used the same clock. Only a rendered timestamp showed it,
+and it showed it as the year 2083 in the archive and `29803424:52` on a call.
+
+These tests are about the writers agreeing with the column, and about the rows already
+stored the other way.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.config import Settings
+from api.main import create_app
+from api.models import Channel, Conversation, Membership, Message, User, Workspace
+from api.security.password import hash_password
+
+PASSWORD = "a sentence i can actually remember"  # noqa: S105
+
+# Anything at or above this is a wall clock, not a position: it is about fifty-six
+# years of milliseconds, and no conversation runs that long.
+EPOCH_SCALE = 10**12
+
+
+@pytest.fixture
+async def stage(migrated: AsyncSession, settings: Settings, database_url: str):
+    """A workspace with an enabled web channel, and somebody who may whisper."""
+    workspace = Workspace(name="Wagner & Partner")
+    migrated.add(workspace)
+    await migrated.flush()
+
+    channel = Channel(
+        workspace_id=workspace.id,
+        kind="web",
+        name="Website",
+        status="active",
+        settings_json={"allowed_origins": ["http://localhost"]},
+        webhook_path="a-public-path",
+    )
+    migrated.add(channel)
+    await migrated.flush()
+
+    user = User(username="sabine", password_hash=hash_password(PASSWORD))
+    migrated.add(user)
+    await migrated.flush()
+    migrated.add(Membership(user_id=user.id, workspace_id=workspace.id, role="reception"))
+    await migrated.commit()
+
+    app = create_app(settings.model_copy(update={"database_url": database_url}))
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        signed_in = AsyncClient(transport=transport, base_url="http://localhost")
+        assert (
+            await signed_in.post(
+                "/api/auth/login", json={"username": "sabine", "password": PASSWORD}
+            )
+        ).status_code == 200
+        anonymous = AsyncClient(transport=transport, base_url="http://localhost")
+        try:
+            yield signed_in, anonymous, channel, migrated
+        finally:
+            await signed_in.aclose()
+            await anonymous.aclose()
+
+
+async def test_a_visitors_line_is_a_position_not_a_clock(stage) -> None:
+    _, anonymous, channel, db = stage
+    sent = await anonymous.post(
+        f"/public/chat/{channel.webhook_path}/messages",
+        json={"text": "Is the quote still good?"},
+        headers={"Origin": "http://localhost"},
+    )
+    assert sent.status_code == 201, sent.text
+
+    row = await db.scalar(select(Message).where(Message.id == sent.json()["message_id"]))
+    assert row.ts_ms < EPOCH_SCALE, f"{row.ts_ms} is a wall clock, not a position"
+    # The first line of a thread sits at its start, give or take the write itself.
+    assert row.ts_ms < 5_000
+
+
+async def test_a_whisper_is_positioned_the_same_way(stage) -> None:
+    """Three writers, one meaning. A whisper written against a different clock would
+    sort to one end of the transcript instead of where it was said."""
+    signed_in, anonymous, channel, db = stage
+    await anonymous.post(
+        f"/public/chat/{channel.webhook_path}/messages",
+        json={"text": "Hello."},
+        headers={"Origin": "http://localhost"},
+    )
+    thread = await db.scalar(select(Conversation))
+
+    whispered = await signed_in.post(
+        f"/api/conversations/{thread.id}/whisper", json={"text": "Offer Thursday."}
+    )
+    assert whispered.status_code == 201, whispered.text
+    assert whispered.json()["ts_ms"] < EPOCH_SCALE
+
+
+async def test_a_later_line_sits_after_an_earlier_one(stage) -> None:
+    """The property the column exists for, and the one a backfill must not break."""
+    _, anonymous, channel, db = stage
+    first = await anonymous.post(
+        f"/public/chat/{channel.webhook_path}/messages",
+        json={"text": "First."},
+        headers={"Origin": "http://localhost"},
+    )
+    handle = first.json()["conversation"]
+    second = await anonymous.post(
+        f"/public/chat/{channel.webhook_path}/messages",
+        json={"text": "Second.", "conversation": handle},
+        headers={"Origin": "http://localhost"},
+    )
+
+    rows = {row.id: row.ts_ms for row in (await db.execute(select(Message))).scalars().all()}
+    assert rows[second.json()["message_id"]] >= rows[first.json()["message_id"]]
+
+
+async def test_a_position_is_never_negative(stage) -> None:
+    """A line written a hair before `started_at` settles is at the start, not before it.
+
+    `started_at` is a server default, so the row's clock and the process's clock are not
+    the same clock. Without a floor, the first line of every conversation could carry a
+    negative position — and `mm:ss` of a negative number is not a thing anybody should
+    have to read.
+    """
+    _, anonymous, channel, db = stage
+    await anonymous.post(
+        f"/public/chat/{channel.webhook_path}/messages",
+        json={"text": "Hello."},
+        headers={"Origin": "http://localhost"},
+    )
+    rows = (await db.execute(select(Message))).scalars().all()
+    assert all(row.ts_ms >= 0 for row in rows)
+
+
+def test_the_helper_measures_from_the_start() -> None:
+    from api.conversations import position_ms
+
+    started = dt.datetime(2026, 8, 31, 14, 0, tzinfo=dt.UTC)
+    assert position_ms(started, at=started) == 0
+    assert position_ms(started, at=started + dt.timedelta(seconds=7)) == 7_000
+    # Naive in, aware out: SQLite hands back naive datetimes for a column written aware.
+    assert position_ms(started.replace(tzinfo=None), at=started + dt.timedelta(minutes=1))
+    # A clock that went backwards does not produce a line before the conversation.
+    assert position_ms(started, at=started - dt.timedelta(seconds=30)) == 0
+
+
+async def test_the_backfill_turns_stored_clocks_into_positions(
+    settings: Settings, database_url: str
+) -> None:
+    """The rows written before the writers were fixed.
+
+    Built by upgrading to the revision *before* the backfill, writing rows the way the
+    old code wrote them, and then running it. Asserting on a hand-called function would
+    prove the arithmetic and not the migration, and the migration is what reaches an
+    installation.
+    """
+    import asyncio
+    import os
+
+    from alembic.config import Config
+    from sqlalchemy import text as sa_text
+
+    from alembic import command
+    from api.config import get_settings
+    from api.db import create_engine
+    from tests.conftest import REPO_ROOT, _reset_postgres
+
+    if database_url.startswith("postgresql"):
+        await _reset_postgres(database_url)
+
+    config = Config(str(REPO_ROOT / "alembic.ini"))
+    config.set_main_option("script_location", str(REPO_ROOT / "alembic"))
+    os.environ["DATABASE_URL"] = database_url
+    get_settings.cache_clear()
+
+    # The schema as it stood before this change.
+    await asyncio.to_thread(command.upgrade, config, "afa4aef2e4c9")
+
+    engine = create_engine(Settings(_env_file=None, database_url=database_url))
+    started = dt.datetime(2026, 8, 31, 14, 0, tzinfo=dt.UTC)
+    started_ms = int(started.timestamp() * 1000)
+
+    async with engine.begin() as connection:
+        await connection.execute(
+            sa_text("INSERT INTO workspaces (id, name) VALUES (1, 'Wagner & Partner')")
+        )
+        await connection.execute(
+            sa_text(
+                "INSERT INTO channels (id, workspace_id, kind, name, status)"
+                " VALUES (1, 1, 'web', 'Web', 'active')"
+            )
+        )
+        await connection.execute(
+            sa_text(
+                "INSERT INTO conversations (id, workspace_id, channel_id, direction, status,"
+                " started_at) VALUES (1, 1, 1, 'inbound', 'open', :started)"
+            ),
+            {"started": started},
+        )
+        # Two lines as the old writers stored them, seven and nineteen seconds in, plus
+        # one already written the new way — which the backfill must leave alone.
+        for row_id, ts_ms in ((1, started_ms + 7_000), (2, started_ms + 19_000), (3, 4_000)):
+            await connection.execute(
+                sa_text(
+                    "INSERT INTO messages (id, workspace_id, conversation_id, ts_ms, speaker,"
+                    " text, is_whisper) VALUES (:id, 1, 1, :ts, 'caller', 'hello', :whisper)"
+                ),
+                {"id": row_id, "ts": ts_ms, "whisper": False},
+            )
+
+    await asyncio.to_thread(command.upgrade, config, "head")
+
+    async with engine.connect() as connection:
+        result = await connection.execute(sa_text("SELECT id, ts_ms FROM messages ORDER BY id"))
+        rows = dict(result.all())
+    await engine.dispose()
+
+    assert rows[1] == 7_000, "a stored clock becomes the position it always meant"
+    assert rows[2] == 19_000
+    assert rows[3] == 4_000, "a value already a position is left alone"
+    # The property the column exists for, and the one a backfill could break.
+    assert rows[1] < rows[2]

--- a/tests/test_public_chat.py
+++ b/tests/test_public_chat.py
@@ -15,6 +15,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.config import Settings
+from api.conversations import position_ms
 from api.main import create_app
 from api.models import Channel, Conversation, Message, Workspace
 
@@ -690,7 +691,12 @@ async def test_a_whisper_reaches_the_model_as_a_note_not_as_something_it_said(
         Message(
             workspace_id=thread.workspace_id,
             conversation_id=thread.id,
-            ts_ms=int(thread.started_at.timestamp() * 1000) + 1,
+            # A position, as every writer now stores: written before the second
+            # question is posted, so it is both earlier in the thread and lower in id
+            # — and `_history` orders by `(ts_ms, id)`, so the two agree whichever way
+            # the clock rounds. This line used to build an epoch value, which is the
+            # shape the writers themselves used to have.
+            ts_ms=position_ms(thread.started_at),
             speaker="human",
             text="Das Angebot gilt bis 30. September.",
             is_whisper=True,


### PR DESCRIPTION
The last of the four bugs this run turned up, and the only one a customer could see.

`messages.ts_ms` is documented as *"milliseconds since the conversation started, not a
wall clock"*, and both screens that render it read it that way. All three writers wrote
epoch milliseconds.

Nothing failed — ordering is unaffected, because every row on a thread used the same
clock. Only a rendered timestamp ever showed it:

| | rendered | should be |
|---|---|---|
| archive | **2083-05-01** | 2026-08-31 |
| call detail | **29803424:52** | 00:07 |

## Which reading wins was not really open

| | |
|---|---|
| the column's docstring | relative |
| `conversations.tsx` — `started_at + ts_ms` | relative |
| `call-detail.tsx` — `mm:ss` into the recording | relative |
| the three writers | epoch |

Three to one, and the column's own reasoning is the tiebreaker: on a call the position
within the recording is what a transcript is read against, and a clock adjustment
mid-call must not be able to reorder the lines. **The writers were the deviation**, so
the writers changed.

`position_ms` is one function the three now share, rather than the expression written a
fourth time with a fourth meaning. It floors at zero — `started_at` is a server default,
so the database's clock and the process's are not the same clock, and the first line can
be written a hair "before" the conversation began.

## The backfill

Converts by the only evidence available: a value at or above `10**12` is a wall clock
(about fifty-six years of milliseconds; no conversation runs that long). Below that it is
already a position and is left alone — which is what makes it safe to run twice. **Order
within a thread is preserved exactly**, since every row shifts by the same `started_at`.

The downgrade deliberately does nothing and says why: re-deriving an epoch from a
position would be inventing data, not restoring it.

## Two mistakes the tests caught before your data could

- SQLite's `julianday` is a float, and a truncating cast loses the last millisecond — a
  line seven seconds in came back as **6999**. It rounds now.
- `INTEGER` is 32 bits on PostgreSQL, capping a conversation at twenty-four days and
  raising beyond it. `BIGINT` on both.

## A test that encoded the bug

`tests/test_public_chat.py` built its whisper fixture with an epoch `ts_ms`, so it started
failing the moment the writers were fixed — the whisper sorted outside the history window.
That is what renaming a column's meaning is supposed to look like, and it is now written
the way production writes.

## Verified on real rows, not only in the suite

Five messages from yesterday's testing were converted on the dev database, and the
archive was then read in a browser:

```
before:  29803424:52
after:   01:27
thread:  09:50 → 09:50 → 09:52 → 09:54 PM   (when those lines were actually sent)
```

## Checks

788 passed, 22 skipped on SQLite. `ruff check`, `ruff format --check`, import contracts
clean. **One migration — `alembic upgrade head` after pulling**, and it rewrites rows, so
it is worth reading before running on anything that matters.

With this, all four bugs found this run are closed.
