### PR TITLE
A phone call is a conversation in the same archive

### DIFF
--- a/api/channels/phone.py
+++ b/api/channels/phone.py
@@ -1,0 +1,353 @@
+"""The phone, from the archive's side — Milestone 11, §B5 decision 6.
+
+A call is a conversation on a `phone` channel plus a `calls` row for what only a call
+has: the caller's number, the recording, the billable seconds, the provider cost. This
+module is the driver that turns a live call into those rows and back: it consumes a
+stream of transcripts, answers each with the voice core (`agent/session/turn.py`), and
+stores the whole thing where `/api/conversations/search` can find it beside every chat.
+
+**The transport boundary is the transcript, not the audio.** The SIP/LiveKit transport
+owns codec ↔ STT ↔ TTS and the room; it hands this driver a `CallTransport` — a stream
+of `Partial`/`Final`s, a `TTSProvider`, and an `AudioSink` to speak into. That seam is
+what keeps the archive side testable without a line, a number or a provider key: a
+scripted transport stands in for a caller, and the real one implements the same three
+things. It is also what §B10's self-hosted-media requirement rests on — the transport
+is swappable because nothing above it knows which one it is.
+
+**Turn-taking is a race, and barge-in is the point of it.** While the agent speaks, the
+driver is still reading the transcript stream; a new transcript arriving mid-answer is
+the caller cutting in, and it stops the speaking (`agent.session.speak`'s `should_stop`)
+and stores only what was actually said — a stored line nobody heard is a transcript
+lying, the same rule every push channel already holds.
+
+**Routing runs first, on the caller ID** — Milestone 4's engine, the phone half it was
+built for. A blocked number is never answered and leaves no conversation; a `pass`
+number is handed to a person and the agent stays silent. This is the one place the
+caller-ID question (§A2, settled on the live line) actually bites, and it is wired now
+so that when the number is real the behaviour already exists.
+
+`agent/` may not import `api/`, so the voice core knows nothing of these tables: it
+speaks and measures, and this driver — which has a session — decides what that means.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import datetime as dt
+import logging
+import time
+from collections.abc import AsyncIterator
+from typing import Protocol
+
+from sqlalchemy.ext.asyncio import AsyncSession as DbSession
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from agent.config import ConfigurationError
+from agent.providers.stt.base import Final, Transcript
+from agent.providers.tts import TTSProvider
+from agent.reply import reply as generate_reply
+from agent.session import AudioSink, TurnResult, speak
+from api import llm, routing, webhooks
+from api.conversations import position_ms
+from api.db import create_sessionmaker, session_scope
+from api.models import Call, Channel, Conversation, Message
+
+logger = logging.getLogger("api.phone")
+
+
+class CallTransport(Protocol):
+    """One live call, as the archive side needs to see it.
+
+    The SIP/LiveKit transport implements this; a scripted one stands in for tests. It
+    is deliberately small: the driver does not touch audio or a codec, only transcripts
+    in and speech out.
+    """
+
+    from_e164: str | None
+    tts: TTSProvider
+    sink: AudioSink
+
+    def transcripts(self) -> AsyncIterator[Transcript]:
+        """The caller's speech as it is recognised — partials then finals, until the
+        call ends and the stream closes."""
+        ...
+
+
+async def _open_call(
+    db: DbSession, channel: Channel, from_e164: str | None
+) -> tuple[Conversation, Call]:
+    """A conversation on the phone channel and its calls row, committed together."""
+    conversation = Conversation(
+        workspace_id=channel.workspace_id,
+        channel_id=channel.id,
+        direction="inbound",
+        external_id=from_e164,
+        handling="ai",
+        status="open",
+    )
+    db.add(conversation)
+    await db.flush()
+    call = Call(
+        conversation_id=conversation.id,
+        workspace_id=channel.workspace_id,
+        from_e164=from_e164,
+    )
+    db.add(call)
+    await db.commit()
+    await db.refresh(conversation)
+    return conversation, call
+
+
+async def _store_line(
+    db: DbSession,
+    conversation: Conversation,
+    *,
+    speaker: str,
+    text: str,
+    confidence: float | None = None,
+    language: str | None = None,
+) -> Message:
+    line = Message(
+        workspace_id=conversation.workspace_id,
+        conversation_id=conversation.id,
+        ts_ms=position_ms(conversation.started_at),
+        speaker=speaker,
+        text=text,
+        stt_confidence=confidence,
+        language=language,
+    )
+    db.add(line)
+    await db.commit()
+    await db.refresh(line)
+    return line
+
+
+async def _announce_start(db: DbSession, channel: Channel, conversation: Conversation) -> None:
+    """The same `conversation.started` every channel queues, so a phone call is not a
+    special case to a webhook receiver — the only difference §B13 allows is transport."""
+    try:
+        await webhooks.queue(
+            db,
+            workspace_id=channel.workspace_id,
+            event="conversation.started",
+            data={
+                "conversation": conversation.external_id,
+                "channel": "phone",
+                "started_at": conversation.started_at.isoformat()
+                if conversation.started_at
+                else None,
+            },
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        logger.exception(
+            "could not queue call-started webhook",
+            extra={"conversation_id": conversation.id},
+        )
+
+
+async def _answer(
+    db: DbSession,
+    channel: Channel,
+    conversation: Conversation,
+    caller_text: str,
+    transport: CallTransport,
+    incoming: Message,
+    provider_override: object | None,
+) -> tuple[asyncio.Task, asyncio.Event]:
+    """Start speaking the agent's answer, returning the speak task and its stop event.
+
+    The reply is generated with the same history and tools every channel uses; the
+    difference is only that it is spoken rather than sent. The caller of this decides
+    the race against the next transcript.
+    """
+    provider = provider_override
+    if provider is None:
+        try:
+            provider = await llm.resolve_provider(db)
+        except ConfigurationError:
+            logger.exception(
+                "phone could not resolve a model", extra={"channel_id": channel.id}
+            )
+            provider = None
+
+    from api.agent_tools import toolset
+    from api.routes.public_chat import _history
+
+    history = await _history(db, conversation, incoming)
+    tools = toolset(
+        create_sessionmaker(db.bind),
+        workspace_id=channel.workspace_id,
+        conversation_id=conversation.id,
+    )
+
+    barge = asyncio.Event()
+    since = time.perf_counter()
+    task = asyncio.ensure_future(
+        speak(
+            generate_reply(caller_text, provider=provider, history=history, tools=tools),
+            tts=transport.tts,
+            sink=transport.sink,
+            should_stop=barge.is_set,
+            since=since,
+        )
+    )
+    return task, barge
+
+
+def _log_turn(conversation: Conversation, result: TurnResult) -> None:
+    if result.first_audio_ms is not None:
+        # Rule 4: end of caller speech to first audio out, the number this whole
+        # product was built to keep small.
+        logger.info(
+            "call turn",
+            extra={
+                "conversation_id": conversation.id,
+                "first_audio_ms": round(result.first_audio_ms),
+                "interrupted": result.interrupted,
+            },
+        )
+
+
+async def run_call(
+    sessionmaker: async_sessionmaker,
+    *,
+    channel_id: int,
+    transport: CallTransport,
+    provider: object | None = None,
+) -> int | None:
+    """Drive one phone call end to end, returning its conversation id.
+
+    Returns None when the caller was blocked by a rule and no conversation was opened.
+    The call ends when the transcript stream closes (the caller hung up); the calls row
+    is finalised with its billable seconds and the conversation is closed.
+
+    `provider` overrides the model, for the standalone agent process that resolves its
+    own and for tests; omitted, the model is resolved from settings like every channel.
+    """
+    async with session_scope(sessionmaker) as db:
+        channel = await db.get(Channel, channel_id)
+        if channel is None:
+            logger.warning("call for an unknown channel %s", channel_id)
+            return None
+
+        # Milestone 4, on the caller ID. A blocked number is never answered.
+        decision = await routing.decide(
+            db,
+            workspace_id=channel.workspace_id,
+            identities=[transport.from_e164] if transport.from_e164 else [],
+        )
+        if decision.action == "block":
+            logger.info(
+                "call dropped by rule",
+                extra={"channel_id": channel_id, "pattern": decision.pattern},
+            )
+            return None
+
+        conversation, call = await _open_call(db, channel, transport.from_e164)
+        await _announce_start(db, channel, conversation)
+        if decision.action == "pass":
+            await routing.apply_pass(db, conversation, decision)
+
+        started_at = conversation.started_at or dt.datetime.now(dt.UTC)
+        answering = decision.action == "ai"
+
+        # A single pull kept in flight, so the driver can race the next transcript
+        # against the agent's speaking - which is what makes barge-in real.
+        stream = transport.transcripts().__aiter__()
+        pending = asyncio.ensure_future(_next(stream))
+        carried: Transcript | None = None
+
+        try:
+            while True:
+                if carried is not None:
+                    transcript, carried = carried, None
+                else:
+                    transcript = await pending
+                    pending = asyncio.ensure_future(_next(stream))
+
+                if transcript is None:
+                    break
+                if not isinstance(transcript, Final):
+                    # A partial before any answer is just the caller still talking.
+                    continue
+
+                caller_line = await _store_line(
+                    db,
+                    conversation,
+                    speaker="caller",
+                    text=transcript.text,
+                    confidence=transcript.confidence,
+                    language=transcript.language,
+                )
+
+                if not answering:
+                    # A person has the call (a `pass` rule, or a takeover). The agent is
+                    # silent; the caller's words are still recorded.
+                    continue
+
+                task, barge = await _answer(
+                    db, channel, conversation, transcript.text, transport, caller_line, provider
+                )
+                done, _ = await asyncio.wait(
+                    {task, pending}, return_when=asyncio.FIRST_COMPLETED
+                )
+
+                if pending in done and pending.result() is not None:
+                    # The caller spoke while the agent was speaking: barge-in. Stop the
+                    # answer and store only what was said - a stored line nobody heard
+                    # is a transcript lying.
+                    interrupter = pending.result()
+                    pending = asyncio.ensure_future(_next(stream))
+                    barge.set()
+                    result = await task
+                    _log_turn(conversation, result)
+                    if result.text:
+                        await _store_line(db, conversation, speaker="agent", text=result.text)
+                    # A Final interrupter is the next caller turn; a partial is the
+                    # caller still forming one, and the loop reads on for its final.
+                    carried = interrupter if isinstance(interrupter, Final) else None
+                else:
+                    # Either the answer finished on its own, or the caller stopped
+                    # talking (the stream ended) - which is not barge-in, so the answer
+                    # is allowed to complete before the call is closed below.
+                    result = await task
+                    _log_turn(conversation, result)
+                    if result.text:
+                        await _store_line(db, conversation, speaker="agent", text=result.text)
+                    if pending.done() and pending.result() is None:
+                        break
+        finally:
+            if not pending.done():
+                pending.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await pending
+
+        ended_at = dt.datetime.now(dt.UTC)
+        conversation.status = "closed"
+        conversation.ended_at = ended_at.replace(tzinfo=None)
+        call.billable_seconds = max(0, int((ended_at - _aware(started_at)).total_seconds()))
+        await db.commit()
+        logger.info(
+            "call ended",
+            extra={
+                "conversation_id": conversation.id,
+                "billable_seconds": call.billable_seconds,
+            },
+        )
+        return conversation.id
+
+
+async def _next(stream: AsyncIterator[Transcript]) -> Transcript | None:
+    """The next transcript, or None when the caller has hung up."""
+    try:
+        return await stream.__anext__()
+    except StopAsyncIteration:
+        return None
+
+
+def _aware(value: dt.datetime) -> dt.datetime:
+    """A stored naive timestamp as UTC, so a subtraction does not raise."""
+    return value if value.tzinfo is not None else value.replace(tzinfo=dt.UTC)

--- a/tests/test_phone_call.py
+++ b/tests/test_phone_call.py
@@ -1,0 +1,351 @@
+"""Milestone 11, the api/ side — a phone call is a conversation in the same archive.
+
+§B5 decision 6: a call is a conversation on a `phone` channel plus a `calls` row for
+what only a call has. This drives the voice core (`agent/session/turn.py`) through a
+**scripted transport** — no SIP, no LiveKit, no number, no provider key, no cost — and
+asserts the thing the live line will later confirm as roadmap check 6: the call lands
+beside the chats, searchable, with a transcript whose caller lines carry their STT
+confidence and language.
+
+The transport boundary is the transcript, not the audio: the SIP/LiveKit transport
+owns codec↔STT↔TTS and hands this driver a stream of `Partial`/`Final`s and a sink to
+speak into. That is the seam the real transport implements next; here a list of
+scripted transcripts stands in for a caller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agent.providers.llm.base import TextDelta
+from agent.providers.stt.base import Final, Partial, Transcript
+from api.channels import phone
+from api.config import Settings
+from api.main import create_app
+from api.models import (
+    Call,
+    Channel,
+    Conversation,
+    Membership,
+    Message,
+    Notification,
+    Rule,
+    User,
+    Workspace,
+)
+from api.security.password import hash_password
+
+PASSWORD = "a sentence i can actually remember"  # noqa: S105
+KEY_HEX = "aa" * 32
+
+
+@pytest.fixture(autouse=True)
+def configured_key(monkeypatch: pytest.MonkeyPatch):
+    from api.config import get_settings
+    from api.models.encrypted import reset_key_cache
+
+    monkeypatch.setenv("ENCRYPTION_KEY", KEY_HEX)
+    get_settings.cache_clear()
+    reset_key_cache()
+    yield
+    get_settings.cache_clear()
+    reset_key_cache()
+
+
+class ScriptedLLM:
+    """Answers each turn with a fixed line, so a call has predictable transcript text."""
+
+    def __init__(self, *lines: str) -> None:
+        self.lines = list(lines)
+        self.turn = 0
+
+    async def stream(self, messages, tools):
+        line = self.lines[min(self.turn, len(self.lines) - 1)]
+        self.turn += 1
+        for word in line.split():
+            yield TextDelta(text=word + " ")
+
+
+class FakeTTS:
+    def stream(self, text: str) -> AsyncIterator[bytes]:
+        async def gen() -> AsyncIterator[bytes]:
+            for word in text.split():
+                # A real suspension point between chunks, so the caller talking over
+                # the agent (the transport's next transcript) can actually land mid-word.
+                await asyncio.sleep(0.005)
+                yield word.encode()
+
+        return gen()
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.heard: list[bytes] = []
+        self.flushes = 0
+
+    async def write(self, chunk: bytes) -> None:
+        self.heard.append(chunk)
+
+    async def flush(self) -> None:
+        self.flushes += 1
+
+
+class ScriptedTransport:
+    """A caller, as a list of transcripts. `after_speaking` events fire once the agent
+    has produced some audio, so a barge-in can be timed to land mid-answer."""
+
+    def __init__(
+        self,
+        transcripts: list[Transcript],
+        *,
+        llm,
+        from_e164: str | None = "+436761234567",
+        barge_after: int | None = None,
+    ) -> None:
+        self._transcripts = transcripts
+        self.llm = llm
+        self.tts = FakeTTS()
+        self.sink = RecordingSink()
+        self.from_e164 = from_e164
+        self._barge_after = barge_after
+
+    async def transcripts(self) -> AsyncIterator[Transcript]:
+        for index, transcript in enumerate(self._transcripts):
+            # A barge-in transcript waits until the agent is mid-answer, so the race in
+            # the driver is real rather than order-of-scheduling luck.
+            if self._barge_after is not None and index == self._barge_after:
+                while len(self.sink.heard) < 2:  # noqa: ASYNC110 - test spin on sink
+                    await asyncio.sleep(0)
+            yield transcript
+            await asyncio.sleep(0)
+
+
+@pytest.fixture
+async def stage(migrated: AsyncSession, settings: Settings, database_url: str):
+    workspace = Workspace(name="Wagner & Partner")
+    migrated.add(workspace)
+    await migrated.flush()
+    channel = Channel(workspace_id=workspace.id, kind="phone", name="Phone", status="active")
+    migrated.add(channel)
+    user = User(username="mohamed", password_hash=hash_password(PASSWORD))
+    migrated.add(user)
+    await migrated.flush()
+    migrated.add(Membership(user_id=user.id, workspace_id=workspace.id, role="admin"))
+    await migrated.commit()
+
+    app = create_app(settings.model_copy(update={"database_url": database_url}))
+    async with app.router.lifespan_context(app):
+        http = AsyncClient(
+            transport=ASGITransport(app=app, raise_app_exceptions=False),
+            base_url="http://localhost",
+        )
+        assert (
+            await http.post(
+                "/api/auth/login", json={"username": "mohamed", "password": PASSWORD}
+            )
+        ).status_code == 200
+        try:
+            yield http, app, channel.id, workspace.id, migrated
+        finally:
+            await http.aclose()
+
+
+async def _messages(db: AsyncSession, conversation_id: int) -> list[Message]:
+    db.expire_all()
+    rows = (
+        await db.execute(
+            select(Message)
+            .where(Message.conversation_id == conversation_id)
+            .order_by(Message.ts_ms, Message.id)
+        )
+    ).scalars()
+    return list(rows)
+
+
+# --- The full loop, stored in the same archive -----------------------------------
+
+
+async def test_a_call_becomes_a_conversation_with_a_calls_row_and_a_transcript(stage) -> None:
+    _http, app, channel_id, workspace_id, db = stage
+    transport = ScriptedTransport(
+        [
+            Final(text="Are you open on Saturday?", confidence=0.93, language="de"),
+            Final(text="Thank you, goodbye.", confidence=0.88, language="de"),
+        ],
+        llm=ScriptedLLM("Yes, we are open until noon.", "You are welcome. Goodbye."),
+    )
+
+    conversation_id = await phone.run_call(
+        app.state.sessionmaker,
+        channel_id=channel_id,
+        transport=transport,
+        provider=transport.llm,
+    )
+
+    # A conversation on the phone channel, closed when the call ended.
+    convo = await db.scalar(select(Conversation).where(Conversation.id == conversation_id))
+    assert convo.workspace_id == workspace_id
+    assert convo.direction == "inbound"
+    assert convo.status == "closed"
+    assert convo.ended_at is not None
+
+    # The calls row - what only a call has (§B5 decision 6).
+    call = await db.scalar(select(Call).where(Call.conversation_id == conversation_id))
+    assert call is not None
+    assert call.from_e164 == "+436761234567"
+    assert call.billable_seconds is not None and call.billable_seconds >= 0
+
+    # The transcript: caller and agent, in order, caller lines carrying stt fields.
+    rows = await _messages(db, conversation_id)
+    assert [(r.speaker, r.text) for r in rows] == [
+        ("caller", "Are you open on Saturday?"),
+        ("agent", "Yes, we are open until noon."),
+        ("caller", "Thank you, goodbye."),
+        ("agent", "You are welcome. Goodbye."),
+    ]
+    caller_lines = [r for r in rows if r.speaker == "caller"]
+    assert caller_lines[0].stt_confidence == 0.93
+    assert caller_lines[0].language == "de"
+    # An agent line is spoken, not heard: no STT fields.
+    agent_lines = [r for r in rows if r.speaker == "agent"]
+    assert agent_lines[0].stt_confidence is None
+
+
+async def test_the_call_is_findable_in_the_same_search_as_a_chat(stage) -> None:
+    http, app, channel_id, _, _db = stage
+    transport = ScriptedTransport(
+        [Final(text="Do you deliver to Salzburg?", confidence=0.9, language="de")],
+        llm=ScriptedLLM("Yes, we deliver across Austria."),
+    )
+    await phone.run_call(
+        app.state.sessionmaker,
+        channel_id=channel_id,
+        transport=transport,
+        provider=transport.llm,
+    )
+
+    # Search is the `q` filter on the same conversations list every channel's chats
+    # appear in - the call is not a second archive.
+    found = await http.get("/api/conversations", params={"q": "Salzburg"})
+    assert found.status_code == 200, found.text
+    threads = found.json()["threads"]
+    assert len(threads) == 1
+    assert threads[0]["channel"] == "phone"
+    assert threads[0]["is_call"] is True
+    assert threads[0]["who"] == "+436761234567"
+
+
+# --- Partials are not stored -----------------------------------------------------
+
+
+async def test_a_partial_never_becomes_a_transcript_line(stage) -> None:
+    _http, app, channel_id, _, db = stage
+    transport = ScriptedTransport(
+        [
+            Partial(text="Are you"),
+            Partial(text="Are you open"),
+            Final(text="Are you open today?", confidence=0.91, language="en"),
+        ],
+        llm=ScriptedLLM("Yes, until six."),
+    )
+    conversation_id = await phone.run_call(
+        app.state.sessionmaker,
+        channel_id=channel_id,
+        transport=transport,
+        provider=transport.llm,
+    )
+    rows = await _messages(db, conversation_id)
+    assert [(r.speaker, r.text) for r in rows] == [
+        ("caller", "Are you open today?"),
+        ("agent", "Yes, until six."),
+    ]
+
+
+# --- Barge-in truncates the stored agent line ------------------------------------
+
+
+async def test_barge_in_stops_the_answer_at_a_sentence_it_had_not_begun(stage) -> None:
+    """The caller cuts in mid-answer. A phrase already begun was heard and is kept; a
+    sentence the answer had not reached is never stored - that line would be the archive
+    lying. The cut is at phrase granularity, not mid-word: audio is what was heard, and
+    there is no honest way to map half a spoken phrase back to text.
+    """
+    _http, app, channel_id, _, db = stage
+    transport = ScriptedTransport(
+        [
+            Final(text="Tell me everything.", confidence=0.9, language="en"),
+            # Lands once the agent is a couple of chunks into its multi-sentence answer.
+            Final(text="Actually, never mind.", confidence=0.9, language="en"),
+        ],
+        llm=ScriptedLLM(
+            "First point here. Second point here. Third point here. Final point here. ",
+            "No problem at all.",
+        ),
+        barge_after=1,
+    )
+    conversation_id = await phone.run_call(
+        app.state.sessionmaker,
+        channel_id=channel_id,
+        transport=transport,
+        provider=transport.llm,
+    )
+    rows = await _messages(db, conversation_id)
+    # Both caller turns landed, each answered.
+    assert [r.speaker for r in rows].count("caller") == 2
+    first_agent = next(r for r in rows if r.speaker == "agent")
+    # A sentence the answer never reached is absent; one it had begun is present.
+    assert "First point here." in first_agent.text
+    assert "Final point here." not in first_agent.text
+
+
+# --- Routing: block and pass on the caller ID ------------------------------------
+
+
+async def test_a_blocked_number_is_not_answered(stage) -> None:
+    _http, app, channel_id, workspace_id, db = stage
+    db.add(Rule(workspace_id=workspace_id, pattern="+43900*", action="block"))
+    await db.commit()
+    transport = ScriptedTransport(
+        [Final(text="Let me in.", confidence=0.9, language="en")],
+        llm=ScriptedLLM("never reached"),
+        from_e164="+43900555",
+    )
+    conversation_id = await phone.run_call(
+        app.state.sessionmaker,
+        channel_id=channel_id,
+        transport=transport,
+        provider=transport.llm,
+    )
+    assert conversation_id is None
+    # Nothing stored, nothing spoken.
+    assert await db.scalar(select(Conversation)) is None
+    assert transport.sink.heard == []
+
+
+async def test_a_pass_number_reaches_a_person_and_the_agent_stays_silent(stage) -> None:
+    _http, app, channel_id, workspace_id, db = stage
+    db.add(Rule(workspace_id=workspace_id, pattern="+436761234567", action="pass", note="VIP"))
+    await db.commit()
+    transport = ScriptedTransport(
+        [Final(text="It is the boss.", confidence=0.9, language="en")],
+        llm=ScriptedLLM("should not be spoken"),
+    )
+    conversation_id = await phone.run_call(
+        app.state.sessionmaker,
+        channel_id=channel_id,
+        transport=transport,
+        provider=transport.llm,
+    )
+    convo = await db.scalar(select(Conversation).where(Conversation.id == conversation_id))
+    assert convo.handling == "human"
+    # The caller's words are recorded; the agent said nothing.
+    rows = await _messages(db, conversation_id)
+    assert [r.speaker for r in rows] == ["caller"]
+    tray = (await db.execute(select(Notification))).scalars().all()
+    assert [t.message_key for t in tray] == ["routed_to_person"]


### PR DESCRIPTION
## Milestone 11 — the api/ side of a call (SPEC §B5 decision 6)

The biggest slice of the phone that is buildable **without the live line**: a call becomes a conversation on a `phone` channel plus a `calls` row for what only a call has, stored where `/api/conversations` finds it beside every chat — roadmap check 6, *same archive*.

### The driver — `api/channels/phone.py`
`run_call(sessionmaker, channel_id, transport)` consumes a stream of transcripts, answers each with the voice core from #144 (`agent/session/turn.py`), and stores the whole call: a conversation, a `calls` row (`from_e164`, `billable_seconds`), and a transcript. It closes the conversation and finalises the call when the caller hangs up (the transcript stream ends).

**The transport boundary is the transcript, not the audio.** A `CallTransport` hands the driver `Partial`/`Final`s, a `TTSProvider` and an `AudioSink`. That seam is exactly what keeps this testable with a **scripted caller** — no SIP, no LiveKit, no number, no provider key, no cost — and it is where the real transport plugs in next. It is also what §B10's self-hosted-media requirement rests on: the transport is swappable because nothing above it knows which one it is.

**Turn-taking is a race the driver runs.** While the agent speaks, it keeps reading the transcript stream; a new transcript arriving mid-answer is barge-in, and it stops the answer **at a phrase it had not begun** — a stored line nobody heard would be the archive lying, the rule every push channel already holds. (The cut is at phrase granularity, not mid-word: audio is what was heard, and there is no honest way to map half a spoken phrase back to text.) The end-of-input case is *not* barge-in — the answer completes before the call closes.

**Routing runs first, on the caller ID** — Milestone 4's phone half, the reason the engine matches on identities. A blocked number is never answered and leaves no conversation; a `pass` number reaches a person with the agent silent and a `routed_to_person` notice.

Caller `Final`s carry `stt_confidence` and `language` into the transcript (§B5); agent lines do not, which is itself the signal that a line was spoken *to* us rather than *by* us.

### Proven on a scripted transport
`tests/test_phone_call.py` (6 tests): the full loop stored as conversation + calls row + transcript with the STT fields on caller lines; the call findable in the same `/api/conversations` search as a chat (`channel: phone`, `is_call: true`); a `Partial` never becoming a transcript line; barge-in dropping a sentence the answer never reached while keeping one it had begun; a blocked number not answered (nothing stored, nothing spoken); a `pass` number reaching a person with the agent silent.

### Deliberately not here
The **LiveKit/SIP transport** that drives this (the `AudioSink` and the audio-in stream, the standalone agent process joining a room) is the next slice, gated on a LiveKit account and a bought number. The **Deepgram/ElevenLabs** implementations behind the STT/TTS interfaces need real keys. And the **live line itself** — buy the number, point it at the SIP endpoint, confirm arrival in the provider console *before any more code* (Rule 2) — is the human step no code can advance. So: **no phone app registered and no settings** — nothing runs a call yet, and a control with no backend is not drawn. `agent/` still never imports `api/`. Full suite green on SQLite and PostgreSQL; the roadmap marker stays put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)