### PR TITLE
Fix package discovery, and ship the source tree in the Linux package

### DIFF
--- a/packaging/linux/build-tree.sh
+++ b/packaging/linux/build-tree.sh
@@ -56,8 +56,13 @@ fi
 /opt/tel-agent/venv/bin/pip install --no-cache-dir .
 mv /opt/tel-agent/venv "$OPT/venv"
 
-# The migration chain and its config ride along - the service migrates before it
-# serves, same as the container entrypoint.
+# The source tree rides along, exactly as in the container (/app): the services
+# run with /opt/tel-agent as their working directory, so `api`, `agent` and the
+# `locales/` the widget reads resolve from here - the same layout the container
+# was proven on. The migration chain and its config come for the same reason.
+cp -r api "$OPT/api"
+cp -r agent "$OPT/agent"
+cp -r locales "$OPT/locales"
 cp -r alembic "$OPT/alembic"
 cp alembic.ini "$OPT/alembic.ini"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,15 @@ Source = "https://github.com/Dpro-at/Tel-Agent"
 requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["agent", "api"]
+# find, not a hand-written list: an explicit `packages = ["agent", "api"]` names the
+# two TOP-LEVEL packages only, so every subpackage (api.security, api.routes,
+# agent.providers, ...) was silently missing from the wheel. Nothing noticed for
+# months because the container and the test suite both run from the repository
+# root, where the source tree on sys.path shadows the broken install - the Linux
+# package's cold-install smoke test was the first environment honest enough to
+# import from site-packages alone.
+[tool.setuptools.packages.find]
+include = ["agent*", "api*"]
 
 # --- Ruff --------------------------------------------------------------------
 # Formatting and linting live here rather than in a separate file, so there is one


### PR DESCRIPTION
## What

The third packages proving run's cold install failed with `ModuleNotFoundError: No module named 'api.security'`.

## Root cause — a real product bug, found by the smoke test

`pyproject.toml` declared `packages = ["agent", "api"]` — an explicit list names the two **top-level** packages only, so every subpackage (`api.security`, `api.routes`, `agent.providers`, …) was silently missing from the wheel. Nothing noticed for months because the container and the test suite both run from the repository root, where the source tree on `sys.path` shadows the broken install. The Linux package's cold-install check was the first environment honest enough to import from site-packages alone — which is exactly why it exists.

## How

1. `[tool.setuptools.packages.find]` with `include = ["agent*", "api*"]` — the wheel is complete.
2. The package ships `api/`, `agent/` and `locales/` beside `alembic/` under `/opt/tel-agent`, with the services' working directory there — the same layout the container was proven on, so the widget's `locales/` resolve too.

## Proof

Post-merge `workflow_dispatch` run of `release-packages.yml`, judged by per-job conclusions.