### PR TITLE
i18n(nl): translate widget.json

### DIFF
--- a/locales/nl/widget.json
+++ b/locales/nl/widget.json
@@ -1,0 +1,10 @@
+{
+  "title": "Chat",
+  "open": "Chat openen",
+  "close": "Chat sluiten",
+  "placeholder": "Typ een bericht",
+  "send": "Versturen",
+  "not_sent": "Dit bericht kon niet worden verzonden.",
+  "no_reply": "Nu geen antwoord.",
+  "cut_off": "Dat antwoord is afgekapt."
+}


### PR DESCRIPTION
## Summary
Adds Dutch (`nl`) translation for `locales/nl/widget.json` — one file only, per contributing rules and #41.

## File
- `locales/nl/widget.json` (8 strings)

## Notes
- Values only; keys unchanged
- No placeholders in this file
- Register matches English (direct / informal)
- Product UI term "Chat" kept as Chat

Closes nothing on its own — `nl` remains a community locale until complete. Part of #41.