### PR TITLE
web/public is optional: guarantee it in the image, skip it in the package

### DIFF
--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -19,6 +19,10 @@ RUN cd web && npm ci
 
 COPY locales/ locales/
 COPY web/ web/
+# web/public does not exist in the repository today (assets ride the CDN), and a
+# COPY of a missing directory fails the build. Guaranteed here so the runtime
+# stage can copy it unconditionally; Next serves an empty one happily.
+RUN mkdir -p web/public
 
 ARG NEXT_PUBLIC_API_URL=http://localhost:8000
 ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL} \

--- a/packaging/linux/build-tree.sh
+++ b/packaging/linux/build-tree.sh
@@ -68,7 +68,11 @@ mkdir -p "$OPT/web-app"
 cp -r web/.next/standalone/. "$OPT/web-app/"
 mkdir -p "$OPT/web-app/web/.next/static"
 cp -r web/.next/static/. "$OPT/web-app/web/.next/static/"
-cp -r web/public "$OPT/web-app/web/public"
+# web/public does not exist in this repository today (assets ride the CDN); Next
+# serves fine without it, so it is copied only if it ever appears.
+if [ -d web/public ]; then
+    cp -r web/public "$OPT/web-app/web/public"
+fi
 
 # --- Config template, services, launcher -----------------------------------
 cp packaging/linux/tel-agent.env "$STAGE/etc/tel-agent/tel-agent.env"


### PR DESCRIPTION
## What

The repository has no `web/public` (assets ride the CDN), and **both** release pipelines tripped on it:

- the web image's `COPY --from=build /repo/web/public` failed the images proving run — a failure first misread as success because `gh run watch | tail` swallows the exit status (the same trap the handover documents for pytest). `tel-agent-api:main` is on GHCR; `tel-agent-web` never published.
- the Linux staging script hit the same missing directory one step later (right after #195's fix let it get that far).

## How

- `docker/web.Dockerfile`: `RUN mkdir -p web/public` in the build stage, so the runtime-stage COPY is unconditional. Next serves an empty public directory happily.
- `packaging/linux/build-tree.sh`: copy `web/public` only if it ever appears.

## Proof

Post-merge proving runs of **both** workflows, checked by per-job conclusion (`gh run view --json conclusion,jobs`), never by a piped watch.