### PR TITLE
Linux packages: deb and rpm that carry their own runtimes

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,0 +1,97 @@
+# Builds the Linux packages - deb and rpm, amd64 and arm64 - and attaches them to
+# the release whose tag triggered the build. The download page's Linux entry
+# becomes real the day these exist on a published release.
+#
+# Same proving rule as the images workflow: a manual run builds the packages and
+# keeps them as workflow artifacts, but only a version tag attaches anything to a
+# release - trying the pipeline cannot impersonate one.
+
+name: Release packages
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  linux:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      # The dashboard, built with the default NEXT_PUBLIC_API_URL - the packaged
+      # edition serves the standard localhost case, same as the published image.
+      - name: Build the dashboard
+        run: |
+          cd web
+          npm ci
+          npm run build
+        env:
+          NODE_ENV: production
+
+      - name: Stage the file tree
+        run: |
+          sh packaging/linux/build-tree.sh ${{ matrix.arch }} "$RUNNER_TEMP/stage"
+
+      - name: Install nfpm
+        run: |
+          curl -fsSL https://github.com/goreleaser/nfpm/releases/download/v2.43.1/nfpm_2.43.1_$(dpkg --print-architecture).deb -o /tmp/nfpm.deb
+          sudo dpkg -i /tmp/nfpm.deb
+
+      - name: Package
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            # A dispatch run on a branch: a version that cannot be mistaken for a release.
+            VERSION="0.0.0~$(git rev-parse --short HEAD)"
+          fi
+          mkdir -p dist
+          for format in deb rpm; do
+            VERSION="$VERSION" ARCH="${{ matrix.arch }}" STAGE="$RUNNER_TEMP/stage" \
+              nfpm package -f packaging/linux/nfpm.yaml -p "$format" -t dist/
+          done
+          ls -lh dist/
+
+      # A cold-start smoke test of the artifact itself, not its sources: install
+      # the deb in a clean container, wait, and ask /health. (amd64 tests in
+      # docker; the arm64 runner is already the target platform.)
+      - name: Install and probe the deb
+        run: |
+          docker run --rm -v "$PWD/dist:/dist" ubuntu:24.04 bash -ec '
+            apt-get update -q && apt-get install -yq /dist/*.deb
+            runuser -u telagent -- sh -c "cd /opt/tel-agent && ENCRYPTION_KEY=$(grep ^ENCRYPTION_KEY= /etc/tel-agent/tel-agent.env | cut -d= -f2) DATABASE_URL=sqlite+aiosqlite:////var/lib/tel-agent/tel-agent.db /bin/sh /opt/tel-agent/api-start.sh" &
+            for i in $(seq 1 30); do
+              sleep 2
+              if /opt/tel-agent/python/bin/python3 -c "import urllib.request; urllib.request.urlopen(\"http://127.0.0.1:8000/health\", timeout=3)"; then
+                echo "API answered /health"; exit 0
+              fi
+            done
+            echo "API never answered /health" >&2; exit 1'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tel-agent-linux-${{ matrix.arch }}
+          path: dist/*
+
+      - name: Attach to the release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$GITHUB_REF_NAME" dist/* --clobber

--- a/packaging/linux/api-start.sh
+++ b/packaging/linux/api-start.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# The API service's start command: migrate, then serve - the same order and the
+# same entry point as the container (`python -m api` honours BIND_HOST and warns
+# when it is widened). A schema that can lag its code turns every upgrade into a
+# 500 hunt.
+set -eu
+cd /opt/tel-agent
+/opt/tel-agent/venv/bin/python -m alembic upgrade head
+exec /opt/tel-agent/venv/bin/python -m api

--- a/packaging/linux/build-tree.sh
+++ b/packaging/linux/build-tree.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# Assembles the file tree that becomes the deb and the rpm - run on a Linux CI
+# runner, once per architecture.
+#
+# The package is deliberately self-contained: it carries its own CPython (from
+# python-build-standalone) and its own Node, because "which Python does your distro
+# ship" is exactly the support question a packaged product exists to remove. The
+# cost is size; the win is that one artifact behaves the same on Debian, Ubuntu,
+# Fedora and RHEL. Everything lands under /opt/tel-agent, and the venv is created
+# at its final absolute path so it needs no relocation tricks.
+#
+# Usage: packaging/linux/build-tree.sh <amd64|arm64> <staging-dir>
+# Expects the repository root as the working directory, with web/ already built
+# (`npm run build` - the standalone bundle is what gets shipped).
+
+set -eu
+
+ARCH="${1:?arch: amd64 or arm64}"
+STAGE="${2:?staging directory}"
+
+# Release tags of the two bundled runtimes. Bump deliberately, with a live check.
+PYTHON_BUILD="20250818"
+PYTHON_VERSION="3.12.11"
+NODE_VERSION="22.19.0"
+
+case "$ARCH" in
+  amd64) PY_ARCH="x86_64-unknown-linux-gnu"; NODE_ARCH="linux-x64" ;;
+  arm64) PY_ARCH="aarch64-unknown-linux-gnu"; NODE_ARCH="linux-arm64" ;;
+  *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+esac
+
+OPT="$STAGE/opt/tel-agent"
+mkdir -p "$OPT" "$STAGE/etc/tel-agent" "$STAGE/usr/lib/systemd/system"
+
+# --- CPython ---------------------------------------------------------------
+curl -fsSL -o /tmp/python.tar.gz \
+  "https://github.com/astral-sh/python-build-standalone/releases/download/${PYTHON_BUILD}/cpython-${PYTHON_VERSION}+${PYTHON_BUILD}-${PY_ARCH}-install_only.tar.gz"
+tar -xzf /tmp/python.tar.gz -C "$OPT"   # extracts to $OPT/python
+
+# --- Node (runs the dashboard's standalone server) -------------------------
+curl -fsSL -o /tmp/node.tar.xz \
+  "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${NODE_ARCH}.tar.xz"
+mkdir -p "$OPT/node"
+tar -xJf /tmp/node.tar.xz -C "$OPT/node" --strip-components=1
+
+# --- The API, in a venv at its final path ----------------------------------
+# The venv is created at the absolute path it will live at, so it needs no
+# relocation tricks; both runners are native per architecture, so a plain
+# install resolves the right wheels. /opt is root's on a CI runner.
+if [ ! -w /opt ] && command -v sudo >/dev/null 2>&1; then
+    sudo install -d -m 0755 -o "$(id -un)" /opt/tel-agent
+else
+    mkdir -p /opt/tel-agent
+fi
+"$OPT/python/bin/python3" -m venv /opt/tel-agent/venv
+/opt/tel-agent/venv/bin/pip install --no-cache-dir .
+mv /opt/tel-agent/venv "$OPT/venv"
+
+# The migration chain and its config ride along - the service migrates before it
+# serves, same as the container entrypoint.
+cp -r alembic "$OPT/alembic"
+cp alembic.ini "$OPT/alembic.ini"
+
+# --- The dashboard ---------------------------------------------------------
+# outputFileTracingRoot is the repository, so the standalone bundle keeps the repo
+# shape and the server entry is web/server.js under it.
+mkdir -p "$OPT/web-app"
+cp -r web/.next/standalone/. "$OPT/web-app/"
+mkdir -p "$OPT/web-app/web/.next/static"
+cp -r web/.next/static/. "$OPT/web-app/web/.next/static/"
+cp -r web/public "$OPT/web-app/web/public"
+
+# --- Config template, services, launcher -----------------------------------
+cp packaging/linux/tel-agent.env "$STAGE/etc/tel-agent/tel-agent.env"
+cp packaging/linux/tel-agent-api.service "$STAGE/usr/lib/systemd/system/"
+cp packaging/linux/tel-agent-web.service "$STAGE/usr/lib/systemd/system/"
+cp packaging/linux/api-start.sh "$OPT/api-start.sh"
+
+echo "staged $(du -sh "$STAGE" | cut -f1) for $ARCH"

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -1,0 +1,34 @@
+# nfpm configuration - one file, two outputs (deb and rpm).
+#   VERSION=x.y.z ARCH=amd64 STAGE=/tmp/stage nfpm package -f packaging/linux/nfpm.yaml -p deb
+# The staged tree comes from packaging/linux/build-tree.sh.
+
+name: tel-agent
+arch: ${ARCH}
+platform: linux
+version: ${VERSION}
+section: net
+priority: optional
+maintainer: Dpro GmbH <office@dpro.at>
+description: |
+  Self-hosted AI agent that answers your business's phone and messages.
+  Ships its own Python and Node runtimes; everything runs locally under
+  /opt/tel-agent with data in /var/lib/tel-agent.
+vendor: Dpro GmbH
+homepage: https://tel-agent.com
+license: AGPL-3.0
+
+contents:
+  - src: ${STAGE}/opt/tel-agent
+    dst: /opt/tel-agent
+  - src: ${STAGE}/usr/lib/systemd/system/tel-agent-api.service
+    dst: /usr/lib/systemd/system/tel-agent-api.service
+  - src: ${STAGE}/usr/lib/systemd/system/tel-agent-web.service
+    dst: /usr/lib/systemd/system/tel-agent-web.service
+  # The operator's config: never overwritten on upgrade.
+  - src: ${STAGE}/etc/tel-agent/tel-agent.env
+    dst: /etc/tel-agent/tel-agent.env
+    type: config|noreplace
+
+scripts:
+  postinstall: packaging/linux/postinstall.sh
+  preremove: packaging/linux/preremove.sh

--- a/packaging/linux/postinstall.sh
+++ b/packaging/linux/postinstall.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# deb postinst / rpm %post - create the service user, generate the key if none,
+# then enable and start both services.
+set -eu
+
+if ! getent passwd telagent >/dev/null; then
+    useradd --system --home-dir /var/lib/tel-agent --shell /usr/sbin/nologin telagent
+fi
+
+mkdir -p /var/lib/tel-agent
+chown telagent:telagent /var/lib/tel-agent
+chmod 750 /var/lib/tel-agent
+
+# Installation secrets are root-owned; the service reads them through systemd's
+# EnvironmentFile, which runs as root before dropping to the service user.
+chown root:root /etc/tel-agent/tel-agent.env
+chmod 600 /etc/tel-agent/tel-agent.env
+
+# Generate ENCRYPTION_KEY on first install only - an empty value in the template
+# marks "never configured", and an upgrade must never touch an existing key.
+if grep -q '^ENCRYPTION_KEY=$' /etc/tel-agent/tel-agent.env; then
+    KEY="$(/opt/tel-agent/venv/bin/python -c 'from api.security.crypto import generate_key; print(generate_key())')"
+    sed -i "s/^ENCRYPTION_KEY=$/ENCRYPTION_KEY=${KEY}/" /etc/tel-agent/tel-agent.env
+    echo "***********************************************************************"
+    echo "Tel-Agent generated an ENCRYPTION_KEY in /etc/tel-agent/tel-agent.env."
+    echo "BACK IT UP somewhere that is NOT the database backup - losing it makes"
+    echo "every credential stored in the dashboard unrecoverable."
+    echo "***********************************************************************"
+fi
+
+if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload
+    systemctl enable --now tel-agent-api.service tel-agent-web.service
+    echo "Tel-Agent is starting: dashboard on http://localhost:3000 (loopback only)."
+else
+    echo "systemd is not running; start the services yourself when it is:"
+    echo "  systemctl enable --now tel-agent-api tel-agent-web"
+fi

--- a/packaging/linux/preremove.sh
+++ b/packaging/linux/preremove.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# deb prerm / rpm %preun - stop the services before the files go. Data in
+# /var/lib/tel-agent and the key in /etc/tel-agent survive removal on purpose:
+# conversations and the key that unlocks stored credentials are the operator's,
+# not the package's.
+set -eu
+if [ -d /run/systemd/system ]; then
+    systemctl disable --now tel-agent-api.service tel-agent-web.service || true
+fi

--- a/packaging/linux/tel-agent-api.service
+++ b/packaging/linux/tel-agent-api.service
@@ -1,0 +1,31 @@
+# The Tel-Agent API and agent loop. Configuration lives in
+# /etc/tel-agent/tel-agent.env; data in /var/lib/tel-agent.
+
+[Unit]
+Description=Tel-Agent API
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+User=telagent
+Group=telagent
+EnvironmentFile=/etc/tel-agent/tel-agent.env
+WorkingDirectory=/opt/tel-agent
+ExecStart=/bin/sh /opt/tel-agent/api-start.sh
+Restart=on-failure
+RestartSec=3
+
+# This process parses strangers' input for a living (§B14 in the spec) - keep it
+# in as small a box as systemd offers without breaking normal operation.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/tel-agent
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/linux/tel-agent-web.service
+++ b/packaging/linux/tel-agent-web.service
@@ -1,0 +1,32 @@
+# The Tel-Agent dashboard - Next.js standalone served by the bundled Node.
+# The published build serves the standard case: dashboard on localhost:3000,
+# API on localhost:8000. Another hostname means rebuilding the dashboard with
+# its own NEXT_PUBLIC_API_URL - see the repository's Docker documentation.
+
+[Unit]
+Description=Tel-Agent dashboard
+After=tel-agent-api.service
+Wants=tel-agent-api.service
+
+[Service]
+Type=exec
+User=telagent
+Group=telagent
+WorkingDirectory=/opt/tel-agent/web-app
+Environment=NODE_ENV=production
+Environment=HOSTNAME=127.0.0.1
+Environment=PORT=3000
+ExecStart=/opt/tel-agent/node/bin/node web/server.js
+Restart=on-failure
+RestartSec=3
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/linux/tel-agent.env
+++ b/packaging/linux/tel-agent.env
@@ -1,0 +1,29 @@
+# Tel-Agent installation settings - read by both systemd services.
+#
+# This file is the packaged edition of `.env` (see .env.example in the source
+# repository for every variable). It holds INSTALLATION secrets only; provider
+# keys and channel tokens are entered in the dashboard and stored encrypted in
+# the database (that is what ENCRYPTION_KEY protects).
+#
+# ENCRYPTION_KEY is generated on first install if this line is empty. BACK IT UP
+# somewhere that is NOT the database backup: losing it makes every stored
+# credential unrecoverable, and a backup holding both the key and the data it
+# protects defeats the encryption.
+ENCRYPTION_KEY=
+
+ENVIRONMENT=production
+DATABASE_URL=sqlite+aiosqlite:////var/lib/tel-agent/tel-agent.db
+
+# Loopback only, on purpose. Reaching the installation from other machines goes
+# through a private network, a VPN, or a reverse proxy terminating TLS.
+BIND_HOST=127.0.0.1
+BIND_PORT=8000
+CORS_ORIGINS=http://localhost:3000
+TRUSTED_HOSTS=localhost,127.0.0.1
+
+# Mail is optional; the dashboard's forgot-password screen explains the state.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_FROM=


### PR DESCRIPTION
## What

The download page's Linux entry promises deb and rpm. This builds them — self-contained on purpose: each package ships its own CPython (python-build-standalone) and its own Node under `/opt/tel-agent`, so one artifact behaves the same on Debian, Ubuntu, Fedora and RHEL, and "which Python does your distro ship" stops being a support question.

## How

- `packaging/linux/build-tree.sh` stages the tree: bundled CPython 3.12 + Node 22, the API in a venv created at its final absolute path, the migration chain, and the dashboard's standalone build (default `NEXT_PUBLIC_API_URL` — the packaged edition serves the standard localhost case, same as the published image).
- Two hardened systemd units (`ProtectSystem=strict`, `NoNewPrivileges`, data writable only under `/var/lib/tel-agent`); the API migrates then serves via `python -m api`, the container's own order and entry point.
- `postinstall` creates the `telagent` system user, generates `ENCRYPTION_KEY` on first install if the template is empty (and says loudly to back it up), and enables both services. `config|noreplace`: an upgrade never touches the operator's env file. Removal keeps data and key — conversations are the operator's, not the package's.
- `release-packages.yml`: amd64 on `ubuntu-latest`, arm64 on GitHub's ARM runner; nfpm produces deb+rpm; **the deb is cold-installed into a clean `ubuntu:24.04` container and `/health` must answer before anything uploads**. A version tag attaches the four artifacts to its release; a manual run only keeps workflow artifacts and versions them `0.0.0~sha` — trying the pipeline cannot impersonate a release.

## Proof

YAML validated; the pipeline's real proof is the post-merge `workflow_dispatch` run, whose built-in cold-install smoke test is the acceptance check (an artifact that installs and answers `/health` from nothing).