### PR TITLE
Do not set NODE_ENV=production over npm ci in the packages workflow

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -37,13 +37,14 @@ jobs:
 
       # The dashboard, built with the default NEXT_PUBLIC_API_URL - the packaged
       # edition serves the standard localhost case, same as the published image.
+      # No NODE_ENV=production on this step: it would make `npm ci` skip the
+      # devDependencies the build itself needs (Tailwind's postcss plugin was the
+      # one that failed). `next build` sets production mode on its own.
       - name: Build the dashboard
         run: |
           cd web
           npm ci
           npm run build
-        env:
-          NODE_ENV: production
 
       - name: Stage the file tree
         run: |


### PR DESCRIPTION
The proving run of #179 failed at `npm run build`: `Cannot find module '@tailwindcss/postcss'` — `NODE_ENV=production` on the whole step made `npm ci` skip the devDependencies the build itself needs. `next build` sets production mode on its own, and `web.Dockerfile` already had this order right (env set only after `npm ci`). One step-level env block removed, with the comment that stops it coming back.