### PR TITLE
A Test button for the calendar, beside the credentials it proves

### DIFF
--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -300,3 +300,84 @@ async def test_model(
         )
 
     return ModelTested(reached=True, model=settings.model, base_url=settings.base_url)
+
+
+class CalendarTested(BaseModel):
+    reached: bool
+    # The collection address that answered - configuration, not a secret; the
+    # username and password stay server-side, like everywhere else on this screen.
+    source: str
+
+
+@router.post(
+    "/calendar/test",
+    response_model=CalendarTested,
+    summary="Ask the configured calendar for one free-busy day, and report what happened",
+)
+async def test_calendar(
+    request: Request, context: Annotated[WorkspaceContext, require_admin]
+) -> object:
+    """Prove the saved CalDAV credentials reach a calendar, before a caller finds out.
+
+    The probe is the cheapest real question the provider can ask: one day's free-busy
+    report. Reachability, sign-in and "this URL is actually a calendar collection" are
+    all proven by it; what the busy periods say does not matter here.
+
+    The same three refusals the availability endpoint distinguishes, as designed
+    answers rather than tracebacks - this is the button somebody presses when
+    credentials stop working.
+    """
+    import datetime as dt
+
+    from agent.providers.calendar import CalDAVCalendar, CalendarError
+    from api.settings import store as settings_store
+
+    db: DbSession = request.state.db
+
+    url = str(
+        await settings_store.get(db, "calendar.caldav_url", workspace_id=context.id) or ""
+    ).strip()
+    if not url:
+        return envelope_response(
+            status_code=status.HTTP_409_CONFLICT,
+            code="calendar_not_configured",
+            message="No calendar is connected. Fill in the CalDAV address and the app "
+            "password above, save, then test.",
+        )
+    username = str(
+        await settings_store.get(db, "calendar.caldav_username", workspace_id=context.id) or ""
+    )
+    password = str(
+        await settings_store.get(db, "calendar.caldav_password", workspace_id=context.id) or ""
+    )
+
+    calendar = CalDAVCalendar(url=url, username=username, password=password)
+    start = dt.datetime.now(dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    try:
+        await calendar.busy(start, start + dt.timedelta(days=1))
+    except CalendarError as error:
+        logger.warning("the calendar test failed: %s", error)
+        if error.status in (401, 403):
+            return envelope_response(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                code="calendar_refused",
+                message=f"The calendar server answered {error.status}. The username or "
+                "the app password is most likely wrong or revoked.",
+            )
+        if error.status is not None:
+            # The server answered, just not with a free-busy report - a 404 is usually
+            # a URL that is not a calendar collection, a 500 is the server's own day.
+            return envelope_response(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                code="calendar_unreachable",
+                message=f"The server answered {error.status} instead of a free-busy "
+                "report. Check that the URL points at a calendar collection.",
+            )
+        return envelope_response(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            code="calendar_unreachable",
+            message="Nothing answered at that address. Check the URL, and that this "
+            "machine can reach the calendar server.",
+        )
+
+    return CalendarTested(reached=True, source=url)

--- a/locales/ar/settings.json
+++ b/locales/ar/settings.json
@@ -428,5 +428,11 @@
   "wev_conversation_ended": "انتهت محادثة",
   "wev_conversation_started": "بدأت محادثة",
   "wev_knowledge_changed": "تغيّر مصدر معرفة",
-  "wev_message_received": "وصلت رسالة"
+  "wev_message_received": "وصلت رسالة",
+  "calendar_test": "اختبار التقويم",
+  "calendar_testing": "جارٍ سؤال التقويم…",
+  "calendar_test_reached": "أجاب التقويم.",
+  "calendar_test_not_configured": "لا يوجد تقويم متصل بعد. املأ عنوان CalDAV وكلمة مرور التطبيق أعلاه ثم احفظ.",
+  "calendar_test_refused": "رفض التقويم تسجيل الدخول.",
+  "calendar_test_unreachable": "تعذّرت قراءة التقويم."
 }

--- a/locales/de/settings.json
+++ b/locales/de/settings.json
@@ -428,5 +428,11 @@
   "wev_conversation_ended": "Ein Gespräch ist beendet",
   "wev_conversation_started": "Ein Gespräch hat begonnen",
   "wev_knowledge_changed": "Eine Wissensquelle wurde geändert",
-  "wev_message_received": "Eine Nachricht ist eingegangen"
+  "wev_message_received": "Eine Nachricht ist eingegangen",
+  "calendar_test": "Kalender testen",
+  "calendar_testing": "Kalender wird gefragt…",
+  "calendar_test_reached": "Der Kalender hat geantwortet.",
+  "calendar_test_not_configured": "Noch kein Kalender verbunden. Oben die CalDAV-Adresse und das App-Passwort eintragen, dann speichern.",
+  "calendar_test_refused": "Der Kalender hat die Anmeldung abgelehnt.",
+  "calendar_test_unreachable": "Der Kalender konnte nicht gelesen werden."
 }

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -428,5 +428,11 @@
   "wev_conversation_ended": "A conversation ended",
   "wev_conversation_started": "A conversation started",
   "wev_knowledge_changed": "A knowledge source changed",
-  "wev_message_received": "A message arrived"
+  "wev_message_received": "A message arrived",
+  "calendar_test": "Test the calendar",
+  "calendar_testing": "Asking the calendar…",
+  "calendar_test_reached": "The calendar answered.",
+  "calendar_test_not_configured": "No calendar is connected yet. Fill in the CalDAV address and the app password above, then save.",
+  "calendar_test_refused": "The calendar refused the sign-in.",
+  "calendar_test_unreachable": "The calendar could not be read."
 }

--- a/tests/test_calendar_screen.py
+++ b/tests/test_calendar_screen.py
@@ -161,3 +161,44 @@ async def test_the_password_never_appears_in_the_answer(stage, monkeypatch) -> N
 async def test_the_window_is_capped_at_a_week(stage) -> None:
     answer = await stage.get("/api/calendar/availability?days=30")
     assert answer.status_code == 422
+
+
+# --- The settings screen's Test button --------------------------------------------
+
+
+async def test_the_calendar_test_says_not_configured_before_credentials(stage) -> None:
+    answer = await stage.post("/api/settings/calendar/test")
+    assert answer.status_code == 409
+    assert answer.json()["error"]["code"] == "calendar_not_configured"
+
+
+async def test_the_calendar_test_reaches_a_working_calendar(stage, monkeypatch) -> None:
+    await _connect(stage)
+    _caldav_stands_in(monkeypatch, lambda request: httpx.Response(200, text=_VFREEBUSY))
+
+    answer = await stage.post("/api/settings/calendar/test")
+    assert answer.status_code == 200
+    body = answer.json()
+    assert body["reached"] is True
+    assert body["source"] == "https://cal.test/dav/"
+
+
+async def test_the_calendar_test_reports_refused_credentials(stage, monkeypatch) -> None:
+    await _connect(stage)
+    _caldav_stands_in(monkeypatch, lambda request: httpx.Response(401))
+
+    answer = await stage.post("/api/settings/calendar/test")
+    assert answer.status_code == 502
+    assert answer.json()["error"]["code"] == "calendar_refused"
+
+
+async def test_the_calendar_test_reports_an_unanswering_server(stage, monkeypatch) -> None:
+    await _connect(stage)
+
+    def unreachable(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route to host")
+
+    _caldav_stands_in(monkeypatch, unreachable)
+    answer = await stage.post("/api/settings/calendar/test")
+    assert answer.status_code == 502
+    assert answer.json()["error"]["code"] == "calendar_unreachable"

--- a/web/app/[locale]/settings/settings.tsx
+++ b/web/app/[locale]/settings/settings.tsx
@@ -47,6 +47,7 @@ import {
   testWebhook,
   testWhatsAppChannel,
   whatsappChannel,
+  testCalendar,
   testModel,
   signOutEverywhereElse,
   tokenList,
@@ -461,6 +462,7 @@ export function Settings({ locale, t }: { locale: Locale; t: SettingsDictionary 
                         <div className="border-od-line bg-od-panel-deep-3 rounded-[10px] border">
                           <SectionHead title={t.calendar_title} note={t.calendar_note} />
                           <LiveSettings fields={calendarFields(t)} labels={liveLabels(t)} />
+                          <CalendarTestRow t={t} />
                         </div>
                       </div>
                     ) : null}
@@ -588,6 +590,74 @@ function ModelTestRow({ t }: { t: SettingsDictionary }) {
         className="border-od-stroke bg-od-raise-10 text-od-text-2 hover:bg-od-border-3 cursor-pointer rounded-md border p-[8px_14px] text-[13px] font-medium disabled:cursor-not-allowed disabled:opacity-50"
       >
         {busy ? t.model_testing : t.model_test}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * The calendar panel's proof: one free-busy day from the saved CalDAV credentials.
+ * Reachability, sign-in and "this URL is a calendar collection" in one probe; what
+ * the busy periods say does not matter here.
+ */
+function CalendarTestRow({ t }: { t: SettingsDictionary }) {
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<{ text: string; machine?: string; bad?: boolean } | null>(
+    null,
+  );
+
+  async function run() {
+    setBusy(true);
+    setResult(null);
+    try {
+      const outcome = await testCalendar();
+      setResult({ text: t.calendar_test_reached, machine: outcome.source });
+    } catch (thrown) {
+      if (thrown instanceof ApiError) {
+        if (thrown.code === "calendar_not_configured") {
+          setResult({ text: t.calendar_test_not_configured, bad: true });
+        } else if (thrown.code === "calendar_refused") {
+          setResult({ text: t.calendar_test_refused, machine: thrown.message, bad: true });
+        } else if (thrown.code === "calendar_unreachable") {
+          setResult({ text: t.calendar_test_unreachable, machine: thrown.message, bad: true });
+        } else {
+          setResult({ text: thrown.message, bad: true });
+        }
+      } else {
+        setResult({ text: thrown instanceof Error ? thrown.message : String(thrown), bad: true });
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-x-[18px] gap-y-3 border-t border-[color:var(--od-raise-6)] p-[14px_18px]">
+      <div
+        className="max-w-[60ch] text-[13px] text-pretty"
+        style={{ color: result?.bad ? "var(--od-red-text-6)" : "var(--od-muted-5)" }}
+      >
+        {result ? (
+          <>
+            {result.text}
+            {result.machine ? (
+              <>
+                {" "}
+                <span dir="ltr" className="mono ltr-data">
+                  {result.machine}
+                </span>
+              </>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={() => void run()}
+        className="border-od-stroke bg-od-raise-10 text-od-text-2 hover:bg-od-border-3 cursor-pointer rounded-md border p-[8px_14px] text-[13px] font-medium disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {busy ? t.calendar_testing : t.calendar_test}
       </button>
     </div>
   );

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -469,6 +469,12 @@ export function testModel(): Promise<{ reached: boolean; model: string; base_url
   return api("/api/settings/llm/test", { method: "POST" });
 }
 
+/** One free-busy day from the configured CalDAV calendar, to prove the saved
+ *  credentials reach it - the cheapest real question the provider can ask. */
+export function testCalendar(): Promise<{ reached: boolean; source: string }> {
+  return api("/api/settings/calendar/test", { method: "POST" });
+}
+
 // --- Members and workspaces ----------------------------------------------------
 
 export type MemberRole = "owner" | "admin" | "reception" | "viewer" | "invited";


### PR DESCRIPTION
## What

The model panel has *Test the model* (#116) and the mail panel sends itself a test (#81); the CalDAV credentials had no equivalent — the first probe of a wrong app password was a caller mid-conversation.

## How

- **`POST /api/settings/calendar/test`** asks the configured CalDAV source for one free-busy day — the cheapest real question, proving reachability, sign-in and "this URL is actually a calendar collection" at once. Refusals are the same three designed answers the availability endpoint (#154) distinguishes: `calendar_not_configured` (409), `calendar_refused` (502, wrong or revoked credentials, with the server's status), `calendar_unreachable` (502 — split further into "answered N instead of a free-busy report" and "nothing answered").
- A `CalendarTestRow` under the CalDAV fields on Settings → Integrations, mirroring `ModelTestRow` exactly; six strings each in en/de/ar.

## Proof

- `tests/test_calendar_screen.py`: the four endpoint outcomes on both dialects.
- **Used live:** all three outcomes rendered on the screen against the stand-in CalDAV (success shows the source address; 401 shows the refused sentence; empty settings show the not-configured sentence).