### PR TITLE
Show the people who built it: a contributors grid in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,15 @@ the rules cannot drift apart.
 Found a security problem? **Do not open a public issue** — see
 [`SECURITY.md`](SECURITY.md).
 
+### The people who built it
+
+Every face here wrote part of Tel-Agent. The grid updates itself as new contributors
+land — a translation counts.
+
+<a href="https://github.com/Dpro-at/Tel-Agent/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Dpro-at/Tel-Agent" alt="Tel-Agent contributors">
+</a>
+
 ---
 
 ## License


### PR DESCRIPTION
## A Contributors section on the front page

The repo's home-page sidebar shows only a handful of contributor avatars (author-based, cached), and the full list lives out of sight under **Insights → Contributors**. This adds a **contributors grid to the README** so every visitor sees who built Tel-Agent — the social proof an open-source project runs on, and an invitation to contribute.

One line, no maintenance: a [contrib.rocks](https://contrib.rocks) image that renders all contributors in a grid and **updates itself** as new ones land, linked to the contributors graph. Placed at the end of the Contributing section, right before License.

Note: contrib.rocks reads GitHub's author-based contributor list, so it shows the human contributors (a co-author-only identity may not appear) — which is the intent.

If you later want to credit non-code contributions (translations, design, ideas) or curate the list by hand, the all-contributors bot is the next step; this is the zero-maintenance start.
