### PR TITLE
Resolve nfpm's config with envsubst - it does not expand env vars in paths

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -63,10 +63,14 @@ jobs:
             # A dispatch run on a branch: a version that cannot be mistaken for a release.
             VERSION="0.0.0~$(git rev-parse --short HEAD)"
           fi
+          # nfpm does not expand env vars in `contents` paths, so the config is
+          # resolved with envsubst first and nfpm reads the concrete file.
+          export VERSION ARCH="${{ matrix.arch }}" STAGE="$RUNNER_TEMP/stage"
+          envsubst '$VERSION $ARCH $STAGE' \
+            < packaging/linux/nfpm.yaml > "$RUNNER_TEMP/nfpm.resolved.yaml"
           mkdir -p dist
           for format in deb rpm; do
-            VERSION="$VERSION" ARCH="${{ matrix.arch }}" STAGE="$RUNNER_TEMP/stage" \
-              nfpm package -f packaging/linux/nfpm.yaml -p "$format" -t dist/
+            nfpm package -f "$RUNNER_TEMP/nfpm.resolved.yaml" -p "$format" -t dist/
           done
           ls -lh dist/
 


### PR DESCRIPTION
The packages proving run failed with the literal `${STAGE}/opt/tel-agent: no matching files` — nfpm does not expand environment variables inside `contents` paths. The workflow now resolves the config with `envsubst` (restricted to `VERSION`, `ARCH`, `STAGE`) and hands nfpm the concrete file; script paths stay relative to the unchanged working directory. Proof is the next `workflow_dispatch` run, judged by per-job conclusions.