### PR TITLE
An empty ENCRYPTION_KEY reads as absent, the same answer everywhere

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -159,6 +159,22 @@ class Settings(BaseSettings):
     def debug(self) -> bool:
         return self.environment == "development"
 
+    @field_validator("encryption_key", mode="before")
+    @classmethod
+    def _empty_key_is_no_key(cls, value: object) -> object:
+        """`ENCRYPTION_KEY=""` reads as absent, the same answer every reader gives.
+
+        A `.env` line left blank produces an empty string, which is not None to a
+        presence check and not a key to `crypto.load_key` — two answers to one
+        question, and the kind of divergence that surfaces as tests passing on one
+        machine and failing on another. Normalised here, at the boundary, so
+        `key_available()`, the production validator and the encrypted column all
+        agree on what was configured.
+        """
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
+
     @field_validator("cors_origins", "trusted_hosts", mode="before")
     @classmethod
     def _split_comma_separated(cls, value: object) -> object:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,25 @@ def test_production_starts_once_the_key_is_present() -> None:
     assert settings.debug is False
 
 
+def test_an_empty_encryption_key_reads_as_absent_everywhere() -> None:
+    """`ENCRYPTION_KEY=""` in a `.env` must mean the same thing in every reader.
+
+    It used to read as *present* to `settings.encryption_key is not None` and as
+    *absent* to `crypto.key_available()` — two answers to one question. Normalised at
+    the settings boundary, so every reader downstream agrees. Whitespace is the same
+    case wearing a space.
+    """
+    for raw in ("", "   "):
+        assert _settings(encryption_key=raw).encryption_key is None
+
+
+def test_an_empty_key_still_refuses_production() -> None:
+    with pytest.raises(ValidationError) as error:
+        _settings(environment="production", encryption_key="")
+
+    assert "ENCRYPTION_KEY" in str(error.value)
+
+
 def test_a_synchronous_database_driver_is_refused() -> None:
     """A blocking driver stalls the event loop, and only under load."""
     with pytest.raises(ValidationError) as error:


### PR DESCRIPTION
## What

`ENCRYPTION_KEY=""` (a blank line in `.env`) produced an empty string in `Settings.encryption_key`: **present** to a `is not None` check, **absent** to `crypto.key_available()` — two answers to one question. This inconsistency has been on the books since #116's investigation.

## How

A `mode="before"` field validator normalises an empty or whitespace-only key to `None` at the settings boundary, so `key_available()`, the production validator and the encrypted column all agree on what was configured. The production refusal of a missing key is unchanged — it now fires for the same reason as every other reader.

## Proof

- New test: `""` and `"   "` both read back as `None`; production still refuses an empty key.
- `tests/test_config.py` 12/12, plus the settings-store, webhooks and web-channel suites that exercise `key_available()`.