### PR TITLE
Ship the one-command install: Docker Compose for the API and the dashboard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# What never enters a build context. The images copy source and build the rest
+# themselves, so everything machine-local, generated or secret stays out - which
+# keeps the context small and keeps `.env` from ever being baked into a layer.
+.git
+.venv
+__pycache__
+**/__pycache__
+*.pyc
+*.egg-info
+.env
+*.db
+*.db-*
+var/
+web/node_modules
+web/.next
+web/out
+tests/
+docs/
+internal/

--- a/.env.example
+++ b/.env.example
@@ -241,6 +241,30 @@ SMTP_USE_SSL=false
 LOG_LEVEL=INFO
 
 # ---------------------------------------------------------------------------
+# Docker Compose only - ignored by a manual run
+# ---------------------------------------------------------------------------
+# docker-compose.yml reads this file for ${...} substitutions. Everything below
+# has a working default for an installation used on the machine that runs it:
+# dashboard on http://localhost:3000, API on http://localhost:8000, both
+# published on loopback only, SQLite on the tel-agent-data volume.
+#
+# Reaching the installation from other machines means three changes, then
+# `docker compose up -d --build` (the dashboard bakes its API address at build
+# time, so it must be rebuilt):
+#
+#   TEL_AGENT_PUBLIC_API_URL=http://your-host:8000
+#   TEL_AGENT_WEB_ORIGIN=http://your-host:3000
+#   TEL_AGENT_TRUSTED_HOSTS=localhost,127.0.0.1,your-host
+#   TEL_AGENT_API_LISTEN=0.0.0.0:8000
+#   TEL_AGENT_WEB_LISTEN=0.0.0.0:3000
+#
+# The postgres profile (docker compose --profile postgres up -d) additionally
+# wants:
+#
+#   TEL_AGENT_POSTGRES_PASSWORD=<something long>
+#   TEL_AGENT_DATABASE_URL=postgresql+asyncpg://telagent:<that password>@db/telagent
+
+# ---------------------------------------------------------------------------
 # Telegram channel (Milestone 3)
 # ---------------------------------------------------------------------------
 # The bot token itself is NOT set here - it is user-entered, stored encrypted in

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts run inside Linux containers; a CRLF checkout on Windows would
+# turn their shebang into "/bin/sh\r" and fail the image at start.
+*.sh text eol=lf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,14 @@ differently on each.
 TEST_POSTGRES_URL=postgresql+asyncpg://user:pass@localhost:5432/telagent_test pytest
 ```
 
+No PostgreSQL on the machine? `docker-compose.dev.yml` starts a throwaway one with
+matching credentials:
+
+```bash
+docker compose -f docker-compose.dev.yml up -d
+TEST_POSTGRES_URL=postgresql+asyncpg://telagent:telagent@localhost:5432/telagent_test pytest
+```
+
 Without it you get the SQLite half and no failure. With it you get both.
 
 **On Windows:** `lint-imports` crashes with a `UnicodeEncodeError` when its output is

--- a/README.md
+++ b/README.md
@@ -165,17 +165,28 @@ generated.
 
 ## Quick start
 
-Not available yet. Once Milestone 9 lands, this section becomes:
-
 ```bash
 git clone https://github.com/Dpro-at/Tel-Agent.git
 cd Tel-Agent
-cp .env.example .env    # add your API keys
-docker compose up -d
+cp .env.example .env
+# set ENCRYPTION_KEY in .env - generate one with: openssl rand -hex 32
+docker compose up -d --build
 ```
 
-Until then, see [`docs/SPEC.md`](docs/SPEC.md) for the full design and
-[`CLAUDE.md`](CLAUDE.md) for the development rules.
+Then open **http://localhost:3000**. The first visit creates the administrator —
+there are no default credentials. The API and its documentation are on
+http://localhost:8000/docs, and conversations live on the `tel-agent-data`
+volume (SQLite by default; a `postgres` profile is in `docker-compose.yml`).
+
+Both ports are published on **loopback only**. Reaching the installation from
+other machines is a decision made in `.env` — the `TEL_AGENT_*` block there
+lists the three values to change and why the dashboard image is rebuilt for it.
+On a server, put a reverse proxy terminating TLS in front instead.
+
+**Running it without Docker** stays supported and documented — contributors need
+to run the code without rebuilding an image on every edit. See
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for the manual run, [`docs/SPEC.md`](docs/SPEC.md)
+for the full design and [`CLAUDE.md`](CLAUDE.md) for the development rules.
 
 ### Requirements when it ships
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,24 @@
+# Development helpers - never the product. The product's own containers are in
+# docker-compose.yml; contributors run the code directly (CONTRIBUTING.md) so an
+# edit does not cost an image rebuild. What this file provides is the second half
+# of the test matrix: a PostgreSQL to point TEST_POSTGRES_URL at.
+#
+#   docker compose -f docker-compose.dev.yml up -d
+#   TEST_POSTGRES_URL=postgresql+asyncpg://telagent:telagent@localhost:5432/telagent_test pytest
+
+services:
+  test-db:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: telagent
+      # Throwaway by definition: this database holds test rows on a developer's
+      # machine and is dropped and rebuilt on every run.
+      POSTGRES_PASSWORD: telagent
+      POSTGRES_DB: telagent_test
+    ports:
+      - "127.0.0.1:5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U telagent -d telagent_test"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,99 @@
+# Tel-Agent - the one-command install (§B10).
+#
+#   cp .env.example .env        # set ENCRYPTION_KEY (openssl rand -hex 32)
+#   docker compose up -d --build
+#
+# Dashboard on http://localhost:3000, API on http://localhost:8000. Both are
+# published on loopback only (§B9): reaching an installation from elsewhere goes
+# through a private network, a VPN, or a reverse proxy terminating TLS - see the
+# Docker section in README.md, including how the TEL_AGENT_* variables below
+# rebuild the dashboard for another hostname.
+#
+# The database is SQLite on the `tel-agent-data` volume by default. To run on
+# PostgreSQL instead:
+#
+#   docker compose --profile postgres up -d --build
+#
+# with TEL_AGENT_DATABASE_URL set in .env to
+# postgresql+asyncpg://telagent:${TEL_AGENT_POSTGRES_PASSWORD}@db/telagent
+#
+# The optional bundled n8n (§B10's automation profile) is reached on
+# http://localhost:5678 and talks to the API like any other machine client:
+#
+#   docker compose --profile automation up -d
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: docker/api.Dockerfile
+    restart: unless-stopped
+    environment:
+      # Refused empty on purpose: an installation without a key stores every
+      # user-entered credential nowhere, and finding that out at the first save
+      # is worse than at `up`.
+      ENCRYPTION_KEY: "${ENCRYPTION_KEY:?set ENCRYPTION_KEY in .env - generate one with openssl rand -hex 32}"
+      ENVIRONMENT: ${TEL_AGENT_ENVIRONMENT:-production}
+      DATABASE_URL: ${TEL_AGENT_DATABASE_URL:-sqlite+aiosqlite:////data/tel-agent.db}
+      CORS_ORIGINS: ${TEL_AGENT_WEB_ORIGIN:-http://localhost:3000}
+      TRUSTED_HOSTS: ${TEL_AGENT_TRUSTED_HOSTS:-localhost,127.0.0.1}
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      SMTP_FROM: ${SMTP_FROM:-}
+    volumes:
+      - tel-agent-data:/data
+    ports:
+      # Loopback by default. Publish wider only on purpose, e.g. 0.0.0.0:8000.
+      - "${TEL_AGENT_API_LISTEN:-127.0.0.1:8000}:8000"
+
+  web:
+    build:
+      context: .
+      dockerfile: docker/web.Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${TEL_AGENT_PUBLIC_API_URL:-http://localhost:8000}
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+    ports:
+      - "${TEL_AGENT_WEB_LISTEN:-127.0.0.1:3000}:3000"
+
+  db:
+    image: postgres:17-alpine
+    profiles: ["postgres"]
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: telagent
+      # No default on purpose (no default credentials, §B9). Left unset, the
+      # postgres image itself refuses to initialise and says why - a `:?` guard
+      # here would instead break `docker compose up` for people not using this
+      # profile at all, because interpolation runs before profiles are applied.
+      POSTGRES_PASSWORD: ${TEL_AGENT_POSTGRES_PASSWORD:-}
+      POSTGRES_DB: telagent
+    volumes:
+      - tel-agent-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U telagent -d telagent"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # §B10's optional automation profile. n8n reaches the API over the compose
+  # network as http://api:8000, authenticating like any other machine client -
+  # a webhook target, or a machine token minted on the API tab.
+  n8n:
+    image: n8nio/n8n:latest
+    profiles: ["automation"]
+    restart: unless-stopped
+    volumes:
+      - tel-agent-n8n:/home/node/.n8n
+    ports:
+      - "${TEL_AGENT_N8N_LISTEN:-127.0.0.1:5678}:5678"
+
+volumes:
+  tel-agent-data:
+  tel-agent-postgres:
+  tel-agent-n8n:

--- a/docker/api-entrypoint.sh
+++ b/docker/api-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Migrate, then serve. In that order, always: the schema belongs to the image's
+# code, and a container that answers requests against last release's tables is a
+# 500 with a long fuse. `python -m api` rather than a bare uvicorn command because
+# that is the entry point that honours BIND_HOST and warns when it is widened.
+set -e
+
+echo "applying database migrations"
+# Retried, because the postgres profile starts the database beside this container
+# and it may still be coming up. Ten failures in a row is a real fault; say so.
+tries=0
+until alembic upgrade head; do
+    tries=$((tries + 1))
+    if [ "$tries" -ge 10 ]; then
+        echo "migrations failed after ${tries} attempts - is the database reachable?" >&2
+        exit 1
+    fi
+    echo "database not ready, retrying (${tries}/10)"
+    sleep 3
+done
+
+exec python -m api

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -1,0 +1,60 @@
+# The API and the agent loop, in one container - §B10.
+#
+# Build context is the repository root:
+#   docker build -f docker/api.Dockerfile .
+#
+# The entrypoint migrates before it serves: an image whose schema can lag its code
+# turns every upgrade into a 500 hunt, and the handover has the scar to prove it.
+
+FROM python:3.12-slim AS build
+
+WORKDIR /app
+
+# Dependencies first, on their own layer, so editing a source file does not
+# reinstall the world. Setuptools refuses to even report requirements without the
+# package directories, so two empty ones stand in for them on this layer.
+COPY pyproject.toml README.md ./
+RUN mkdir -p api agent && pip install --no-cache-dir .
+
+COPY api/ api/
+COPY agent/ agent/
+COPY locales/ locales/
+COPY alembic/ alembic/
+COPY alembic.ini ./
+COPY scripts/ scripts/
+# The package itself again, now that its source is present.
+RUN pip install --no-cache-dir --no-deps --force-reinstall .
+
+# ---------------------------------------------------------------------------
+
+FROM python:3.12-slim
+
+# Never root: this process parses strangers' input for a living (§B14).
+RUN useradd --create-home --uid 1000 telagent
+WORKDIR /app
+
+COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=build /usr/local/bin /usr/local/bin
+COPY --from=build /app /app
+COPY docker/api-entrypoint.sh /entrypoint.sh
+
+# Conversations, the SQLite database and backups live here, on a volume.
+RUN mkdir -p /data && chown telagent:telagent /data /app
+VOLUME /data
+
+USER telagent
+
+# Inside the container the server must listen on the bridge interface - the host
+# decides what is published, and the compose file publishes loopback only.
+ENV BIND_HOST=0.0.0.0 \
+    BIND_PORT=8000 \
+    DATABASE_URL=sqlite+aiosqlite:////data/tel-agent.db
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=4)"]
+
+# Via `sh` rather than directly: a COPY from a Windows checkout has no execute
+# bit to preserve, and the script does not need one this way.
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -1,0 +1,49 @@
+# The dashboard - §B10.
+#
+# Build context is the repository root, because the UI dictionaries live in
+# `locales/`, one level above `web/`, and the build imports them:
+#   docker build -f docker/web.Dockerfile .
+#
+# NEXT_PUBLIC_API_URL is baked at build time - it is a browser-side constant, and
+# the CSP's connect-src is derived from it. The default serves an installation
+# reached as http://localhost:3000 with the API published on localhost:8000. An
+# installation reached under another name rebuilds with its own value; the compose
+# file wires that through TEL_AGENT_PUBLIC_API_URL.
+
+FROM node:22-alpine AS build
+
+WORKDIR /repo
+
+COPY web/package.json web/package-lock.json web/
+RUN cd web && npm ci
+
+COPY locales/ locales/
+COPY web/ web/
+
+ARG NEXT_PUBLIC_API_URL=http://localhost:8000
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL} \
+    NODE_ENV=production
+RUN cd web && npm run build
+
+# ---------------------------------------------------------------------------
+
+FROM node:22-alpine
+
+WORKDIR /app
+
+# `outputFileTracingRoot` is the repository, so the standalone bundle keeps the
+# repo shape: the server entry is web/server.js under it. `node` is the non-root
+# user the base image already ships.
+COPY --from=build --chown=node:node /repo/web/.next/standalone ./
+COPY --from=build --chown=node:node /repo/web/.next/static ./web/.next/static
+COPY --from=build --chown=node:node /repo/web/public ./web/public
+
+USER node
+
+ENV NODE_ENV=production \
+    HOSTNAME=0.0.0.0 \
+    PORT=3000
+
+EXPOSE 3000
+
+CMD ["node", "web/server.js"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dependencies = [
     # makes is a dependency this repository declares - a transitive extra is one
     # uvicorn release away from disappearing.
     "websockets>=13",
+    # A runtime dependency since Milestone 3, not just the test client: every
+    # channel transport and the webhook sender speak HTTP through it. It used to
+    # sit only in [dev], which the Docker image was first to notice.
+    "httpx>=0.28",
 ]
 
 [project.scripts]

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -43,6 +43,10 @@ function contentSecurityPolicy(): string {
 
 const config: NextConfig = {
   reactStrictMode: true,
+  // The Docker image runs `node server.js` from this bundle: the server plus only the
+  // files it traces, instead of the whole node_modules tree. Harmless in development,
+  // which never reads it.
+  output: "standalone",
   async headers() {
     return [
       {


### PR DESCRIPTION
## Milestone 10 — Docker packaging (SPEC §B10)

The README's quick start is real now:

```bash
cp .env.example .env   # set ENCRYPTION_KEY (openssl rand -hex 32)
docker compose up -d --build
```

Dashboard on http://localhost:3000, API on http://localhost:8000, conversations on the `tel-agent-data` volume.

### The shape
- **`docker/api.Dockerfile`** — python:3.12-slim, non-root, healthcheck on `/health`. The entrypoint applies `alembic upgrade head` **before** serving (with retries, for the postgres profile's startup race) and then runs `python -m api` — the entry point that honours `BIND_HOST`, so the §B9 loopback discipline carries into the container: the process binds the bridge interface and **the host publishes 127.0.0.1 only** unless `.env` says otherwise.
- **`docker/web.Dockerfile`** — node:22-alpine standalone build (context is the repo root because `locales/` sits above `web/`). `NEXT_PUBLIC_API_URL` is a build ARG: it is a browser-side constant and the CSP's `connect-src` derives from it, so serving the installation under another hostname is a rebuild — `.env.example`'s new `TEL_AGENT_*` block documents exactly that, and why.
- **`docker-compose.yml`** — api + web, a `postgres` profile (no default password on purpose; the image itself refuses to initialise without one), and §B10's optional `automation` profile with bundled n8n. `ENCRYPTION_KEY` is refused empty at `up`, not discovered at the first save; `ENVIRONMENT=production` inside the container makes the API enforce the same.
- **`docker-compose.dev.yml`** — never the product: a throwaway PostgreSQL matching CONTRIBUTING.md's `TEST_POSTGRES_URL`, so the second half of the test matrix stops requiring a local server. Contributors keep running the code directly, per the roadmap's own words.

### Found by the image, fixed here
`httpx` sat only in `[dev]` while every channel transport and the webhook sender import it at runtime — every dev machine had it via the test extras, and the container was the first environment honest enough to fail. Moved to runtime dependencies. Also `.gitattributes` now pins LF on `*.sh`, so a Windows checkout cannot turn the entrypoint's shebang into `/bin/sh\r`.

### Proven live, on Docker Desktop (server 29.1.3)
Fresh volumes, `docker compose up -d --build`: migrations applied, ten official extensions loaded, healthcheck green. In the browser against the containers: the first-run **Set up this installation** screen → administrator created → signed in → System health shows Tel-Agent server and Database *Running* (SQLite on the volume, 1.7 ms) and everything unconfigured honestly grey. Then a full `docker compose down && up` — the account and workspace survive on the volume (login 200 after the cycle).

Not live-tested: the `postgres`/`automation` profiles end to end, and `docker-compose.dev.yml` (port 5432 is held by the dev machine's own PostgreSQL; the file passes `docker compose config`). The `update` screen stays a fixture — pulling new containers and rolling back is an update *mechanism*, its own piece of work on top of this packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)