### PR TITLE
The LiveKit/SIP transport's audio bridge, and the SDK binding that needs the line

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -127,6 +127,62 @@ view) or Milestone 11 (web chat), whichever arrives first. The reference
 implementation and five rejected alternatives are in
 `internal/brand-explorations/scroll-test/orb-lab/`.
 
+**2026-09-02 — A relay service for self-hosted installations.**
+A self-hosted installation sits behind a router on a private network, and that is a
+problem twice over: the owner cannot reach their own dashboard from outside, and —
+more importantly — **the messaging channels cannot work at all**. WhatsApp, Messenger,
+Instagram and Telegram deliver messages by calling a public HTTPS webhook; a server on
+a LAN has no such address, so the setup story becomes "get a public IP, open ports,
+obtain a domain, configure TLS" — which ends most non-technical installations before
+they begin.
+
+The relay collapses that to nothing. Tel-Agent runs relay servers in a few regions;
+the installation opens an **outbound** tunnel to the nearest one (no port forwarding,
+no static IP at the customer's end) and receives a stable public address such as
+`name.tel-agent.com`. That one URL then serves as:
+
+1. the **webhook endpoint** the messaging platforms deliver to,
+2. the **public chat page and embed widget** address,
+3. **remote access** to the dashboard and the future desktop/mobile apps.
+
+Properties that are part of the idea, not optional extras:
+
+- **The relay stores nothing.** It forwards traffic; conversations, recordings and
+  credentials stay on the customer's machine. TLS terminates at the installation
+  (passthrough), so the relay cannot read what it carries. That is the promise that
+  makes self-hosting meaningful, and it must survive implementation.
+- **Voice never crosses the relay.** Call media takes its own path (§CLAUDE.md, SIP
+  section). The relay carries text, webhooks and dashboard traffic only — this keeps
+  both latency and bandwidth honest.
+- **Custom domains.** A customer points `agent.their-company.com` at the relay via
+  CNAME; certificates are issued automatically. Same mechanics as any hosted platform
+  with custom domains.
+- **Region-aware routing** — an installation connects to the nearest relay, chosen
+  automatically.
+- **Optional, always.** A technical user with their own public endpoint never needs
+  it; the direct path stays first-class.
+
+How the choice is presented — clarified 2026-09-02, because it decides whether the
+open edition stays trustworthy:
+
+- **The relay client ships inside the open edition**, not as a separate download.
+  The settings screen offers one choice with three answers: local network only
+  (the default), *my own public address* (a field for the user's domain or reverse
+  proxy), or *connect to the relay* (one button, an account, a stable address).
+- **Off by default, always.** The installation never contacts our servers until the
+  owner explicitly turns the relay on. A self-hosted program that phones home
+  unasked forfeits exactly the trust self-hosting exists to provide.
+- **The own-address path is first-class**, on the same screen, never buried. Making
+  our path easy must never make the user's own path harder.
+- **The relay server itself is a hosted service run by Tel-Agent Cloud** and, like
+  number reselling above, never enters the open edition. What lands in this
+  repository is the client half: the tunnel the installation opens, pointed at
+  whatever the user configures.
+
+Deferred because Milestone 0 is the only milestone, and the relay matters at
+Milestone 3 (messaging channels) at the earliest. The commercial side is recorded
+in `internal/DECISIONS.md` (D-033).
+
 **2026-08-20 — Redraw the logo as clean vector, and draw a 16 px icon.**
 Everything in `docs/brand/tel-agent-logo/` is traced from raster artwork, not drawn.
 It renders correctly and scales, but the full-colour marks are ~200 colour-band

--- a/agent/README.md
+++ b/agent/README.md
@@ -60,12 +60,20 @@ the response). Both are exercised against stand-ins in `tests/test_voice_provide
 and no cost. `config.py` reads their env (`DEEPGRAM_*`, `ELEVENLABS_*`) the same way it
 reads the model's, and `configured_stt()`/`configured_tts()` build them.
 
-What is still to come, blocked on a bought number and a LiveKit account: the LiveKit/
-SIP transport that feeds the call's audio into `DeepgramSTT` and plays `ElevenLabsTTS`
-out — the `CallTransport` `api/channels/phone.py` already defined. The `api/` side that
-stores a call in the same archive is done (`phone.run_call`). `routing/` is a stub -
-the rules engine lives at `api/routing.py` (Milestone 4), which the phone already calls
-on the caller ID.
+The transport's codec-free core is built too: `session/audio.py`'s `CallAudioBridge`
+turns a media room into the `CallTransport` `run_call` consumes — inbound frames into
+`DeepgramSTT`, `ElevenLabsTTS` out through the room — behind a tiny `RoomAudio` seam, so
+the whole thing is exercised in `tests/test_audio_bridge.py` with a fake room and the
+real providers against their stand-ins: a whole call, frames in to frames out, stored
+in the archive.
+
+The one piece no fake can finish is `session/livekit_room.py` — the actual LiveKit
+binding that joins a room and moves RTP. It is written against the documented SDK API
+but **not proven**, because its whole job is real audio through a real connection; it is
+a *verify* when the LiveKit account and the number exist, not a *write* (Rule 2). The
+`livekit` SDK is the optional `voice` extra so the core installs without it. `routing/`
+is a stub - the rules engine lives at `api/routing.py` (Milestone 4), which the phone
+already calls on the caller ID.
 
 Configuration comes from the environment, in `config.py`. That file exists rather than
 importing `api.config` because this package never imports from `api/` - at Milestone 11

--- a/agent/config.py
+++ b/agent/config.py
@@ -177,12 +177,21 @@ DEFAULT_TTS_OUTPUT_FORMAT = "ulaw_8000"
 
 @dataclass(frozen=True)
 class SttSettings:
-    """Which speech-to-text service listens, and in what language."""
+    """Which speech-to-text service listens, in what language, and over which codec.
+
+    `encoding` and `sample_rate` are the transport's business, not the installer's: a
+    direct SIP call is μ-law 8 kHz, but a LiveKit room hands the agent 16-bit PCM at
+    the room's rate, and Deepgram must be told which. They default to the SIP case and
+    the LiveKit transport overrides them - so the same provider serves both media paths
+    without a transcode on either.
+    """
 
     api_key: str
     model: str
     language: str
     base_url: str
+    encoding: str = "mulaw"
+    sample_rate: int = 8000
 
 
 @dataclass(frozen=True)
@@ -213,6 +222,18 @@ def stt_settings() -> SttSettings | None:
         language=_clean("STT_LANGUAGE") or "de",
         base_url=_clean("DEEPGRAM_BASE_URL").rstrip("/") or DEFAULT_STT_BASE_URL,
     )
+
+
+def _replace_codec(settings: SttSettings, *, encoding: str, sample_rate: int) -> SttSettings:
+    """The same STT configuration, re-coded for a transport's media format.
+
+    A transport knows its audio format and the installer does not, so the transport
+    calls this rather than asking the operator to set a codec they cannot know. Kept
+    here beside `SttSettings` so the field names have one home.
+    """
+    import dataclasses
+
+    return dataclasses.replace(settings, encoding=encoding, sample_rate=sample_rate)
 
 
 @lru_cache(maxsize=1)

--- a/agent/providers/stt/deepgram.py
+++ b/agent/providers/stt/deepgram.py
@@ -41,11 +41,11 @@ from agent.providers.stt.base import Final, Partial, Transcript
 
 logger = logging.getLogger("agent.stt")
 
-# What the transport carries: G.711 μ-law, 8 kHz, one channel. Punctuation on, because a
-# transcript line without it reads worse and Deepgram's costs nothing.
-_AUDIO_PARAMS = {
-    "encoding": "mulaw",
-    "sample_rate": "8000",
+# The knobs that do not depend on the transport's codec. `interim_results` is what
+# makes the partials arrive at all; punctuation is on because a transcript line without
+# it reads worse and Deepgram's costs nothing. The encoding and sample rate come from
+# the settings, because a SIP call is μ-law 8 kHz and a LiveKit room is 16-bit PCM.
+_FIXED_PARAMS = {
     "channels": "1",
     "interim_results": "true",
     "punctuate": "true",
@@ -64,7 +64,9 @@ class DeepgramSTT:
 
     def _url(self) -> str:
         params = {
-            **_AUDIO_PARAMS,
+            **_FIXED_PARAMS,
+            "encoding": self._settings.encoding,
+            "sample_rate": str(self._settings.sample_rate),
             "model": self._settings.model,
             "language": self._settings.language,
         }

--- a/agent/session/__init__.py
+++ b/agent/session/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from agent.session.audio import CallAudioBridge, RoomAudio
 from agent.session.turn import AudioSink, TurnResult, speak
 
-__all__ = ["AudioSink", "TurnResult", "speak"]
+__all__ = ["AudioSink", "CallAudioBridge", "RoomAudio", "TurnResult", "speak"]

--- a/agent/session/audio.py
+++ b/agent/session/audio.py
@@ -1,0 +1,92 @@
+"""The audio bridge — a room's frames on one side, STT and TTS on the other.
+
+Milestone 11's transport has two halves. This is the half that carries no vendor: it
+turns a media room (LiveKit, or a raw SIP stream) into the `CallTransport` the archive
+side (`api.channels.phone.run_call`) consumes, by wiring the caller's inbound audio
+into a speech-to-text stream and the agent's synthesised speech back out. The other
+half — actually joining a LiveKit room and moving RTP — is `livekit_room.py`, and it is
+the only part that cannot be proven without a real account.
+
+**The seam is `RoomAudio`, and it is deliberately tiny.** Inbound frames in, outbound
+frames out, and a flush for barge-in. Everything vendor-specific — connecting,
+subscribing to a track, resampling, publishing — lives behind it, so this bridge and
+everything above it is exercised with a fake room that carries plain bytes. That is the
+same line every channel draws between "what happened in the conversation" and "which
+wire it arrived on".
+
+**This bridge satisfies `CallTransport` structurally** (`from_e164`, `tts`, `sink`,
+`transcripts()`), so `run_call` drives it exactly as it drives the scripted transport
+in the tests — the real one is not a special case. `agent/` owns it because it is audio
+and providers, not storage; `run_call`, which has the database, stays in `api/`.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from typing import Protocol
+
+from agent.providers.stt import STTProvider
+from agent.providers.stt.base import Transcript
+from agent.providers.tts import TTSProvider
+
+logger = logging.getLogger("agent.session")
+
+
+class RoomAudio(Protocol):
+    """A live call's audio, reduced to what the bridge needs of any media transport.
+
+    `from_e164` is the caller's number when the transport knows it (a SIP call does; a
+    web-RTC test may not). `inbound` is the caller's audio as it arrives; `play` sends
+    one frame back; `flush` drops whatever is queued for playback but not yet heard,
+    which is the barge-in act a provider cannot perform because it never sees the queue.
+    The frame bytes are in the codec both sides agreed on out of band — μ-law for a SIP
+    stream, PCM for a LiveKit room — and the STT/TTS are configured to match.
+    """
+
+    from_e164: str | None
+
+    def inbound(self) -> AsyncIterator[bytes]:
+        """The caller's audio frames, until the call ends and the stream closes."""
+        ...
+
+    async def play(self, frame: bytes) -> None:
+        """Send one audio frame to the caller."""
+        ...
+
+    async def flush(self) -> None:
+        """Drop queued-but-unplayed audio. Called on barge-in."""
+        ...
+
+
+class _RoomSink:
+    """An `AudioSink` (see `agent.session.turn`) backed by a room's playback side."""
+
+    def __init__(self, room: RoomAudio) -> None:
+        self._room = room
+
+    async def write(self, chunk: bytes) -> None:
+        await self._room.play(chunk)
+
+    async def flush(self) -> None:
+        await self._room.flush()
+
+
+class CallAudioBridge:
+    """A `CallTransport` over a `RoomAudio`, speaking through the given STT and TTS.
+
+    The bridge holds no state of its own: `transcripts()` is the caller's inbound audio
+    piped straight into the recogniser, and the sink is the room's playback. Everything
+    that makes a call a call - turn-taking, barge-in, storage - is `run_call`'s, and it
+    sees only this small surface.
+    """
+
+    def __init__(self, room: RoomAudio, *, stt: STTProvider, tts: TTSProvider) -> None:
+        self.from_e164 = room.from_e164
+        self.tts = tts
+        self.sink = _RoomSink(room)
+        self._room = room
+        self._stt = stt
+
+    def transcripts(self) -> AsyncIterator[Transcript]:
+        return self._stt.stream(self._room.inbound())

--- a/agent/session/livekit_room.py
+++ b/agent/session/livekit_room.py
@@ -1,0 +1,125 @@
+"""The LiveKit half of the transport — the one part no fake can finish.
+
+This fills the `RoomAudio` seam `audio.py` defines, using `livekit.rtc`: it joins a
+room, reads the caller's audio track as PCM frames, and publishes the agent's speech
+back. Per the locked decision, a provider number points at a LiveKit Cloud SIP trunk
+and LiveKit bridges the call into a room; the agent is a participant that never touches
+SIP or RTP directly.
+
+**This module is NOT proven, and it says so in the open.** Every other piece of
+Milestone 11 is exercised against a stand-in — the voice core, the providers, the
+archive side, and the bridge above. This one cannot be: its whole job is to move real
+audio through a real LiveKit connection, and a fake room proves the bridge, not this.
+It is written against the documented `livekit-rtc` API so that when the account and the
+number exist it is a *verify*, not a *write* — but until a call has actually rung, treat
+every frame size, sample rate and resample here as a hypothesis. Rule 2 is explicit:
+confirm the call arrives in the provider console before trusting any of this code.
+
+**`livekit` is an optional dependency.** The core installs without it (the bridge and
+everything above need only plain bytes), and this module imports it lazily so the test
+suite and a text-only installation never require the SDK. Install it with the `voice`
+extra when wiring the phone.
+
+**Codec.** LiveKit carries 16-bit PCM at the room's sample rate, not the μ-law a raw
+SIP stream uses, so the providers are re-coded to `linear16` at that rate (see
+`agent.config._replace_codec` and `ElevenLabs`'s `pcm_*` output). No μ-law transcode
+happens on the LiveKit path; the μ-law defaults are for the direct-SIP path instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import AsyncIterator
+
+logger = logging.getLogger("agent.session.livekit")
+
+# What ElevenLabs streams and what Deepgram is told, for a room at this rate. LiveKit's
+# default publish rate; a trunk may negotiate another, in which case these follow it.
+ROOM_SAMPLE_RATE = 48000
+STT_ENCODING = "linear16"
+
+
+class LiveKitRoom:
+    """A `RoomAudio` backed by a LiveKit room. Unproven until a real call rings.
+
+    Construct it with a connected `rtc.Room`, the caller's number (from the SIP
+    participant's attributes), and an `rtc.AudioSource` already publishing a track. The
+    worker that builds this is where the connection and token live; keeping them out of
+    here is what lets the frame-moving logic be read on its own.
+    """
+
+    def __init__(
+        self, room, source, *, from_e164, sample_rate: int = ROOM_SAMPLE_RATE  # noqa: ANN001
+    ) -> None:
+        self.from_e164 = from_e164
+        self._room = room
+        self._source = source
+        self._sample_rate = sample_rate
+        self._inbound: asyncio.Queue[bytes | None] = asyncio.Queue()
+        # Held so the drain task is not garbage-collected mid-call (RUF006).
+        self._drain: asyncio.Task | None = None
+
+    def attach(self, track) -> None:  # noqa: ANN001
+        """Start draining the caller's subscribed audio track into the inbound queue.
+
+        Called from the room's `track_subscribed` handler. `rtc.AudioStream` yields
+        `rtc.AudioFrame`s; `frame.data` is the PCM samples as bytes, which is exactly
+        what Deepgram wants at `linear16`.
+        """
+        from livekit import rtc
+
+        stream = rtc.AudioStream(track)
+
+        async def drain() -> None:
+            try:
+                async for event in stream:
+                    await self._inbound.put(bytes(event.frame.data))
+            finally:
+                await self._inbound.put(None)
+
+        self._drain = asyncio.ensure_future(drain())
+
+    async def inbound(self) -> AsyncIterator[bytes]:
+        while True:
+            frame = await self._inbound.get()
+            if frame is None:
+                return
+            yield frame
+
+    async def play(self, frame: bytes) -> None:
+        """Push one synthesised PCM frame to the room's audio source.
+
+        `capture_frame` applies its own playout pacing, which is what makes the audio
+        arrive at the caller in real time rather than all at once.
+        """
+        from livekit import rtc
+
+        audio_frame = rtc.AudioFrame(
+            data=frame,
+            sample_rate=self._sample_rate,
+            num_channels=1,
+            samples_per_channel=len(frame) // 2,  # 16-bit samples
+        )
+        await self._source.capture_frame(audio_frame)
+
+    async def flush(self) -> None:
+        """Drop queued playout on barge-in.
+
+        `AudioSource.clear_queue()` exists for exactly this; guarded because an older
+        SDK may not have it, and losing the flush is a bug to see rather than to hide.
+        """
+        clear = getattr(self._source, "clear_queue", None)
+        if clear is None:
+            logger.warning("this livekit AudioSource has no clear_queue; barge-in cannot flush")
+            return
+        result = clear()
+        if asyncio.iscoroutine(result):
+            await result
+
+
+async def hang_up(room) -> None:  # noqa: ANN001
+    """Disconnect from the room, ignoring an already-closed connection."""
+    with contextlib.suppress(Exception):
+        await room.disconnect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,13 @@ dependencies = [
 tel-agent = "api.__main__:main"
 
 [project.optional-dependencies]
+# The phone's media transport (Milestone 11). Optional because the core - every text
+# channel, the whole dashboard - runs without it: only the LiveKit room binding in
+# `agent/session/livekit_room.py` imports it, lazily. Install with `.[voice]` when
+# wiring the phone against a LiveKit account.
+voice = [
+    "livekit>=0.17",
+]
 dev = [
     "ruff>=0.14",
     "pytest>=8.3",

--- a/tests/test_audio_bridge.py
+++ b/tests/test_audio_bridge.py
@@ -1,0 +1,266 @@
+"""Milestone 11 — the audio bridge, and the whole transport core end to end.
+
+The bridge (`agent.session.CallAudioBridge`) is thin, so its unit tests are about
+wiring: the caller's inbound frames reach the recogniser, the agent's audio reaches the
+room, and a flush reaches the room. The integration test is the one that matters — it
+runs a whole call through `run_call` with the **real** Deepgram and ElevenLabs clients
+pointed at stand-ins, so everything except the LiveKit wire is exercised together:
+frames in → STT → transcripts → reply → TTS → frames out, stored as a call. The LiveKit
+wire itself (`livekit_room.py`) is the one piece no fake can finish.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import websockets
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agent.config import SttSettings, TtsSettings
+from agent.providers.llm.base import TextDelta
+from agent.providers.stt.base import Final, Partial, Transcript
+from agent.providers.stt.deepgram import DeepgramSTT
+from agent.providers.tts.elevenlabs import ElevenLabsTTS
+from agent.session import CallAudioBridge
+from api.channels import phone
+from api.config import Settings
+from api.main import create_app
+from api.models import Call, Channel, Conversation, Membership, Message, User, Workspace
+from api.security.password import hash_password
+
+PASSWORD = "a sentence i can actually remember"  # noqa: S105
+KEY_HEX = "aa" * 32
+
+
+@pytest.fixture(autouse=True)
+def configured_key(monkeypatch: pytest.MonkeyPatch):
+    from api.config import get_settings
+    from api.models.encrypted import reset_key_cache
+
+    monkeypatch.setenv("ENCRYPTION_KEY", KEY_HEX)
+    get_settings.cache_clear()
+    reset_key_cache()
+    yield
+    get_settings.cache_clear()
+    reset_key_cache()
+
+
+class FakeRoom:
+    """A `RoomAudio` carrying plain bytes: scripted inbound frames, captured outbound."""
+
+    def __init__(self, frames: list[bytes], *, from_e164: str | None = "+436761234567") -> None:
+        self.from_e164 = from_e164
+        self._frames = frames
+        self.played: list[bytes] = []
+        self.flushes = 0
+
+    async def inbound(self) -> AsyncIterator[bytes]:
+        import asyncio
+
+        for frame in self._frames:
+            yield frame
+            await asyncio.sleep(0)
+
+    async def play(self, frame: bytes) -> None:
+        self.played.append(frame)
+
+    async def flush(self) -> None:
+        self.flushes += 1
+
+
+# --- Bridge wiring ---------------------------------------------------------------
+
+
+class _RecordingSTT:
+    def __init__(self, transcripts: list[Transcript]) -> None:
+        self._transcripts = transcripts
+        self.consumed: list[bytes] = []
+
+    def stream(self, audio: AsyncIterator[bytes]) -> AsyncIterator[Transcript]:
+        async def gen() -> AsyncIterator[Transcript]:
+            async for chunk in audio:
+                self.consumed.append(chunk)
+            for transcript in self._transcripts:
+                yield transcript
+
+        return gen()
+
+
+class _WordTTS:
+    def stream(self, text: str) -> AsyncIterator[bytes]:
+        async def gen() -> AsyncIterator[bytes]:
+            for word in text.split():
+                yield word.encode()
+
+        return gen()
+
+
+async def test_the_bridge_pipes_inbound_audio_into_the_recogniser() -> None:
+    room = FakeRoom([b"frame-1", b"frame-2"])
+    stt = _RecordingSTT([Partial(text="hi"), Final(text="hi there", confidence=0.9)])
+    bridge = CallAudioBridge(room, stt=stt, tts=_WordTTS())
+
+    out = [t async for t in bridge.transcripts()]
+
+    assert stt.consumed == [b"frame-1", b"frame-2"]
+    assert [t.text for t in out] == ["hi", "hi there"]
+    assert bridge.from_e164 == "+436761234567"
+
+
+async def test_the_bridge_sink_plays_to_the_room_and_flush_reaches_it() -> None:
+    room = FakeRoom([])
+    bridge = CallAudioBridge(room, stt=_RecordingSTT([]), tts=_WordTTS())
+
+    await bridge.sink.write(b"hello")
+    await bridge.sink.write(b"world")
+    await bridge.sink.flush()
+
+    assert room.played == [b"hello", b"world"]
+    assert room.flushes == 1
+
+
+# --- The whole transport core, end to end ----------------------------------------
+
+
+class _FakeDeepgram:
+    """A local WebSocket server speaking Deepgram's protocol, scripted per call."""
+
+    def __init__(self, script: list[dict]) -> None:
+        self._script = script
+
+    async def _handler(self, ws) -> None:
+        async for message in ws:
+            if not isinstance(message, bytes):
+                data = json.loads(message)
+                if data.get("type") == "CloseStream":
+                    break
+        for result in self._script:
+            await ws.send(json.dumps(result))
+        await ws.close()
+
+    async def __aenter__(self) -> str:
+        self._server = await websockets.serve(self._handler, "127.0.0.1", 0)
+        return f"ws://127.0.0.1:{self._server.sockets[0].getsockname()[1]}"
+
+    async def __aexit__(self, *exc) -> None:
+        self._server.close()
+        await self._server.wait_closed()
+
+
+def _final(text: str) -> dict:
+    return {
+        "type": "Results",
+        "is_final": True,
+        "channel": {"alternatives": [{"transcript": text, "confidence": 0.92}]},
+    }
+
+
+class _ScriptedLLM:
+    def __init__(self, *lines: str) -> None:
+        self.lines = list(lines)
+        self.turn = 0
+
+    async def stream(self, messages, tools):
+        line = self.lines[min(self.turn, len(self.lines) - 1)]
+        self.turn += 1
+        for word in line.split():
+            yield TextDelta(text=word + " ")
+
+
+def _el_tts() -> ElevenLabsTTS:
+    def handler(request: httpx.Request) -> httpx.Response:
+        # One byte-chunk per word of the requested text, so "played" audio is checkable.
+        text = json.loads(request.content)["text"]
+        return httpx.Response(200, content=text.replace(" ", "").encode())
+
+    settings = TtsSettings(
+        api_key="dev-fake-key",
+        voice_id="voice-1",
+        model="eleven_turbo_v2_5",
+        output_format="pcm_8000",
+        base_url="https://tts.test",
+    )
+    return ElevenLabsTTS(settings, transport=httpx.MockTransport(handler))
+
+
+@pytest.fixture
+async def stage(migrated: AsyncSession, settings: Settings, database_url: str):
+    workspace = Workspace(name="Wagner & Partner")
+    migrated.add(workspace)
+    await migrated.flush()
+    channel = Channel(workspace_id=workspace.id, kind="phone", name="Phone", status="active")
+    migrated.add(channel)
+    user = User(username="mohamed", password_hash=hash_password(PASSWORD))
+    migrated.add(user)
+    await migrated.flush()
+    migrated.add(Membership(user_id=user.id, workspace_id=workspace.id, role="admin"))
+    await migrated.commit()
+
+    app = create_app(settings.model_copy(update={"database_url": database_url}))
+    async with app.router.lifespan_context(app):
+        http = AsyncClient(
+            transport=ASGITransport(app=app, raise_app_exceptions=False),
+            base_url="http://localhost",
+        )
+        assert (
+            await http.post(
+                "/api/auth/login", json={"username": "mohamed", "password": PASSWORD}
+            )
+        ).status_code == 200
+        try:
+            yield app, channel.id, migrated
+        finally:
+            await http.aclose()
+
+
+async def test_a_whole_call_runs_through_the_bridge_and_lands_in_the_archive(stage) -> None:
+    """Frames in → real Deepgram (stand-in) → transcripts → reply → real ElevenLabs
+    (stand-in) → frames out, stored as a conversation with a calls row. Everything but
+    the LiveKit wire, exercised at once."""
+    app, channel_id, db = stage
+
+    async with _FakeDeepgram([_final("Are you open on Saturday?")]) as dg_url:
+        stt = DeepgramSTT(
+            SttSettings(
+                api_key="dev-fake-key",
+                model="nova-2",
+                language="de",
+                base_url=dg_url,
+                encoding="linear16",
+                sample_rate=8000,
+            )
+        )
+        room = FakeRoom([b"\x00\x01\x02\x03", b"\x04\x05\x06\x07"])
+        bridge = CallAudioBridge(room, stt=stt, tts=_el_tts())
+
+        conversation_id = await phone.run_call(
+            app.state.sessionmaker,
+            channel_id=channel_id,
+            transport=bridge,
+            provider=_ScriptedLLM("Yes, we are open until noon."),
+        )
+
+    # The caller's audio reached the recogniser, and the agent's speech reached the room.
+    assert room.played  # ElevenLabs bytes were captured back into the room
+    convo = await db.scalar(select(Conversation).where(Conversation.id == conversation_id))
+    assert convo.status == "closed"
+    call = await db.scalar(select(Call).where(Call.conversation_id == conversation_id))
+    assert call is not None
+    rows = (
+        await db.execute(
+            select(Message)
+            .where(Message.conversation_id == conversation_id)
+            .order_by(Message.ts_ms, Message.id)
+        )
+    ).scalars().all()
+    assert [(r.speaker, r.text) for r in rows] == [
+        ("caller", "Are you open on Saturday?"),
+        ("agent", "Yes, we are open until noon."),
+    ]
+    # The caller line came from Deepgram, so it carries the confidence Deepgram gave.
+    assert rows[0].stt_confidence == 0.92

--- a/tests/test_voice_settings.py
+++ b/tests/test_voice_settings.py
@@ -81,3 +81,24 @@ def test_a_key_with_no_voice_is_a_refused_half_configuration(
     with pytest.raises(ConfigurationError) as caught:
         tts_settings()
     assert "ELEVENLABS_VOICE_ID" in str(caught.value)
+
+
+def test_a_transport_recodes_stt_for_its_own_media_format(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default is the SIP case (μ-law 8 kHz); a LiveKit room is 16-bit PCM, and the
+    transport re-codes the settings without touching the key or the language."""
+    from agent.config import _replace_codec
+
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "dg-key")
+    base = stt_settings()
+    assert (base.encoding, base.sample_rate) == ("mulaw", 8000)
+
+    room = _replace_codec(base, encoding="linear16", sample_rate=48000)
+    assert (room.encoding, room.sample_rate) == ("linear16", 48000)
+    # Everything else is carried through unchanged.
+    assert (room.api_key, room.model, room.language) == (
+        base.api_key,
+        base.model,
+        base.language,
+    )


### PR DESCRIPTION
## Milestone 11 — the transport, in its two honest halves

The transport is the last piece of the phone, and it splits cleanly into what a fake can prove and what only a live line can.

### The half that carries no vendor — `agent/session/audio.py` (proven)
`CallAudioBridge` turns a media room into the `CallTransport` `run_call` consumes: the caller's inbound frames piped into `DeepgramSTT`, `ElevenLabsTTS` out through the room, behind a tiny `RoomAudio` seam (inbound frames, `play`, `flush`). Because the seam is plain bytes, **the whole transport core is exercised end to end** in `tests/test_audio_bridge.py` with a fake room and the *real* providers against their stand-ins (a local Deepgram WebSocket, an httpx-mocked ElevenLabs): a whole call, frames in → STT → transcripts → reply → TTS → frames out, stored as a conversation with a `calls` row and a transcript carrying Deepgram's confidence. That is roadmap check 5 (full loop) with everything but the LiveKit wire.

**Codec is the transport's business, not the installer's.** A raw SIP call is μ-law 8 kHz; a LiveKit room is 16-bit PCM at the room's rate. So `DeepgramSTT`'s `encoding`/`sample_rate` are configurable (`SttSettings`, `_replace_codec`) and the transport sets them — no transcode on either media path. The μ-law defaults are the direct-SIP case; the LiveKit path re-codes to `linear16`.

### The half no fake can finish — `agent/session/livekit_room.py` (written, NOT proven)
The actual `livekit.rtc` binding: join a room, subscribe to the caller's audio track as PCM frames, publish the agent's speech, flush on barge-in. It fills the `RoomAudio` seam, written against the documented SDK API **so that when the LiveKit account and the number exist it is a verify, not a write** — its own header says, in the open, that every frame size and sample rate in it is a hypothesis until a call has actually rung (Rule 2: confirm arrival in the provider console before trusting any of it). This is the one module in Milestone 11 with no test, on purpose: its whole job is real audio through a real connection, which a fake room does not carry.

`livekit` is the optional **`voice`** extra, imported lazily — the core (every text channel, the whole dashboard) installs without it, and `import agent.session` works with no SDK present.

### Tests
`tests/test_audio_bridge.py` (3): the bridge pipes inbound audio into the recogniser, the sink plays to the room and flush reaches it, and the full call runs through `run_call` and lands in the archive. `tests/test_voice_settings.py` gains the codec-recode case. `agent/` still never imports `api/`; full suite green on SQLite and PostgreSQL.

### What is now left of the phone
Only the live line: an account, a bought number pointed at a LiveKit Cloud SIP trunk, real keys, and the standalone worker that connects a room and calls `run_call` with a `LiveKitRoom` — then Rule 2's six checks and twenty Austrian-German calls. Everything up to the connection is built and proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)