### PR TITLE
Format under the current ruff release

### DIFF
--- a/agent/providers/calendar/caldav.py
+++ b/agent/providers/calendar/caldav.py
@@ -144,9 +144,7 @@ def _duration(text: str) -> dt.timedelta | None:
     rather than guessed."""
     import re
 
-    match = re.fullmatch(
-        r"P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?", text
-    )
+    match = re.fullmatch(r"P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?", text)
     if match is None or not any(match.groups()):
         return None
     days, hours, minutes, seconds = (int(part) if part else 0 for part in match.groups())

--- a/agent/session/livekit_room.py
+++ b/agent/session/livekit_room.py
@@ -52,11 +52,11 @@ class LiveKitRoom:
 
     def __init__(
         self,
-        room,
-        source,
+        room,  # noqa: ANN001 - rtc.Room; the voice extra is imported lazily
+        source,  # noqa: ANN001 - rtc.AudioSource, same reason
         *,
-        from_e164,
-        sample_rate: int = ROOM_SAMPLE_RATE,  # noqa: ANN001
+        from_e164: str,
+        sample_rate: int = ROOM_SAMPLE_RATE,
     ) -> None:
         self.from_e164 = from_e164
         self._room = room

--- a/agent/session/livekit_room.py
+++ b/agent/session/livekit_room.py
@@ -51,7 +51,12 @@ class LiveKitRoom:
     """
 
     def __init__(
-        self, room, source, *, from_e164, sample_rate: int = ROOM_SAMPLE_RATE  # noqa: ANN001
+        self,
+        room,
+        source,
+        *,
+        from_e164,
+        sample_rate: int = ROOM_SAMPLE_RATE,  # noqa: ANN001
     ) -> None:
         self.from_e164 = from_e164
         self._room = room

--- a/tests/test_audio_bridge.py
+++ b/tests/test_audio_bridge.py
@@ -252,12 +252,16 @@ async def test_a_whole_call_runs_through_the_bridge_and_lands_in_the_archive(sta
     call = await db.scalar(select(Call).where(Call.conversation_id == conversation_id))
     assert call is not None
     rows = (
-        await db.execute(
-            select(Message)
-            .where(Message.conversation_id == conversation_id)
-            .order_by(Message.ts_ms, Message.id)
+        (
+            await db.execute(
+                select(Message)
+                .where(Message.conversation_id == conversation_id)
+                .order_by(Message.ts_ms, Message.id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert [(r.speaker, r.text) for r in rows] == [
         ("caller", "Are you open on Saturday?"),
         ("agent", "Yes, we are open until noon."),

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -132,9 +132,7 @@ async def stage(migrated: AsyncSession, settings: Settings, database_url: str):
                 "/api/auth/login", json={"username": "mohamed", "password": PASSWORD}
             )
         ).status_code == 200
-        offered = toolset(
-            app.state.sessionmaker, workspace_id=workspace.id, conversation_id=1
-        )
+        offered = toolset(app.state.sessionmaker, workspace_id=workspace.id, conversation_id=1)
         tool = next(t for t in offered if t.name == "check_calendar")
         try:
             yield http, tool


### PR DESCRIPTION
## What

A new ruff release changed how it folds short call arguments. CI installs ruff fresh from the `[dev]` extras, so `main` itself now fails `ruff format --check .` on four files that were correctly formatted when they merged — which blocks every open pull request's CI (#152 went red on exactly this).

## How

`ruff format .` under the current release (0.16.5), plus re-pinning the two `noqa: ANN001` suppressions the reformat had moved off their lines in `LiveKitRoom.__init__` (and giving `from_e164` the `str` annotation it could always have had). Formatting only — no behaviour changes.

## Proof

- `ruff format --check .` and `ruff check .` both clean.
- `tests/test_audio_bridge.py` and `tests/test_calendar.py` (the touched modules' suites) green.