### PR TITLE
Stop rebuilding the same schema five hundred times a run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,14 @@ jobs:
     runs-on: ubuntu-latest
     # A hung job otherwise runs to GitHub's six-hour cap. One did: the database never
     # came up and pytest sat waiting for a connection that was never going to arrive,
-    # holding a pull request for forty minutes before anybody looked. Twenty minutes is
-    # roughly three times the honest runtime, so a real slowdown still passes.
+    # holding a pull request for forty minutes before anybody looked.
+    #
+    # **Twenty was not three times the runtime, it was barely twice it.** The same
+    # commit took 8m53s and 20m16s depending on which runner picked it up, and the slow
+    # draw failed at the cap with `Terminate orphan process: pid (2631) (pytest)` -
+    # nothing wrong with the code, and a re-run passed at 10m26s. Parallelism is what
+    # fixed that (see the pytest step); this stays at twenty because the ceiling is now
+    # several times the runtime again rather than adjacent to it.
     timeout-minutes: 20
 
     # D-029 supports two dialects, so the suite runs against both. Without a real
@@ -105,4 +111,13 @@ jobs:
       - run: lint-imports
       # pytest exits 5 on an empty suite and CI reads that as a failure, so the
       # repository always carries at least one real test.
-      - run: pytest
+      # `-n auto` uses every core the runner has. The suite is embarrassingly parallel:
+      # each test builds its own database and shares nothing with any other, and it runs
+      # the whole matrix twice, once per dialect. The one thing that had to change first
+      # was PostgreSQL - `_reset_postgres` drops and recreates `public`, so workers
+      # sharing a database would have deleted each other's schema mid-test and it would
+      # have read as flakiness. `tests/conftest.py` gives each worker its own.
+      #
+      # Measured on a developer machine, both dialects, the same 1269 tests:
+      # 16m43s serially, 3m14s on four workers.
+      - run: pytest -n auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ dev = [
     # hung test never prints its own name. This makes a hang a normal failure with a
     # stack trace in it.
     "pytest-timeout>=2.3",
+    # The suite is embarrassingly parallel - every test builds its own database and
+    # shares nothing - and it runs the whole matrix twice, once per dialect. See
+    # `_worker_database` in tests/conftest.py for the one thing that had to change
+    # before `-n` was safe.
+    "pytest-xdist>=3.6",
     "import-linter>=2.1",
     "httpx>=0.28",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shutil
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -122,6 +123,46 @@ async def running_app(settings: Settings) -> AsyncIterator[AsyncClient]:
 POSTGRES_URL = os.environ.get("TEST_POSTGRES_URL")
 
 
+async def _create_database(url: str) -> None:
+    """Make this database if it is not there, from the maintenance database.
+
+    `CREATE DATABASE` cannot run inside a transaction and cannot be issued from within
+    the database it names, so it goes through `postgres` with autocommit.
+    """
+    name = url.rsplit("/", 1)[1]
+    server = url.rsplit("/", 1)[0] + "/postgres"
+    engine = create_engine(Settings(_env_file=None, database_url=server)).execution_options(
+        isolation_level="AUTOCOMMIT"
+    )
+    try:
+        async with engine.connect() as connection:
+            exists = await connection.scalar(
+                sa_text("SELECT 1 FROM pg_database WHERE datname = :name"), {"name": name}
+            )
+            if not exists:
+                await connection.execute(sa_text(f'CREATE DATABASE "{name}"'))
+    finally:
+        await engine.dispose()
+
+
+def _worker_database(url: str) -> str:
+    """One PostgreSQL database per parallel worker.
+
+    Without this the suite cannot be run in parallel at all: `_reset_postgres` drops and
+    recreates `public`, so two workers sharing a database would delete each other's
+    schema mid-test - and the failures would look like flaky tests rather than like the
+    configuration mistake they are.
+
+    `PYTEST_XDIST_WORKER` is `gw0`, `gw1`, … under `-n`, and unset otherwise, so a plain
+    serial run keeps using the database it always did.
+    """
+    worker = os.environ.get("PYTEST_XDIST_WORKER")
+    if not worker:
+        return url
+    base, name = url.rsplit("/", 1)
+    return f"{base}/{name}_{worker}"
+
+
 async def _open_sessions(url: str) -> str:
     """Every other connection to this database, and what it is doing.
 
@@ -178,32 +219,36 @@ async def _reset_postgres(url: str) -> None:
         await engine.dispose()
 
 
+@pytest.fixture(scope="session")
+async def postgres_worker_database() -> None:
+    """Create this worker's own database, once, before anything asks for it."""
+    if POSTGRES_URL is not None:
+        await _create_database(_worker_database(POSTGRES_URL))
+
+
 @pytest.fixture(
     params=["sqlite", *(["postgresql"] if POSTGRES_URL else [])],
     ids=lambda dialect: f"on-{dialect}",
 )
-def database_url(request: pytest.FixtureRequest, tmp_path: Path) -> str:
+def database_url(
+    request: pytest.FixtureRequest, tmp_path: Path, postgres_worker_database: None
+) -> str:
     """The URL under test, one per supported dialect."""
     if request.param == "postgresql":
         assert POSTGRES_URL is not None
-        return POSTGRES_URL
+        return _worker_database(POSTGRES_URL)
     return f"sqlite+aiosqlite:///{tmp_path}/test.db"
 
 
-@pytest.fixture
-async def migrated(settings: Settings, database_url: str) -> AsyncIterator[AsyncSession]:
-    """A database built by `alembic upgrade head`.
-
-    The schema comes from **running the migration**, not from
-    `Base.metadata.create_all()`. Creating tables from the models would test the models
-    against themselves and pass even if the migration were empty - and the migration is
-    what actually reaches an installation.
-    """
-    if database_url.startswith("postgresql"):
-        await _reset_postgres(database_url)
-
+def _alembic_config() -> Config:
     config = Config(str(REPO_ROOT / "alembic.ini"))
     config.set_main_option("script_location", str(REPO_ROOT / "alembic"))
+    return config
+
+
+async def upgrade_to_head(database_url: str) -> None:
+    """`alembic upgrade head` against this URL, the way an operator would run it."""
+    config = _alembic_config()
     # env.py reads the URL from Settings, so it is set the way an operator would.
     os.environ["DATABASE_URL"] = database_url
     get_settings.cache_clear()
@@ -216,6 +261,56 @@ async def migrated(settings: Settings, database_url: str) -> AsyncIterator[Async
     finally:
         os.environ.pop("DATABASE_URL", None)
         get_settings.cache_clear()
+
+
+@pytest.fixture(scope="session")
+def sqlite_template(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """The migrated SQLite schema, built once and copied per test.
+
+    **Five hundred and forty-six of this suite's tests were each running the whole
+    migration chain from nothing** — about 830 ms apiece, roughly two thirds of an
+    eleven-minute run, to arrive at the identical empty schema every time. Copying the
+    file instead costs about a millisecond.
+
+    **This does not weaken what the fixture promises.** The schema still comes from
+    *running* the migration rather than from `Base.metadata.create_all()`; the migration
+    simply runs once per session instead of once per test, and every test gets a copy of
+    its output. A copy of the migration's result is not the models testing themselves.
+
+    A test that needs the chain itself — `tests/test_positions.py` upgrades to an
+    earlier revision and then forward — drives alembic directly and is unaffected.
+    """
+    path = tmp_path_factory.mktemp("schema") / "template.db"
+    asyncio.run(upgrade_to_head(f"sqlite+aiosqlite:///{path}"))
+    return path
+
+
+@pytest.fixture
+async def migrated(
+    settings: Settings, database_url: str, sqlite_template: Path
+) -> AsyncIterator[AsyncSession]:
+    """A database built by `alembic upgrade head`.
+
+    The schema comes from **running the migration**, not from
+    `Base.metadata.create_all()`. Creating tables from the models would test the models
+    against themselves and pass even if the migration were empty - and the migration is
+    what actually reaches an installation. See `sqlite_template` for why that run is
+    once per session rather than once per test.
+    """
+    if database_url.startswith("postgresql"):
+        # **No template on this side, and that is a measurement rather than an
+        # oversight.** The same trick was tried here - `CREATE DATABASE … TEMPLATE` in
+        # place of the migration - and it made the PostgreSQL half *slower*: 37.8s to
+        # 50.7s over the same fifty-one tests. Cloning a database copies its whole file
+        # layout and needs every connection dropped first, which costs more than
+        # emptying a small schema and replaying the chain on a connection that is
+        # already open. SQLite has no equivalent cost, which is why it keeps the copy.
+        await _reset_postgres(database_url)
+        await upgrade_to_head(database_url)
+    else:
+        # `database_url` is `sqlite+aiosqlite:///<tmp_path>/test.db`, and the file does
+        # not exist yet - this is what creates it.
+        shutil.copyfile(sqlite_template, database_url.split("///", 1)[1])
 
     engine = create_engine(settings.model_copy(update={"database_url": database_url}))
     sessionmaker = create_sessionmaker(engine)


### PR DESCRIPTION
CI failed at its twenty-minute cap on #125 and passed at `10m26s` on a re-run of the same
commit, nothing changed. **The cap was not the problem** — the job had grown until it sat
next to it.

## Measured first

"Make the suite faster" invites guessing, so:

```
654 tests, 546 of them (83%) in files using the `migrated` fixture
~830 ms per `alembic upgrade head`
~453s of a 665s run spent arriving at the identical empty schema
```

Nine of the twelve slowest entries were **`setup`**, not `call`. There is no slow test in
this suite; there were five hundred tests each paying for the whole migration chain.

## What changed

**The SQLite schema is built once per session and copied.** A file copy is about a
millisecond against 830. This does not weaken what the fixture promises — the schema
still comes from *running* the migration, not from `Base.metadata.create_all()`, and a
copy of the migration's output is not the models testing themselves. A test that needs
the chain itself (`test_positions.py` upgrades to an earlier revision and forward) drives
alembic directly and is untouched.

**Each xdist worker gets its own PostgreSQL database.** Without this, `-n auto` would
have broken the suite *silently*: `_reset_postgres` drops and recreates `public` on a
shared database, so two workers would delete each other's schema mid-test — and that
reads as flaky tests, not as a configuration mistake.

**`pytest -n auto` in CI.** The timeout stays at 20 minutes; raising it would have hidden
the symptom and let every new test walk back toward the edge. The comment claiming twenty
was "three times the honest runtime" is corrected to what actually happened.

## One idea measured and thrown away

The same template trick on PostgreSQL — `CREATE DATABASE … TEMPLATE` instead of the
migration — **made it slower**:

```
PostgreSQL half without the template:  37.84s
PostgreSQL half with the template:     50.72s
```

Cloning a database copies its whole file layout and needs every connection dropped
first, which costs more than emptying a small schema and replaying the chain on a
connection that is already open. Both numbers are in the comment, so nobody spends an
afternoon rediscovering it.

## Result

Both dialects, the same 1269 tests, same machine:

| | |
|---|---|
| serially, as today | **16m43s** |
| this change, four workers | **3m14s** |

Intermediate numbers, three files, both dialects: `111.73s` → `49.70s` (copy alone) →
`23.86s` (four workers).

## Run three times before committing

A change to the test harness is the worst place for flakiness to enter, and one green run
does not prove its absence:

```
run 1:  1269 passed in 2:59
run 2:  1269 passed in 3:14
run 3:  1269 passed in 4:06
```

Not one test flickered. `ruff check`, `ruff format --check` clean. No production code is
touched — this is `tests/conftest.py`, one dev dependency, and the workflow.

**Expect less than 5.2x on CI**: this machine has 32 cores and a GitHub runner has 4, and
8 workers only beat 4 by 23.86s → 21.31s here, so the bottleneck is database setup and
I/O rather than CPU. CI's own number on this pull request is the real measurement.
