### PR TITLE
Ship the API in the bundled Python itself - a venv cannot be staged

### DIFF
--- a/packaging/linux/api-start.sh
+++ b/packaging/linux/api-start.sh
@@ -2,8 +2,9 @@
 # The API service's start command: migrate, then serve - the same order and the
 # same entry point as the container (`python -m api` honours BIND_HOST and warns
 # when it is widened). A schema that can lag its code turns every upgrade into a
-# 500 hunt.
+# 500 hunt. The bundled interpreter is used by module, never via installed
+# script shebangs - those bake in build-time paths.
 set -eu
 cd /opt/tel-agent
-/opt/tel-agent/venv/bin/python -m alembic upgrade head
-exec /opt/tel-agent/venv/bin/python -m api
+/opt/tel-agent/python/bin/python3 -m alembic upgrade head
+exec /opt/tel-agent/python/bin/python3 -m api

--- a/packaging/linux/build-tree.sh
+++ b/packaging/linux/build-tree.sh
@@ -35,7 +35,7 @@ mkdir -p "$OPT" "$STAGE/etc/tel-agent" "$STAGE/usr/lib/systemd/system"
 # --- CPython ---------------------------------------------------------------
 curl -fsSL -o /tmp/python.tar.gz \
   "https://github.com/astral-sh/python-build-standalone/releases/download/${PYTHON_BUILD}/cpython-${PYTHON_VERSION}+${PYTHON_BUILD}-${PY_ARCH}-install_only.tar.gz"
-tar -xzf /tmp/python.tar.gz -C "$OPT"   # extracts to $OPT/python
+tar -xzf /tmp/python.tar.gz -C "$OPT"   # the tarball's top level is python/
 
 # --- Node (runs the dashboard's standalone server) -------------------------
 curl -fsSL -o /tmp/node.tar.xz \
@@ -43,18 +43,15 @@ curl -fsSL -o /tmp/node.tar.xz \
 mkdir -p "$OPT/node"
 tar -xJf /tmp/node.tar.xz -C "$OPT/node" --strip-components=1
 
-# --- The API, in a venv at its final path ----------------------------------
-# The venv is created at the absolute path it will live at, so it needs no
-# relocation tricks; both runners are native per architecture, so a plain
-# install resolves the right wheels. /opt is root's on a CI runner.
-if [ ! -w /opt ] && command -v sudo >/dev/null 2>&1; then
-    sudo install -d -m 0755 -o "$(id -un)" /opt/tel-agent
-else
-    mkdir -p /opt/tel-agent
-fi
-"$OPT/python/bin/python3" -m venv /opt/tel-agent/venv
-/opt/tel-agent/venv/bin/pip install --no-cache-dir .
-mv /opt/tel-agent/venv "$OPT/venv"
+# --- The API, straight into the bundled Python -----------------------------
+# No venv, deliberately. A venv's symlinks and shebangs embed the absolute path
+# of the interpreter that created it - built in a staging directory, they ship
+# pointing at a runner path that exists on no target machine (the first proving
+# run's exact failure). The bundled CPython is wholly ours, so its own
+# site-packages IS the isolated environment; installing there leaves no
+# symlinks and no baked-in paths to get wrong.
+"$OPT/python/bin/python3" -m ensurepip --upgrade >/dev/null 2>&1 || true
+"$OPT/python/bin/python3" -m pip install --no-cache-dir .
 
 # The migration chain and its config ride along - the service migrates before it
 # serves, same as the container entrypoint.

--- a/packaging/linux/postinstall.sh
+++ b/packaging/linux/postinstall.sh
@@ -19,7 +19,7 @@ chmod 600 /etc/tel-agent/tel-agent.env
 # Generate ENCRYPTION_KEY on first install only - an empty value in the template
 # marks "never configured", and an upgrade must never touch an existing key.
 if grep -q '^ENCRYPTION_KEY=$' /etc/tel-agent/tel-agent.env; then
-    KEY="$(/opt/tel-agent/venv/bin/python -c 'from api.security.crypto import generate_key; print(generate_key())')"
+    KEY="$(/opt/tel-agent/python/bin/python3 -c 'from api.security.crypto import generate_key; print(generate_key())')"
     sed -i "s/^ENCRYPTION_KEY=$/ENCRYPTION_KEY=${KEY}/" /etc/tel-agent/tel-agent.env
     echo "***********************************************************************"
     echo "Tel-Agent generated an ENCRYPTION_KEY in /etc/tel-agent/tel-agent.env."


### PR DESCRIPTION
## What

The second packages proving run got further (envsubst fix #203 held) and failed in the cold-install smoke test: `/opt/tel-agent/venv/bin/python: not found`, exit 127 in postinst.

## Why

`python -m venv` embeds the creating interpreter's **absolute path** in the venv's symlinks and shebangs. A venv built inside `$RUNNER_TEMP/stage` ships links to a runner path that exists on no target machine.

## How

No venv at all. The bundled CPython is wholly ours, so its own site-packages **is** the isolated environment: `pip install .` straight into it, and everything runs by module (`python -m alembic`, `python -m api`, `python -c`) — never via installed script shebangs, which bake in build-time paths. No symlinks, no baked paths, nothing to relocate — and the smoke test exists precisely to prove that from a clean container.

## Proof

The post-merge `workflow_dispatch` run, judged by per-job conclusions.