### PR TITLE
Publish the Docker images on release - the pull half of Milestone 10

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,0 +1,71 @@
+# Publishes the two Docker images to GitHub Container Registry, so `docker compose up`
+# can *pull* an installation instead of building one - the half of Milestone 10 that
+# turns the download page's Docker entry into a real button.
+#
+# Triggered by publishing a version tag (the release-drafter's draft becoming real is
+# exactly that moment), and manually for a proving run - a manual run publishes images
+# tagged with the branch name, never `latest`, so trying the pipeline cannot impersonate
+# a release.
+#
+# No secrets beyond the workflow's own GITHUB_TOKEN. Note for the first publish:
+# GHCR creates new packages private - making `tel-agent-api` and `tel-agent-web`
+# public is a one-time click in the package settings.
+
+name: Release images
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: tel-agent-api
+            dockerfile: docker/api.Dockerfile
+          - image: tel-agent-web
+            dockerfile: docker/web.Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      # arm64 alongside amd64: a Raspberry-class box or an ARM VPS is a natural home
+      # for a self-hosted agent, and cross-building here is cheaper than asking every
+      # such user to build on the device.
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # Lowercase is a registry requirement, and the org name carries a capital.
+          images: ghcr.io/dpro-at/${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
+
+      - uses: docker/build-push-action@v6
+        with:
+          # The build context is the repository root, not the sub-package - web/
+          # imports locales/ one level up and the API image installs the package.
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max

--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ there are no default credentials. The API and its documentation are on
 http://localhost:8000/docs, and conversations live on the `tel-agent-data`
 volume (SQLite by default; a `postgres` profile is in `docker-compose.yml`).
 
+From the first tagged release on, the images are also published to GitHub
+Container Registry, so the build step can be skipped entirely:
+`docker compose -f docker-compose.release.yml up -d` — same layout, same
+volumes, interchangeable with the from-source file on one machine.
+
 Both ports are published on **loopback only**. Reaching the installation from
 other machines is a decision made in `.env` — the `TEL_AGENT_*` block there
 lists the three values to change and why the dashboard image is rebuilt for it.

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,0 +1,74 @@
+# Tel-Agent from the published images - install without building anything.
+#
+#   cp .env.example .env        # set ENCRYPTION_KEY (openssl rand -hex 32)
+#   docker compose -f docker-compose.release.yml up -d
+#
+# Same layout as docker-compose.yml (which builds from source), same volumes, same
+# profiles - the two files are interchangeable on one machine because the volume
+# names match. Pin a version with TEL_AGENT_VERSION=0.1.0 in .env; unset means the
+# newest release.
+#
+# **One honest limitation of the published web image:** the dashboard bakes the API's
+# public address in at build time (NEXT_PUBLIC_API_URL), so the published image serves
+# the standard case - browser and server on the same machine, API on
+# http://localhost:8000. Reaching the dashboard under another hostname needs the web
+# image rebuilt for it: use docker-compose.yml with TEL_AGENT_PUBLIC_API_URL set.
+
+services:
+  api:
+    image: ghcr.io/dpro-at/tel-agent-api:${TEL_AGENT_VERSION:-latest}
+    restart: unless-stopped
+    environment:
+      ENCRYPTION_KEY: "${ENCRYPTION_KEY:?set ENCRYPTION_KEY in .env - generate one with openssl rand -hex 32}"
+      ENVIRONMENT: ${TEL_AGENT_ENVIRONMENT:-production}
+      DATABASE_URL: ${TEL_AGENT_DATABASE_URL:-sqlite+aiosqlite:////data/tel-agent.db}
+      CORS_ORIGINS: ${TEL_AGENT_WEB_ORIGIN:-http://localhost:3000}
+      TRUSTED_HOSTS: ${TEL_AGENT_TRUSTED_HOSTS:-localhost,127.0.0.1}
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      SMTP_FROM: ${SMTP_FROM:-}
+    volumes:
+      - tel-agent-data:/data
+    ports:
+      - "${TEL_AGENT_API_LISTEN:-127.0.0.1:8000}:8000"
+
+  web:
+    image: ghcr.io/dpro-at/tel-agent-web:${TEL_AGENT_VERSION:-latest}
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+    ports:
+      - "${TEL_AGENT_WEB_LISTEN:-127.0.0.1:3000}:3000"
+
+  db:
+    image: postgres:17-alpine
+    profiles: ["postgres"]
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: telagent
+      POSTGRES_PASSWORD: ${TEL_AGENT_POSTGRES_PASSWORD:-}
+      POSTGRES_DB: telagent
+    volumes:
+      - tel-agent-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U telagent -d telagent"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  n8n:
+    image: n8nio/n8n:latest
+    profiles: ["automation"]
+    restart: unless-stopped
+    volumes:
+      - tel-agent-n8n:/home/node/.n8n
+    ports:
+      - "${TEL_AGENT_N8N_LISTEN:-127.0.0.1:5678}:5678"
+
+volumes:
+  tel-agent-data:
+  tel-agent-postgres:
+  tel-agent-n8n:


### PR DESCRIPTION
## What

`docker compose up -d --build` has worked since #142. What did not exist is an installation that skips the build — which is what the download page's Docker entry promises.

## How

- **`.github/workflows/release-images.yml`** — pushing a version tag (the release-drafter's draft becoming real is exactly that act) builds `tel-agent-api` and `tel-agent-web` for **amd64 + arm64** and publishes them to `ghcr.io/dpro-at/`, tagged `{version}`, `{major}.{minor}` and `latest`. No secrets beyond the workflow's own `GITHUB_TOKEN`. A `workflow_dispatch` run publishes branch-tagged images for proving the pipeline — it can never produce `latest`, so trying it cannot impersonate a release.
- **`docker-compose.release.yml`** — same layout, volumes and profiles as the from-source file (interchangeable on one machine), pulling the published images; `TEL_AGENT_VERSION` pins a version. It states the one honest limitation: the dashboard bakes `NEXT_PUBLIC_API_URL` at build time, so a non-localhost hostname still means building from source.
- A four-line README note under Quick start.

## After merging

1. A `workflow_dispatch` proving run (publishes `:main`-tagged images only).
2. GHCR creates the two packages **private** — making them public is a one-time click in each package's settings.
3. Publishing the drafted `v0.1.0` release then produces the first real `latest` — and the download page's Docker button can become real.

## Proof

Both files parse; the compose mirrors `docker-compose.yml` whose stack was proven live end-to-end in #142. The pipeline itself is proven by the post-merge dispatch run (it cannot be exercised from a fork context).