### PR TITLE
Deepgram and ElevenLabs, behind the voice interfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,9 +78,21 @@ RTP_PORT_MAX=20000
 SIP_CODEC=PCMU
 
 # ---------------------------------------------------------------------------
-# Speech to text
+# Speech to text — Deepgram, streaming (Milestone 11, §B3)
+#
+# A key alone is enough: the model and language have working defaults. Like the
+# model above, this is the installer's / standalone path; §B9.2 puts a key entered
+# from the screen in an encrypted column, and that wins over this file.
 # ---------------------------------------------------------------------------
 DEEPGRAM_API_KEY=
+
+# The streaming model. `nova-2` is the current default; a call needs the low-latency
+# one, not the batch/quality tiers.
+DEEPGRAM_MODEL=nova-2
+
+# Where Deepgram's streaming socket lives. Nobody changes this in production; tests
+# point it at a stand-in.
+DEEPGRAM_BASE_URL=wss://api.deepgram.com
 
 # Language of the calls. Austrian German is the primary target; test with real
 # names and addresses, which is where STT accuracy actually breaks down.
@@ -115,10 +127,26 @@ LLM_API_KEY=
 LLM_BASE_URL=https://api.openai.com/v1
 
 # ---------------------------------------------------------------------------
-# Text to speech
+# Text to speech — ElevenLabs, streaming (Milestone 11, §B3)
+#
+# Both the key and a voice are required: ElevenLabs has no default voice, and a call
+# with no voice cannot speak. Same §B9.2 story as the others - the screen's encrypted
+# value wins over this file.
 # ---------------------------------------------------------------------------
 ELEVENLABS_API_KEY=
 ELEVENLABS_VOICE_ID=
+
+# The synthesis model. `eleven_turbo_v2_5` is the low-latency one Rule 3's budget
+# needs; the quality-first models are too slow for a live call.
+ELEVENLABS_MODEL_ID=eleven_turbo_v2_5
+
+# The audio codec streamed back. `ulaw_8000` is G.711 μ-law at 8 kHz - what a SIP call
+# carries (SIP_CODEC above), so the transport forwards it with no transcode on the
+# media path.
+ELEVENLABS_OUTPUT_FORMAT=ulaw_8000
+
+# Where ElevenLabs lives. Nobody changes this in production; tests point it elsewhere.
+ELEVENLABS_BASE_URL=https://api.elevenlabs.io
 
 # ---------------------------------------------------------------------------
 # Agent behaviour

--- a/agent/README.md
+++ b/agent/README.md
@@ -49,12 +49,23 @@ missing interfaces (partials and finals in, audio chunks out, `cancel()` mandato
 and `session/turn.py` is the turn-taker that speaks a streamed reply through them and
 stops the instant the caller cuts in - the barge-in that Rule 3 makes non-optional,
 with the end-of-speech-to-first-audio latency Rule 4 logs. All of it runs on fakes in
-`tests/test_voice_turn.py`; no provider, no SIP, no key. What is still to come, and is
-blocked on a bought number and real provider keys: the Deepgram/ElevenLabs
-implementations, the LiveKit/SIP transport that feeds audio in and plays it out, and
-the `api/` side that stores a call beside every other conversation. `routing/` is a
-stub - the rules engine itself lives at `api/routing.py` (Milestone 4), which the phone
-will call once caller ID is settled on a live line.
+`tests/test_voice_turn.py`; no provider, no SIP, no key.
+
+The two concrete providers §B3 names for v1 are in place behind those interfaces:
+`providers/stt/deepgram.py` (Deepgram's streaming WebSocket — interims as `Partial`s,
+`is_final` as `Final`s, μ-law 8 kHz to match a SIP call) and `providers/tts/eleven
+labs.py` (ElevenLabs' streaming endpoint, `ulaw_8000` output, cancellation by closing
+the response). Both are exercised against stand-ins in `tests/test_voice_providers.py`
+— a WebSocket server for Deepgram, an httpx `MockTransport` for ElevenLabs — so no key
+and no cost. `config.py` reads their env (`DEEPGRAM_*`, `ELEVENLABS_*`) the same way it
+reads the model's, and `configured_stt()`/`configured_tts()` build them.
+
+What is still to come, blocked on a bought number and a LiveKit account: the LiveKit/
+SIP transport that feeds the call's audio into `DeepgramSTT` and plays `ElevenLabsTTS`
+out — the `CallTransport` `api/channels/phone.py` already defined. The `api/` side that
+stores a call in the same archive is done (`phone.run_call`). `routing/` is a stub -
+the rules engine lives at `api/routing.py` (Milestone 4), which the phone already calls
+on the caller ID.
 
 Configuration comes from the environment, in `config.py`. That file exists rather than
 importing `api.config` because this package never imports from `api/` - at Milestone 11

--- a/agent/config.py
+++ b/agent/config.py
@@ -150,3 +150,93 @@ def llm_settings() -> LlmSettings | None:
     the owner saved over what an installer wrote once - see §B9.2.
     """
     return settings_from(**environment_values(), names=ENVIRONMENT_NAMES)
+
+
+# --- The voice providers - Milestone 11, §B3 -------------------------------------
+#
+# STT and TTS join the model at the phone, and they are configured the same way and for
+# the same reason: the standalone agent process has no settings screen, so the
+# environment describes them, and `None` means "not configured" rather than a failure.
+# The real key lives encrypted in the database once a dashboard exists (§B9.2); these
+# read the installer's/standalone path.
+
+# Deepgram's streaming endpoint speaks over WebSocket, so the base is `wss://`. The
+# model and language are the two knobs Rule 4 cares about - `nova-2` is the current
+# streaming model, and German is the target the accuracy bar is set against.
+DEFAULT_STT_BASE_URL = "wss://api.deepgram.com"
+DEFAULT_STT_MODEL = "nova-2"
+
+# ElevenLabs, and the two choices a phone forces. `eleven_turbo_v2_5` is the low-latency
+# model - Rule 3's budget does not survive the quality-first one - and `ulaw_8000` is
+# G.711 μ-law at 8 kHz, which is what a SIP call carries (SIP_CODEC=PCMU); asking for
+# mp3 would mean transcoding on the media thread, which Rule 3 forbids.
+DEFAULT_TTS_BASE_URL = "https://api.elevenlabs.io"
+DEFAULT_TTS_MODEL = "eleven_turbo_v2_5"
+DEFAULT_TTS_OUTPUT_FORMAT = "ulaw_8000"
+
+
+@dataclass(frozen=True)
+class SttSettings:
+    """Which speech-to-text service listens, and in what language."""
+
+    api_key: str
+    model: str
+    language: str
+    base_url: str
+
+
+@dataclass(frozen=True)
+class TtsSettings:
+    """Which text-to-speech service speaks, in which voice, at which codec."""
+
+    api_key: str
+    voice_id: str
+    model: str
+    output_format: str
+    base_url: str
+
+
+@lru_cache(maxsize=1)
+def stt_settings() -> SttSettings | None:
+    """The speech-to-text the environment describes, or `None`.
+
+    A key alone is enough: model and language have working defaults, so an installer
+    who set `DEEPGRAM_API_KEY` gets German nova-2 without four more variables. No key is
+    the honest "no STT", which the phone reports rather than failing a call.
+    """
+    key = _clean("DEEPGRAM_API_KEY")
+    if not key:
+        return None
+    return SttSettings(
+        api_key=key,
+        model=_clean("DEEPGRAM_MODEL") or DEFAULT_STT_MODEL,
+        language=_clean("STT_LANGUAGE") or "de",
+        base_url=_clean("DEEPGRAM_BASE_URL").rstrip("/") or DEFAULT_STT_BASE_URL,
+    )
+
+
+@lru_cache(maxsize=1)
+def tts_settings() -> TtsSettings | None:
+    """The text-to-speech the environment describes, or `None`.
+
+    Both the key and a voice are required, because ElevenLabs has no default voice and a
+    call with no voice cannot speak - unlike the language, which STT can default. A key
+    without a voice is the half-configuration `settings_from` refuses for the model, and
+    it raises here for the same reason: a silent fallback would be found on a live call.
+    """
+    key = _clean("ELEVENLABS_API_KEY")
+    if not key:
+        return None
+    voice = _clean("ELEVENLABS_VOICE_ID")
+    if not voice:
+        raise ConfigurationError(
+            "ELEVENLABS_API_KEY is set but ELEVENLABS_VOICE_ID is empty. Set a voice, "
+            "or clear the key to run without a voice."
+        )
+    return TtsSettings(
+        api_key=key,
+        voice_id=voice,
+        model=_clean("ELEVENLABS_MODEL_ID") or DEFAULT_TTS_MODEL,
+        output_format=_clean("ELEVENLABS_OUTPUT_FORMAT") or DEFAULT_TTS_OUTPUT_FORMAT,
+        base_url=_clean("ELEVENLABS_BASE_URL").rstrip("/") or DEFAULT_TTS_BASE_URL,
+    )

--- a/agent/providers/stt/__init__.py
+++ b/agent/providers/stt/__init__.py
@@ -2,6 +2,27 @@
 
 from __future__ import annotations
 
+from agent.config import SttSettings, stt_settings
 from agent.providers.stt.base import Final, Partial, STTProvider, Transcript
+from agent.providers.stt.deepgram import DeepgramSTT
 
-__all__ = ["Final", "Partial", "STTProvider", "Transcript"]
+__all__ = [
+    "DeepgramSTT",
+    "Final",
+    "Partial",
+    "STTProvider",
+    "Transcript",
+    "configured_stt",
+    "stt_for",
+]
+
+
+def stt_for(settings: SttSettings) -> STTProvider:
+    """The implementation for a configuration. One service today, a dict the day of two."""
+    return DeepgramSTT(settings)
+
+
+def configured_stt() -> STTProvider | None:
+    """What the environment says should listen, or `None` when nothing is configured."""
+    settings = stt_settings()
+    return None if settings is None else stt_for(settings)

--- a/agent/providers/stt/deepgram.py
+++ b/agent/providers/stt/deepgram.py
@@ -1,0 +1,138 @@
+"""Deepgram, behind the STT interface — §B3's v1 speech-to-text.
+
+Deepgram's streaming API is a WebSocket: audio frames go up, JSON transcript messages
+come down, and — crucially for Rule 3 — interim results come down *before* the caller
+has stopped talking. Those interims are the `Partial`s the turn-taker uses to start
+thinking during endpointing, the largest slice of the 800 ms budget; the `is_final`
+messages are the `Final`s that become transcript lines.
+
+**Two directions at once, joined here.** A sender task pumps the caller's audio up; the
+generator reads messages down and yields transcripts. When the audio stream ends (the
+caller hung up, or the turn's audio is done), it sends Deepgram's `CloseStream` so the
+service flushes any last final rather than dropping a half-heard phrase, then drains the
+remaining messages until the socket closes.
+
+**The connection is a G.711 μ-law telephone call.** `encoding=mulaw&sample_rate=8000`
+matches SIP_CODEC=PCMU, so the transport forwards the call's own frames with no
+transcode on the media path (Rule 0). `interim_results=true` is what makes the partials
+arrive; `language` is set rather than detected, because Rule 4's accuracy bar is a
+German one and asking Deepgram to guess the language of a two-word answer is how it
+guesses wrong.
+
+**Cancellation is the generator's close.** Stopping consumption unwinds the `async with`
+connection and cancels the sender; the socket closes, and Deepgram stops billing for a
+stream nobody is reading. The key rides in the `Authorization` header and is never
+logged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from collections.abc import AsyncIterator
+from urllib.parse import urlencode
+
+import websockets
+
+from agent.config import SttSettings
+from agent.providers.stt.base import Final, Partial, Transcript
+
+logger = logging.getLogger("agent.stt")
+
+# What the transport carries: G.711 μ-law, 8 kHz, one channel. Punctuation on, because a
+# transcript line without it reads worse and Deepgram's costs nothing.
+_AUDIO_PARAMS = {
+    "encoding": "mulaw",
+    "sample_rate": "8000",
+    "channels": "1",
+    "interim_results": "true",
+    "punctuate": "true",
+}
+
+
+class STTError(RuntimeError):
+    """The Deepgram socket failed in a way a retry would not fix."""
+
+
+class DeepgramSTT:
+    """Streams transcripts from a μ-law call. Satisfies `STTProvider` structurally."""
+
+    def __init__(self, settings: SttSettings) -> None:
+        self._settings = settings
+
+    def _url(self) -> str:
+        params = {
+            **_AUDIO_PARAMS,
+            "model": self._settings.model,
+            "language": self._settings.language,
+        }
+        return f"{self._settings.base_url}/v1/listen?{urlencode(params)}"
+
+    def stream(self, audio: AsyncIterator[bytes]) -> AsyncIterator[Transcript]:
+        settings = self._settings
+        url = self._url()
+
+        async def gen() -> AsyncIterator[Transcript]:
+            headers = {"Authorization": f"Token {settings.api_key}"}
+            async with websockets.connect(url, additional_headers=headers) as ws:
+                sender = asyncio.ensure_future(_pump(ws, audio))
+                try:
+                    async for raw in ws:
+                        transcript = _read(raw, settings.language)
+                        if transcript is not None:
+                            yield transcript
+                finally:
+                    sender.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await sender
+
+        return gen()
+
+
+async def _pump(ws: websockets.ClientConnection, audio: AsyncIterator[bytes]) -> None:
+    """Send the caller's audio up, then ask Deepgram to flush.
+
+    `CloseStream` rather than just closing the socket: it tells Deepgram to finalise
+    whatever it is mid-way through recognising, so the caller's last phrase becomes a
+    `Final` instead of being lost with the connection.
+    """
+    try:
+        async for chunk in audio:
+            if chunk:
+                await ws.send(chunk)
+    except websockets.ConnectionClosed:
+        return
+    with contextlib.suppress(websockets.ConnectionClosed):
+        await ws.send(json.dumps({"type": "CloseStream"}))
+
+
+def _read(raw: str | bytes, fallback_language: str) -> Transcript | None:
+    """One Deepgram message into a `Partial`, a `Final`, or nothing.
+
+    Metadata, `UtteranceEnd` and empty transcripts are the "nothing": they are real
+    messages, but not something a caller said, and a transcript line for them would be
+    the archive inventing speech.
+    """
+    try:
+        message = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if message.get("type") != "Results":
+        return None
+    alternatives = (message.get("channel") or {}).get("alternatives") or []
+    if not alternatives:
+        return None
+    text = str(alternatives[0].get("transcript") or "").strip()
+    if not text:
+        return None
+    if message.get("is_final"):
+        confidence = alternatives[0].get("confidence")
+        language = (message.get("channel") or {}).get("detected_language") or fallback_language
+        return Final(
+            text=text,
+            confidence=float(confidence) if isinstance(confidence, int | float) else None,
+            language=language,
+        )
+    return Partial(text=text)

--- a/agent/providers/tts/__init__.py
+++ b/agent/providers/tts/__init__.py
@@ -2,6 +2,24 @@
 
 from __future__ import annotations
 
+from agent.config import TtsSettings, tts_settings
 from agent.providers.tts.base import TTSProvider
+from agent.providers.tts.elevenlabs import ElevenLabsTTS
 
-__all__ = ["TTSProvider"]
+__all__ = [
+    "ElevenLabsTTS",
+    "TTSProvider",
+    "configured_tts",
+    "tts_for",
+]
+
+
+def tts_for(settings: TtsSettings) -> TTSProvider:
+    """The implementation for a configuration. One service today, a dict the day of two."""
+    return ElevenLabsTTS(settings)
+
+
+def configured_tts() -> TTSProvider | None:
+    """What the environment says should speak, or `None` when nothing is configured."""
+    settings = tts_settings()
+    return None if settings is None else tts_for(settings)

--- a/agent/providers/tts/elevenlabs.py
+++ b/agent/providers/tts/elevenlabs.py
@@ -1,0 +1,100 @@
+"""ElevenLabs, behind the TTS interface — §B3's v1 text-to-speech.
+
+The streaming endpoint, not the batch one: `POST /v1/text-to-speech/{voice}/stream`
+returns audio in chunks as it synthesises, which is what Rule 3 needs — the first
+chunk leaves before the last is made, so the first sentence speaks while the rest
+generates. The batch endpoint would return one blob at the end, reintroducing exactly
+the silence the streaming design exists to remove.
+
+**The output format is a telephony codec, not mp3.** `ulaw_8000` is G.711 μ-law at
+8 kHz, which is what a SIP call already carries (SIP_CODEC=PCMU). Asking for mp3 and
+transcoding to μ-law on the way to the caller would put a CPU-bound decode on the media
+path, which Rule 0's "nothing on the call path may block" forbids. The transport hands
+these bytes straight to the room.
+
+**Cancellation is the generator's own close.** The `async with client.stream(...)`
+lives inside the generator, so when `agent.session.speak` stops consuming on barge-in,
+`GeneratorExit` unwinds the `async with`, the HTTP response closes, and ElevenLabs
+stops synthesising — which stops the bill, not just the playback. That is why the
+request is opened inside the generator and streamed, never awaited to completion first.
+
+The key rides in `xi-api-key` and is never logged: it is set on the client here and the
+log lines below name the voice and the byte count, never the header.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+
+import httpx
+
+from agent.config import TtsSettings
+
+logger = logging.getLogger("agent.tts")
+
+# Tight, because this is on the call path. A synthesiser that has not sent its first
+# chunk in this long is one whose silence the caller is already hearing; the transport
+# would rather fail the turn than hold the line.
+_CONNECT_TIMEOUT = 5.0
+_READ_TIMEOUT = 15.0
+
+# ElevenLabs' documented default voice settings, made explicit so a change is a change
+# here rather than a drift in their defaults. Stability against expressiveness is a
+# per-installation choice that belongs in settings the day somebody asks for it.
+_VOICE_SETTINGS = {
+    "stability": 0.5,
+    "similarity_boost": 0.75,
+    "style": 0.0,
+    "use_speaker_boost": True,
+}
+
+
+class TTSError(RuntimeError):
+    """ElevenLabs refused. Carries the status and the start of its body, never the key."""
+
+
+class ElevenLabsTTS:
+    """Streams μ-law audio for the phone. Satisfies `TTSProvider` structurally.
+
+    `transport` is injectable so a test can stand in for ElevenLabs with an
+    `httpx.MockTransport`; production leaves it None and a real client is built.
+    """
+
+    def __init__(
+        self, settings: TtsSettings, *, transport: httpx.BaseTransport | None = None
+    ) -> None:
+        self._settings = settings
+        self._transport = transport
+
+    def stream(self, text: str) -> AsyncIterator[bytes]:
+        settings = self._settings
+        transport = self._transport
+
+        async def gen() -> AsyncIterator[bytes]:
+            url = (
+                f"{settings.base_url}/v1/text-to-speech/{settings.voice_id}/stream"
+                f"?output_format={settings.output_format}"
+            )
+            headers = {"xi-api-key": settings.api_key, "accept": "audio/basic"}
+            body = {
+                "text": text,
+                "model_id": settings.model,
+                "voice_settings": _VOICE_SETTINGS,
+            }
+            timeout = httpx.Timeout(_READ_TIMEOUT, connect=_CONNECT_TIMEOUT)
+            client = httpx.AsyncClient(timeout=timeout, transport=transport)
+            try:
+                async with client.stream("POST", url, headers=headers, json=body) as response:
+                    if response.status_code >= 300:
+                        detail = (await response.aread())[:200].decode("utf-8", "replace")
+                        raise TTSError(f"ElevenLabs answered {response.status_code}: {detail}")
+                    async for chunk in response.aiter_bytes():
+                        if chunk:
+                            yield chunk
+            finally:
+                # Closes the connection whether the stream finished or barge-in unwound
+                # it, which is what stops synthesis at the far end.
+                await client.aclose()
+
+        return gen()

--- a/tests/test_voice_providers.py
+++ b/tests/test_voice_providers.py
@@ -1,0 +1,222 @@
+"""Milestone 11 — Deepgram and ElevenLabs, against stand-ins for the real services.
+
+§B3's v1 pair, behind the interfaces #144 defined. Neither test needs a real key or a
+cent: ElevenLabs is an `httpx.MockTransport` that streams bytes back, and Deepgram is a
+real local WebSocket server speaking its JSON protocol — the same "fake the platform,
+not the code" approach every channel's tests use. What is under test is the wire
+handling: that partials and finals come out in order with their confidence and
+language, that audio streams chunk by chunk, that a refusal is raised not swallowed,
+and that closing the stream stops the far end (cancellation).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import websockets
+
+from agent.config import SttSettings, TtsSettings
+from agent.providers.stt.base import Final, Partial
+from agent.providers.stt.deepgram import DeepgramSTT
+from agent.providers.tts.elevenlabs import ElevenLabsTTS, TTSError
+
+
+async def _audio(*chunks: bytes) -> AsyncIterator[bytes]:
+    for chunk in chunks:
+        yield chunk
+        await asyncio.sleep(0)
+
+
+# --- ElevenLabs TTS, against an httpx MockTransport ------------------------------
+
+
+def _tts(handler, **over) -> ElevenLabsTTS:
+    settings = TtsSettings(
+        api_key="dev-fake-key",
+        voice_id="voice-1",
+        model="eleven_turbo_v2_5",
+        output_format="ulaw_8000",
+        base_url="https://tts.test",
+        **over,
+    )
+    return ElevenLabsTTS(settings, transport=httpx.MockTransport(handler))
+
+
+async def test_tts_streams_audio_chunks_and_sends_the_right_request() -> None:
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["key"] = request.headers.get("xi-api-key")
+        seen["body"] = json.loads(request.content)
+        # Three chunks of "audio", to prove streaming rather than one blob.
+        return httpx.Response(200, stream=_ByteStream([b"aud", b"io", b"!!"]))
+
+    tts = _tts(handler)
+    chunks = [chunk async for chunk in tts.stream("Guten Tag")]
+
+    assert b"".join(chunks) == b"audio!!"
+    assert "/v1/text-to-speech/voice-1/stream" in seen["url"]
+    assert "output_format=ulaw_8000" in seen["url"]
+    assert seen["key"] == "dev-fake-key"
+    assert seen["body"]["text"] == "Guten Tag"
+    assert seen["body"]["model_id"] == "eleven_turbo_v2_5"
+
+
+async def test_tts_raises_on_a_refusal_rather_than_yielding_silence() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "invalid key"})
+
+    tts = _tts(handler)
+    with pytest.raises(TTSError) as caught:
+        async for _ in tts.stream("hallo"):
+            pass
+    assert "401" in str(caught.value)
+
+
+async def test_tts_closing_the_stream_early_closes_the_response() -> None:
+    """Barge-in: the consumer stops after the first chunk, and the response must close
+    so ElevenLabs stops synthesising - the far-end stop the whole design rests on."""
+    closed = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=_ByteStream([b"one", b"two", b"three"], closed))
+
+    tts = _tts(handler)
+    gen = tts.stream("a long answer")
+    first = await gen.__anext__()
+    assert first == b"one"
+    await gen.aclose()
+    # The generator's finally closed the client, which closed the stream.
+    assert closed.is_set()
+
+
+class _ByteStream(httpx.AsyncByteStream):
+    """A streaming body that yields its chunks one at a time and flags when closed."""
+
+    def __init__(self, chunks: list[bytes], closed: asyncio.Event | None = None) -> None:
+        self._chunks = chunks
+        self._closed = closed
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+            await asyncio.sleep(0)
+
+    async def aclose(self) -> None:
+        if self._closed is not None:
+            self._closed.set()
+
+
+# --- Deepgram STT, against a local WebSocket server -----------------------------
+
+
+class FakeDeepgram:
+    """A WebSocket server that speaks Deepgram's transcript protocol.
+
+    It receives audio frames, and on `CloseStream` (or once enough audio has arrived)
+    sends a scripted sequence of interim and final results, then closes - the shape a
+    real streaming recognition has, reduced to what the client must parse.
+    """
+
+    def __init__(self, script: list[dict]) -> None:
+        self._script = script
+        self.received: list[bytes] = []
+        self.closed_by_client = False
+
+    async def _handler(self, ws) -> None:
+        async for message in ws:
+            if isinstance(message, bytes):
+                self.received.append(message)
+                continue
+            data = json.loads(message)
+            if data.get("type") == "CloseStream":
+                self.closed_by_client = True
+                break
+        for result in self._script:
+            await ws.send(json.dumps(result))
+        await ws.close()
+
+    async def __aenter__(self) -> str:
+        self._server = await websockets.serve(self._handler, "127.0.0.1", 0)
+        port = self._server.sockets[0].getsockname()[1]
+        return f"ws://127.0.0.1:{port}"
+
+    async def __aexit__(self, *exc) -> None:
+        self._server.close()
+        await self._server.wait_closed()
+
+
+def _results(transcript: str, *, is_final: bool, confidence: float = 0.9) -> dict:
+    return {
+        "type": "Results",
+        "is_final": is_final,
+        "channel": {"alternatives": [{"transcript": transcript, "confidence": confidence}]},
+    }
+
+
+def _stt(base_url: str) -> DeepgramSTT:
+    return DeepgramSTT(
+        SttSettings(api_key="dev-fake-key", model="nova-2", language="de", base_url=base_url)
+    )
+
+
+async def test_stt_yields_partials_then_a_final_with_confidence_and_language() -> None:
+    script = [
+        _results("Guten", is_final=False),
+        _results("Guten Tag", is_final=False),
+        _results("Guten Tag.", is_final=True, confidence=0.95),
+        {"type": "Metadata", "duration": 1.2},  # not a transcript; must be ignored
+    ]
+    async with FakeDeepgram(script) as url:
+        stt = _stt(url)
+        out = [t async for t in stt.stream(_audio(b"\x00\x01", b"\x02\x03"))]
+
+    assert [type(t) for t in out] == [Partial, Partial, Final]
+    assert out[0].text == "Guten"
+    assert out[-1].text == "Guten Tag."
+    assert out[-1].confidence == 0.95
+    assert out[-1].language == "de"
+
+
+async def test_stt_sends_the_audio_and_then_closes_the_stream() -> None:
+    fake = FakeDeepgram([_results("Ja.", is_final=True)])
+    async with fake as url:
+        stt = _stt(url)
+        out = [t async for t in stt.stream(_audio(b"aaaa", b"bbbb"))]
+
+    assert [t.text for t in out] == ["Ja."]
+    # The caller's audio arrived, and the client asked Deepgram to flush.
+    assert fake.received == [b"aaaa", b"bbbb"]
+    assert fake.closed_by_client is True
+
+
+async def test_stt_an_empty_transcript_is_not_a_line() -> None:
+    """A silent frame gets an empty transcript from Deepgram; storing it would be the
+    archive inventing a line nobody said."""
+    async with FakeDeepgram([_results("", is_final=True)]) as url:
+        stt = _stt(url)
+        out = [t async for t in stt.stream(_audio(b"\x00\x00"))]
+    assert out == []
+
+
+async def test_stt_the_key_travels_as_an_authorization_token() -> None:
+    seen: dict = {}
+
+    async def handler(ws) -> None:
+        seen["auth"] = ws.request.headers.get("Authorization")
+        await ws.close()
+
+    server = await websockets.serve(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        stt = _stt(f"ws://127.0.0.1:{port}")
+        _ = [t async for t in stt.stream(_audio(b"x"))]
+    finally:
+        server.close()
+        await server.wait_closed()
+    assert seen["auth"] == "Token dev-fake-key"

--- a/tests/test_voice_settings.py
+++ b/tests/test_voice_settings.py
@@ -1,0 +1,83 @@
+"""The environment describing the voice providers — Milestone 11, §B3/§B9.2.
+
+The same rules the model's settings hold: no key is the supported "not configured"
+state, sensible defaults fill in the rest, and a half-configuration (a key with no
+voice, where a voice cannot be defaulted) is refused rather than found on a live call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.config import (
+    ConfigurationError,
+    stt_settings,
+    tts_settings,
+)
+
+_VOICE_ENV = (
+    "DEEPGRAM_API_KEY",
+    "DEEPGRAM_MODEL",
+    "DEEPGRAM_BASE_URL",
+    "STT_LANGUAGE",
+    "ELEVENLABS_API_KEY",
+    "ELEVENLABS_VOICE_ID",
+    "ELEVENLABS_MODEL_ID",
+    "ELEVENLABS_OUTPUT_FORMAT",
+    "ELEVENLABS_BASE_URL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch):
+    for name in _VOICE_ENV:
+        monkeypatch.delenv(name, raising=False)
+    stt_settings.cache_clear()
+    tts_settings.cache_clear()
+    yield
+    stt_settings.cache_clear()
+    tts_settings.cache_clear()
+
+
+def test_no_key_is_not_configured_for_either() -> None:
+    assert stt_settings() is None
+    assert tts_settings() is None
+
+
+def test_a_deepgram_key_alone_configures_german_nova(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-key")
+    settings = stt_settings()
+    assert settings is not None
+    assert settings.model == "nova-2"
+    assert settings.language == "de"
+    assert settings.base_url.startswith("wss://")
+
+
+def test_deepgram_env_overrides_the_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-key")
+    monkeypatch.setenv("DEEPGRAM_MODEL", "nova-3")
+    monkeypatch.setenv("STT_LANGUAGE", "en")
+    monkeypatch.setenv("DEEPGRAM_BASE_URL", "ws://127.0.0.1:9000/")
+    settings = stt_settings()
+    assert (settings.model, settings.language) == ("nova-3", "en")
+    # The trailing slash is trimmed so the client's path join is clean.
+    assert settings.base_url == "ws://127.0.0.1:9000"
+
+
+def test_elevenlabs_needs_a_key_and_a_voice(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "xi-key")
+    monkeypatch.setenv("ELEVENLABS_VOICE_ID", "voice-42")
+    settings = tts_settings()
+    assert settings is not None
+    assert settings.voice_id == "voice-42"
+    assert settings.model == "eleven_turbo_v2_5"
+    assert settings.output_format == "ulaw_8000"
+
+
+def test_a_key_with_no_voice_is_a_refused_half_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "xi-key")
+    with pytest.raises(ConfigurationError) as caught:
+        tts_settings()
+    assert "ELEVENLABS_VOICE_ID" in str(caught.value)


### PR DESCRIPTION
## Milestone 11 — the v1 STT/TTS pair (SPEC §B3)

The wire protocol behind the interfaces #144 defined, and the last slice buildable without a live line: both are proven against **stand-ins**, so no real key and no cost.

> The ElevenLabs request shape was learned from a prior in-house project (Twilio + ElevenLabs) — **read, never copied**: that one is TypeScript and used the *batch* endpoint; this is the *streaming* one a call needs.

### `agent/providers/stt/deepgram.py`
Deepgram's streaming API is a WebSocket: audio frames up, JSON transcript messages down. Interim results arrive **before** the caller stops talking — those are the `Partial`s the turn-taker uses to start thinking during endpointing (Rule 3's largest budget slice); `is_final` messages are the `Final`s that carry `confidence` and the language and become transcript lines. A sender task pumps the caller's audio and then sends Deepgram's `CloseStream`, so the last phrase is flushed rather than lost with the socket. The connection is `encoding=mulaw&sample_rate=8000` — G.711 μ-law to match `SIP_CODEC=PCMU`, so the transport forwards the call's own frames with no transcode on the media path. The key rides in `Authorization: Token …`, never logged.

### `agent/providers/tts/elevenlabs.py`
Streams from `POST /v1/text-to-speech/{voice}/stream?output_format=ulaw_8000` — the streaming endpoint (the first chunk leaves before the last is made, Rule 3), and μ-law output so the transport forwards G.711 straight to the room with no transcode. **`cancel()` is the generator's close:** barge-in unwinds the `async with client.stream(...)`, the response closes, and ElevenLabs stops synthesising — the bill with it. A refusal raises `TTSError` rather than yielding silence.

### Configuration
`agent/config.py` reads `DEEPGRAM_*` / `ELEVENLABS_*` the way it already reads the model's, with working defaults (nova-2, German; turbo_v2_5, ulaw_8000) and the same half-configuration refusal — a key with no voice raises, because a voice cannot be defaulted and a silent fallback would be found on a live call. `.env.example` documents each. `configured_stt()` / `configured_tts()` build them from the environment, the standalone process's path.

### Proven on stand-ins
- `tests/test_voice_providers.py` (7): Deepgram against a **local WebSocket server** speaking its JSON protocol (partials→finals in order with confidence+language, audio sent then `CloseStream`, empty transcript is not a line, key as an `Authorization` token); ElevenLabs against an **httpx MockTransport** (audio streamed chunk by chunk, the request shape and `xi-api-key`, a 401 raised not swallowed, and closing early closes the response — the far-end stop).
- `tests/test_voice_settings.py` (5): the env rules — no key is "not configured", defaults fill in, a key with no voice is refused.

### Deliberately not wired in yet
`run_call` gets its STT/TTS from the transport, and the **LiveKit/SIP transport** — the thing that feeds the call's audio into `DeepgramSTT` and plays `ElevenLabsTTS` out, and that builds them via `configured_*` — is the next slice, gated on a LiveKit account and a bought number. This PR is the providers, ready for it. `agent/` still never imports `api/`. Full suite green on SQLite and PostgreSQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)