### PR TITLE
Milestone 11's voice core: the two interfaces and the turn that stops on barge-in

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -39,12 +39,22 @@ the database and publishes events; it does not serve the UI.
 
 ## Right now
 
-Milestone 0. The model interface exists and has one implementation behind it - an
-OpenAI-compatible `/chat/completions` endpoint, streaming - and `reply.py` is what the
-web chat route consumes. `tools/` holds the first built-in tool, `take_message`, which
-the model is offered on every turn. `stt/`, `tts/`, `session/` and `routing/` are still
-empty: this structure is where that code goes as it grows, not an instruction to build
-it all now.
+The model interface exists and has one implementation behind it - an OpenAI-compatible
+`/chat/completions` endpoint, streaming - and `reply.py` is what every channel consumes.
+`tools/` holds the built-in tools the model is offered.
+
+Milestone 11's software core is now in place, ahead of the live line it cannot be
+closed without: `providers/stt/base.py` and `providers/tts/base.py` are §B3's two
+missing interfaces (partials and finals in, audio chunks out, `cancel()` mandatory),
+and `session/turn.py` is the turn-taker that speaks a streamed reply through them and
+stops the instant the caller cuts in - the barge-in that Rule 3 makes non-optional,
+with the end-of-speech-to-first-audio latency Rule 4 logs. All of it runs on fakes in
+`tests/test_voice_turn.py`; no provider, no SIP, no key. What is still to come, and is
+blocked on a bought number and real provider keys: the Deepgram/ElevenLabs
+implementations, the LiveKit/SIP transport that feeds audio in and plays it out, and
+the `api/` side that stores a call beside every other conversation. `routing/` is a
+stub - the rules engine itself lives at `api/routing.py` (Milestone 4), which the phone
+will call once caller ID is settled on a live line.
 
 Configuration comes from the environment, in `config.py`. That file exists rather than
 importing `api.config` because this package never imports from `api/` - at Milestone 11

--- a/agent/providers/stt/__init__.py
+++ b/agent/providers/stt/__init__.py
@@ -1,1 +1,7 @@
 """Speech-to-text providers: stream(audio) -> partial and final transcripts."""
+
+from __future__ import annotations
+
+from agent.providers.stt.base import Final, Partial, STTProvider, Transcript
+
+__all__ = ["Final", "Partial", "STTProvider", "Transcript"]

--- a/agent/providers/stt/base.py
+++ b/agent/providers/stt/base.py
@@ -1,0 +1,78 @@
+"""The interface every speech-to-text provider sits behind — §B3.
+
+    STTProvider → stream(audio) -> partial and final transcripts
+
+One method, and it is a stream in and a stream out. Audio arrives in chunks as the
+caller speaks, and transcripts come back before the caller has stopped: a **partial**
+is the provider's best guess so far, revised as more audio arrives, and a **final** is
+what it commits to once it decides a phrase has ended.
+
+**Partials are what make the budget.** Rule 3 gives endpointing — deciding the caller
+has finished — the largest single slice of the 800 ms, and a provider that only spoke
+at end of utterance would spend that slice in silence. Partials let the turn-taker see
+the sentence forming and start thinking before the caller's mouth has closed. They are
+never stored and never read aloud; only a final becomes a transcript line.
+
+**A final carries its confidence and language, because §B5 asked for them per line.**
+`messages.stt_confidence` and `.language` turn "German accuracy" (Rule 4) from an
+impression into a query, and they are null on a text channel — which is itself the
+signal that a line was typed rather than spoken. So they are on the `Final`, not
+guessed later.
+
+**Cancellation is the stream's own close**, the same argument the LLM interface makes:
+the consumer stops consuming, `GeneratorExit` is thrown in at the `yield`, and the
+implementation's `finally` closes the provider's socket. An implementation must
+therefore yield from inside its connection's context manager rather than collecting
+first — the interface is written so the second implementation cannot quietly be the
+blocking kind.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class Partial:
+    """The provider's best guess at the phrase in progress, still being revised.
+
+    Not stored, not spoken: a partial exists so the turn-taker can see the caller is
+    still talking and can begin work before the final arrives. Its text will change.
+    """
+
+    text: str
+
+
+@dataclass(frozen=True)
+class Final:
+    """A phrase the provider has committed to — this becomes one transcript line.
+
+    `confidence` is 0..1 where the provider offers it, else None; `language` is the
+    BCP-47 tag it detected, or None. Both ride here rather than being inferred later,
+    because §B5 put `stt_confidence` and `language` on `messages` for exactly this and
+    the provider is the only thing that knows them.
+    """
+
+    text: str
+    confidence: float | None = None
+    language: str | None = None
+
+
+Transcript = Partial | Final
+
+
+class STTProvider(Protocol):
+    """Turns a stream of audio into a stream of transcripts."""
+
+    def stream(self, audio: AsyncIterator[bytes]) -> AsyncIterator[Transcript]:
+        """Transcribe `audio` as it arrives, yielding partials then finals.
+
+        Consumes audio chunks (the codec is the transport's concern, agreed out of
+        band — G.711 8 kHz mono for v1, per the SIP settings) and yields `Partial`s as
+        the guess firms up and a `Final` when a phrase closes. A silent call yields
+        nothing and is not an error. An error is raised, never yielded, so a caller
+        cannot mistake a failed connection for a caller who said nothing.
+        """
+        ...

--- a/agent/providers/tts/__init__.py
+++ b/agent/providers/tts/__init__.py
@@ -1,1 +1,7 @@
 """Text-to-speech providers. ``cancel()`` is mandatory, not optional."""
+
+from __future__ import annotations
+
+from agent.providers.tts.base import TTSProvider
+
+__all__ = ["TTSProvider"]

--- a/agent/providers/tts/base.py
+++ b/agent/providers/tts/base.py
@@ -1,0 +1,47 @@
+"""The interface every text-to-speech provider sits behind — §B3.
+
+    TTSProvider → stream(text) -> audio chunks
+                → cancel()        # on barge-in, stop instantly
+
+**`cancel()` is not optional, and it is the whole reason this milestone is hard.** When
+the caller talks over the agent, the audio already produced is sitting in a playback
+buffer ahead of the listener, and stopping the *producer* is not enough — the queued
+speech has to be thrown away too, or the agent finishes its sentence over the caller
+and the product feels broken (Rule 3). So cancellation here is two acts, and the
+interface names both:
+
+- **Stop producing.** Closing the returned audio iterator throws `GeneratorExit` into
+  the provider's generator, whose `finally` closes the HTTP response — which stops the
+  synthesis at the far end rather than only ignoring it, so nothing more is billed.
+- **Flush what is queued.** That is the *sink's* job, not the provider's: the thing
+  playing the audio holds the buffer, and `agent/session` flushes it on barge-in. The
+  provider cannot flush a buffer it never sees.
+
+This module is the producer half. It is written as an async iterator for the same
+reason the LLM interface is: a provider that returned a finished audio blob could never
+be put on a call, because the first chunk would not leave until the last was made
+(Rule 3 — the first sentence speaks while the rest is still being generated). Writing
+the signature this way means the second implementation cannot quietly be the blocking
+kind.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Protocol
+
+
+class TTSProvider(Protocol):
+    """Turns text into a stream of audio chunks, cancellable mid-utterance."""
+
+    def stream(self, text: str) -> AsyncIterator[bytes]:
+        """Speak `text`, yielding audio chunks as they are synthesised.
+
+        The first chunk must leave as soon as it exists, not once the whole utterance
+        is made: on a call the first sentence is spoken while the rest is still being
+        generated. Chunks are in the codec the transport expects (G.711 8 kHz mono for
+        v1). Cancellation is closing this iterator — the generator's `finally` closes
+        the provider's response, stopping synthesis at the far end — paired with the
+        sink flushing whatever it has already buffered. An error is raised, not yielded.
+        """
+        ...

--- a/agent/session/__init__.py
+++ b/agent/session/__init__.py
@@ -1,1 +1,7 @@
 """Conversation lifecycle, turn-taking, barge-in and whisper handling."""
+
+from __future__ import annotations
+
+from agent.session.turn import AudioSink, TurnResult, speak
+
+__all__ = ["AudioSink", "TurnResult", "speak"]

--- a/agent/session/turn.py
+++ b/agent/session/turn.py
@@ -1,0 +1,204 @@
+"""Speaking a turn, and stopping the instant the caller cuts in — Rule 3.
+
+This is the half of Milestone 11 that every other milestone was written to make
+possible. `agent.reply.reply` already yields text a piece at a time rather than a
+finished paragraph; here that text is spoken *while the rest is still being generated*,
+and the speaking stops mid-word when the caller talks over it.
+
+**Barge-in is two acts, and both are here.** Stopping the synthesiser (closing the TTS
+iterator, whose `finally` closes the provider's response and stops the far-end billing)
+and flushing the audio already handed to the sink (the queued speech ahead of the
+listener). Doing only the first leaves the agent finishing its sentence over the caller
+from the playback buffer; doing only the second keeps paying for audio nobody hears.
+
+**Text is spoken in phrases, not per token nor all at once.** A token is too small to
+synthesise well and all-at-once reintroduces the silence Rule 3 forbids. So the reply's
+tokens are gathered to the next sentence boundary and that phrase is sent to the TTS,
+which begins the next phrase while the current one is still playing — the first sentence
+speaks while the rest generates.
+
+**Latency is measured from the end of the caller's speech**, which the caller passes in
+as `since` (the moment endpointing fired), to the first byte of audio out. That is the
+number Rule 3 budgets at 800 ms and Rule 4 logs on every call; this module records it
+and the caller decides what to do with a turn that missed.
+
+`agent/` may not import `api/`, so nothing here stores a transcript or touches a
+session: the turn produces text and audio and a measurement, and the caller that has a
+database decides what those mean.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from agent.providers.tts import TTSProvider
+
+logger = logging.getLogger("agent.session")
+
+# Where a phrase ends: sentence punctuation, or a comma once the phrase is long enough
+# that waiting for a full stop would delay the first audio past the budget. Tuned for
+# speech, not prose - a caller would rather hear the first clause a beat early than the
+# whole sentence a beat late.
+_SENTENCE_END = re.compile(r"[.!?]['\")\]]?\s")
+_SOFT_BREAK = re.compile(r"[,;:]['\")\]]?\s")
+# Below this a comma is not worth breaking on; above it, break at the first comma so a
+# long sentence does not hold the first audio hostage to its full stop.
+_SOFT_BREAK_MIN = 60
+
+
+@dataclass
+class TurnResult:
+    """What one spoken turn produced, for the transcript and for Rule 4."""
+
+    # The whole text the agent said, assembled from the phrases - one transcript line.
+    text: str = ""
+    # End of caller speech to first audio out, in milliseconds. None when the agent
+    # said nothing (an empty reply) so nothing was ever spoken.
+    first_audio_ms: float | None = None
+    # True when the caller cut in and the turn was cut short. The stored line is what
+    # was actually said before the interruption, not what the model would have finished.
+    interrupted: bool = False
+    # Every phrase's first-audio latency, so a turn that started fast and then stalled
+    # is visible rather than averaged away.
+    phrase_latencies_ms: list[float] = field(default_factory=list)
+
+
+class AudioSink(Protocol):
+    """Where synthesised audio goes, and the flush that barge-in needs.
+
+    The transport implements this - LiveKit, or a SIP media stream - and it owns the
+    playback buffer. `flush` discards whatever is buffered but not yet heard, which is
+    the act closing the TTS iterator cannot perform because the provider never sees the
+    buffer.
+    """
+
+    async def write(self, chunk: bytes) -> None:
+        """Queue one audio chunk for playback."""
+        ...
+
+    async def flush(self) -> None:
+        """Discard queued-but-unplayed audio. Called on barge-in."""
+        ...
+
+
+def _phrases(buffer: str, *, final: bool) -> tuple[list[str], str]:
+    """Split what has arrived so far into complete phrases and a remainder.
+
+    `final` true flushes the remainder as a last phrase - the reply has ended, so the
+    tail is spoken rather than held for a boundary that will never come.
+    """
+    phrases: list[str] = []
+    while True:
+        match = _SENTENCE_END.search(buffer)
+        if match is None and len(buffer) >= _SOFT_BREAK_MIN:
+            match = _SOFT_BREAK.search(buffer)
+        if match is None:
+            break
+        cut = match.end()
+        phrase = buffer[:cut].strip()
+        if phrase:
+            phrases.append(phrase)
+        buffer = buffer[cut:]
+    if final:
+        tail = buffer.strip()
+        if tail:
+            phrases.append(tail)
+        buffer = ""
+    return phrases, buffer
+
+
+async def speak(
+    text_stream: AsyncIterator[str],
+    *,
+    tts: TTSProvider,
+    sink: AudioSink,
+    should_stop: Callable[[], bool],
+    since: float | None = None,
+) -> TurnResult:
+    """Speak a reply as it streams, stopping the instant `should_stop()` is true.
+
+    `text_stream` is `agent.reply.reply(...)`. `should_stop` is polled between audio
+    chunks and is how the caller wires barge-in - it returns true the moment the audio
+    input side hears the caller start again. `since` is the end-of-speech instant for
+    the latency measurement; omitted, latency is measured from the first phrase.
+    """
+    result = TurnResult()
+    started = since if since is not None else time.perf_counter()
+    buffer = ""
+    said: list[str] = []
+
+    async def emit(phrase: str) -> bool:
+        """Speak one phrase. Returns False if barge-in cut it short."""
+        phrase_start = time.perf_counter()
+        first_chunk = True
+        audio = tts.stream(phrase)
+        try:
+            async for chunk in audio:
+                if should_stop():
+                    return False
+                await sink.write(chunk)
+                if first_chunk:
+                    first_chunk = False
+                    latency = (time.perf_counter() - phrase_start) * 1000
+                    result.phrase_latencies_ms.append(latency)
+                    if result.first_audio_ms is None:
+                        result.first_audio_ms = (time.perf_counter() - started) * 1000
+        finally:
+            # Closes the provider's response - stops synthesis (and its bill) at the far
+            # end rather than only ignoring what it sends. Runs whether the phrase
+            # finished or barge-in returned early.
+            await audio.aclose()
+        return True
+
+    try:
+        async for piece in text_stream:
+            if should_stop():
+                result.interrupted = True
+                break
+            buffer += piece
+            phrases, buffer = _phrases(buffer, final=False)
+            for phrase in phrases:
+                said.append(phrase)
+                if not await emit(phrase):
+                    result.interrupted = True
+                    break
+            if result.interrupted:
+                break
+        else:
+            # The reply ended on its own; speak whatever tail is left.
+            phrases, buffer = _phrases(buffer, final=True)
+            for phrase in phrases:
+                if should_stop():
+                    result.interrupted = True
+                    break
+                said.append(phrase)
+                if not await emit(phrase):
+                    result.interrupted = True
+                    break
+    finally:
+        # Whatever ended this - a clean finish or barge-in - the reply generator is
+        # closed so its own `finally` stops the model mid-generation and stops that bill
+        # too. Closing an exhausted generator is harmless.
+        await text_stream.aclose()
+
+    if result.interrupted:
+        # The queued-but-unheard audio is discarded here: closing the TTS iterator
+        # stopped production, this stops playback of what was already handed over.
+        await sink.flush()
+
+    result.text = " ".join(said).strip()
+    if result.first_audio_ms is not None:
+        logger.info(
+            "spoken turn",
+            extra={
+                "first_audio_ms": round(result.first_audio_ms),
+                "interrupted": result.interrupted,
+                "phrases": len(result.phrase_latencies_ms),
+            },
+        )
+    return result

--- a/tests/test_voice_turn.py
+++ b/tests/test_voice_turn.py
@@ -1,0 +1,177 @@
+"""Milestone 11 — speaking a turn, and stopping the instant the caller cuts in.
+
+The interfaces (STT, TTS) are §B3's "abstraction written on day one"; this exercises
+the turn-taker that speaks a streamed reply through them. The load-bearing test is the
+barge-in one: Rule 3 makes `cancel()` mandatory, and "mandatory" means a test that
+fails if queued audio is not thrown away. Everything here runs on fakes — no provider,
+no line, no key, no cost — because the behaviour under test is the orchestration, and a
+real provider would test the provider.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from agent.providers.stt.base import Final, Partial
+from agent.providers.tts.base import TTSProvider
+from agent.session import speak
+from agent.session.turn import _phrases
+
+
+class RecordingSink:
+    """An `AudioSink` that keeps what it played and what survived a flush.
+
+    `heard` is everything written; `flushed` counts barge-in flushes. A real sink
+    would drop the queued frames; here we record that flush was asked for, because that
+    request *is* the discard the transport then performs.
+    """
+
+    def __init__(self) -> None:
+        self.heard: list[bytes] = []
+        self.flushes = 0
+
+    async def write(self, chunk: bytes) -> None:
+        self.heard.append(chunk)
+
+    async def flush(self) -> None:
+        self.flushes += 1
+
+
+class FakeTTS:
+    """One audio chunk per whitespace-delimited word, so 'barge-in' is observable at
+    word granularity. Records whether its generator was closed - the far-end stop."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.spoken: list[str] = []
+
+    def stream(self, text: str) -> AsyncIterator[bytes]:
+        self.spoken.append(text)
+
+        async def gen() -> AsyncIterator[bytes]:
+            try:
+                for word in text.split():
+                    yield word.encode()
+            finally:
+                self.closed = True
+
+        return gen()
+
+
+# A TTSProvider is a structural type; FakeTTS satisfies it.
+_: TTSProvider = FakeTTS()
+
+
+async def _stream(pieces: list[str]) -> AsyncIterator[str]:
+    for piece in pieces:
+        yield piece
+
+
+# --- Phrase chunking --------------------------------------------------------------
+
+
+def test_a_reply_is_cut_into_speakable_phrases() -> None:
+    phrases, rest = _phrases("Yes, we are open. Until noon on ", final=False)
+    # The full stop closes a phrase; the trailing clause waits for its boundary.
+    assert phrases == ["Yes, we are open."]
+    assert rest == "Until noon on "
+
+
+def test_a_long_clause_breaks_on_a_comma_rather_than_holding_the_first_audio() -> None:
+    # No full stop yet - the sentence is still forming - but long enough that waiting
+    # for one would delay the first audio, so it breaks at the comma.
+    long = "It depends on the day of the week and the season, but usually the "
+    phrases, rest = _phrases(long, final=False)
+    assert phrases[0].endswith(",")
+    assert rest.startswith("but usually")
+
+
+def test_the_tail_is_spoken_when_the_reply_ends_without_punctuation() -> None:
+    phrases, rest = _phrases("no full stop here", final=True)
+    assert phrases == ["no full stop here"]
+    assert rest == ""
+
+
+# --- The full turn ----------------------------------------------------------------
+
+
+async def test_the_whole_reply_is_spoken_and_measured() -> None:
+    tts = FakeTTS()
+    sink = RecordingSink()
+    result = await speak(
+        _stream(["Yes, we are open. ", "Until noon."]),
+        tts=tts,
+        sink=sink,
+        should_stop=lambda: False,
+    )
+    assert result.text == "Yes, we are open. Until noon."
+    assert not result.interrupted
+    assert result.first_audio_ms is not None
+    # Every word became a chunk; nothing was flushed because nothing was interrupted.
+    assert b"".join(sink.heard) == b"Yes,weareopen.Untilnoon."
+    assert sink.flushes == 0
+    assert tts.closed
+
+
+async def test_an_empty_reply_says_nothing_and_measures_nothing() -> None:
+    tts = FakeTTS()
+    sink = RecordingSink()
+    result = await speak(_stream([]), tts=tts, sink=sink, should_stop=lambda: False)
+    assert result.text == ""
+    assert result.first_audio_ms is None
+    assert sink.heard == []
+
+
+# --- Barge-in: the load-bearing case ----------------------------------------------
+
+
+async def test_barge_in_stops_the_synthesiser_and_flushes_the_queue() -> None:
+    """The caller talks over the agent. Production stops (the TTS generator is closed)
+    and the queued audio is flushed - both, because either alone leaves the product
+    broken: talking over the caller, or paying for unheard speech."""
+    tts = FakeTTS()
+    sink = RecordingSink()
+
+    # The caller cuts in the moment the agent has said its first two words.
+    def should_stop() -> bool:
+        return len(sink.heard) >= 2
+
+    result = await speak(
+        _stream(["One two three four five. ", "And a whole second sentence. "]),
+        tts=tts,
+        sink=sink,
+        should_stop=should_stop,
+    )
+
+    assert result.interrupted is True
+    # It stopped at the barge-in, not at the end of the reply.
+    assert len(sink.heard) == 2
+    # The queue was flushed exactly once, and the synthesiser was closed (far-end stop).
+    assert sink.flushes == 1
+    assert tts.closed
+    # The second sentence was never even sent to the TTS - the turn ended first.
+    assert "And a whole second sentence." not in tts.spoken
+
+
+async def test_a_clean_turn_never_flushes() -> None:
+    """Flush is barge-in's alone: a turn that finishes normally must not discard audio,
+    or the last words of every answer would be cut off."""
+    tts = FakeTTS()
+    sink = RecordingSink()
+    result = await speak(
+        _stream(["All done here."]), tts=tts, sink=sink, should_stop=lambda: False
+    )
+    assert not result.interrupted
+    assert sink.flushes == 0
+
+
+# --- The STT interface's own shape ------------------------------------------------
+
+
+def test_a_final_carries_confidence_and_language_a_partial_does_not() -> None:
+    """§B5 put `stt_confidence` and `language` on `messages`; a `Final` is where they
+    come from, and a `Partial` - never stored - has no room for them."""
+    final = Final(text="Guten Tag", confidence=0.94, language="de")
+    assert (final.confidence, final.language) == (0.94, "de")
+    partial = Partial(text="Guten")
+    assert not hasattr(partial, "confidence")


### PR DESCRIPTION
## Milestone 11 — the phone, its software core (SPEC §B3, Rules 3 & 4)

The phone is last on purpose, and it is the milestone that judges the ten before it. It **cannot be closed here**: the six roadmap checks (arrive → answer → speak → listen → full loop → same archive) all need a bought number pointed at a SIP endpoint, a LiveKit account, real Deepgram/ElevenLabs keys, and twenty real Austrian-German calls — none of which is code, and none of which I can or should do (buying numbers and entering provider keys spend real money, §B9.1). This PR builds the part that **is** code and that §B3 says is written first: *the abstraction is written on day one; the implementation comes after the first call works.*

### The two interfaces chat never needed
- **`agent/providers/stt/base.py`** — `STTProvider.stream(audio) -> Partial | Final`. **Partials** are never stored and never spoken; they exist so endpointing (Rule 3's largest budget slice) can start before the caller's mouth closes. A **Final** carries `confidence` and `language`, because §B5 put `stt_confidence` and `language` on `messages` and the provider is the only thing that knows them.
- **`agent/providers/tts/base.py`** — `TTSProvider.stream(text) -> bytes`, an async iterator so the first chunk leaves before the last is made (Rule 3). Its cancellation is documented as the two acts barge-in needs.

Both mirror the existing `llm/base.py`: streams, errors raised not yielded, cancellation by closing the iterator so the provider's `finally` stops the far end.

### The turn-taker — `agent/session/turn.py`
`speak()` takes `agent.reply.reply`'s streamed answer and voices it **in phrases** — gathered to a sentence boundary (or a comma once a clause runs long), so the first sentence speaks while the rest is still generating. It **stops the instant the caller cuts in**, and barge-in is both acts the spec names:
1. **Stop producing** — close the TTS iterator; its `finally` closes the provider's response, stopping synthesis *and its bill* at the far end.
2. **Flush the queue** — the `AudioSink` (the transport's, later) discards the buffered-but-unheard audio the provider never sees.

Doing only the first talks over the caller from the playback buffer; doing only the second keeps paying for unheard speech. End-of-speech → first-audio latency is measured and logged (Rule 3's 800 ms budget, Rule 4's per-call number).

### Proven on fakes — no provider, no line, no key, no cost
`tests/test_voice_turn.py` (8 tests): phrase chunking incl. the long-clause comma break and the unpunctuated tail; the full turn spoken and measured; an empty reply that says and measures nothing; and the **load-bearing barge-in test** — the caller cuts in mid-answer, and the synthesiser is confirmed closed, the queue flushed exactly once, and the un-started second sentence never even sent to the TTS. A clean turn is asserted to *never* flush (or every answer would lose its last words).

### Deliberately not here
The Deepgram/ElevenLabs implementations, the LiveKit/SIP transport that feeds audio in and plays it out, and the `api/` side that stores a `calls` row beside every other conversation — all gated on the live line. And **no settings for the unbuilt providers**: a control with no backend is not drawn (the pattern every wired screen followed). `agent/` still never imports `api/` — checked. Full suite green on SQLite and PostgreSQL; the roadmap marker stays where it is, because a milestone the phone has not yet rung is not closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)