### PR TITLE
feat(packaging): add unsigned macOS installer

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -40,6 +40,7 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           [ "$GITHUB_REF_TYPE" = tag ] || VERSION="0.0.0-$(git rev-parse --short HEAD)"
           sh packaging/macos/build-tree.sh ${{ matrix.arch }} "$RUNNER_TEMP/tel-agent-macos"
+          mkdir -p dist
           pkgbuild --root "$RUNNER_TEMP/tel-agent-macos/root" --scripts "$RUNNER_TEMP/tel-agent-macos/scripts" --identifier at.dpro.tel-agent --version "$VERSION" --install-location / "dist/Tel-Agent-$VERSION-macos-${{ matrix.arch }}-unsigned.pkg"
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -17,6 +17,40 @@ permissions:
   contents: write
 
 jobs:
+  macos:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: macos-13
+          - arch: arm64
+            runner: macos-14
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Build the dashboard
+        run: cd web && npm ci && npm run build
+      - name: Build the unsigned package
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          [ "$GITHUB_REF_TYPE" = tag ] || VERSION="0.0.0-$(git rev-parse --short HEAD)"
+          sh packaging/macos/build-tree.sh ${{ matrix.arch }} "$RUNNER_TEMP/tel-agent-macos"
+          pkgbuild --root "$RUNNER_TEMP/tel-agent-macos/root" --scripts "$RUNNER_TEMP/tel-agent-macos/scripts" --identifier at.dpro.tel-agent --version "$VERSION" --install-location / "dist/Tel-Agent-$VERSION-macos-${{ matrix.arch }}-unsigned.pkg"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tel-agent-macos-${{ matrix.arch }}
+          path: dist/*.pkg
+      - name: Attach to the release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$GITHUB_REF_NAME" dist/*.pkg --clobber
+
   windows:
     runs-on: windows-latest
     steps:

--- a/packaging/macos/api-start.sh
+++ b/packaging/macos/api-start.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+cd /Library/Tel-Agent
+if grep -q '^ENCRYPTION_KEY=$' .env; then
+  KEY="$(python/bin/python3 -c 'from api.security.crypto import generate_key; print(generate_key())')"
+  sed -i '' "s/^ENCRYPTION_KEY=$/ENCRYPTION_KEY=${KEY}/" .env
+fi
+python/bin/python3 -m alembic upgrade head
+exec python/bin/python3 -m api

--- a/packaging/macos/build-tree.sh
+++ b/packaging/macos/build-tree.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Assemble a self-contained macOS payload for pkgbuild.
+set -eu
+
+ARCH="${1:?arm64 or amd64}"
+STAGE="${2:?staging directory}"
+PYTHON_BUILD="20250818"
+PYTHON_VERSION="3.12.11"
+NODE_VERSION="22.19.0"
+
+case "$ARCH" in
+  arm64) PY_ARCH="aarch64-apple-darwin"; NODE_ARCH="arm64" ;;
+  amd64) PY_ARCH="x86_64-apple-darwin"; NODE_ARCH="x64" ;;
+  *) echo "unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+APP="$STAGE/root/Library/Tel-Agent"
+mkdir -p "$APP" "$STAGE/scripts"
+curl -fsSL -o /tmp/tel-agent-python.tar.gz "https://github.com/astral-sh/python-build-standalone/releases/download/${PYTHON_BUILD}/cpython-${PYTHON_VERSION}+${PYTHON_BUILD}-${PY_ARCH}-install_only_stripped.tar.gz"
+tar -xzf /tmp/tel-agent-python.tar.gz -C "$APP"
+curl -fsSL -o /tmp/tel-agent-node.tar.gz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-darwin-${NODE_ARCH}.tar.gz"
+mkdir -p "$APP/node"
+tar -xzf /tmp/tel-agent-node.tar.gz -C "$APP/node" --strip-components=1
+
+"$APP/python/bin/python3" -m ensurepip --upgrade >/dev/null 2>&1 || true
+"$APP/python/bin/python3" -m pip install --no-cache-dir .
+cp -R api agent locales alembic "$APP/"
+cp alembic.ini "$APP/"
+cp packaging/macos/tel-agent.env "$APP/.env.template"
+cp packaging/macos/api-start.sh "$APP/"
+mkdir -p "$STAGE/root/Library/LaunchDaemons"
+cp packaging/macos/com.dpro.tel-agent.api.plist "$STAGE/root/Library/LaunchDaemons/"
+cp packaging/macos/com.dpro.tel-agent.web.plist "$STAGE/root/Library/LaunchDaemons/"
+mkdir -p "$APP/web-app/web/.next/static"
+cp -R web/.next/standalone/. "$APP/web-app/"
+cp -R web/.next/static/. "$APP/web-app/web/.next/static/"
+cp packaging/macos/postinstall "$STAGE/scripts/postinstall"
+cp packaging/macos/preinstall "$STAGE/scripts/preinstall"
+chmod 755 "$STAGE/scripts/"* "$APP/api-start.sh"

--- a/packaging/macos/com.dpro.tel-agent.api.plist
+++ b/packaging/macos/com.dpro.tel-agent.api.plist
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>Label</key><string>com.dpro.tel-agent.api</string><key>ProgramArguments</key><array><string>/Library/Tel-Agent/api-start.sh</string></array><key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>WorkingDirectory</key><string>/Library/Tel-Agent</string></dict></plist>

--- a/packaging/macos/com.dpro.tel-agent.web.plist
+++ b/packaging/macos/com.dpro.tel-agent.web.plist
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>Label</key><string>com.dpro.tel-agent.web</string><key>ProgramArguments</key><array><string>/Library/Tel-Agent/node/bin/node</string><string>web/server.js</string></array><key>EnvironmentVariables</key><dict><key>NODE_ENV</key><string>production</string><key>HOSTNAME</key><string>127.0.0.1</string><key>PORT</key><string>38471</string></dict><key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>WorkingDirectory</key><string>/Library/Tel-Agent/web-app</string></dict></plist>

--- a/packaging/macos/postinstall
+++ b/packaging/macos/postinstall
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+mkdir -p '/Library/Application Support/Tel-Agent'
+if [ ! -f /Library/Tel-Agent/.env ]; then cp /Library/Tel-Agent/.env.template /Library/Tel-Agent/.env; fi
+chmod 600 /Library/Tel-Agent/.env
+launchctl bootstrap system /Library/LaunchDaemons/com.dpro.tel-agent.api.plist
+launchctl bootstrap system /Library/LaunchDaemons/com.dpro.tel-agent.web.plist
+USER="$(stat -f%Su /dev/console)"
+if [ "$USER" != "root" ]; then sudo -u "$USER" open http://localhost:38471 || true; fi

--- a/packaging/macos/preinstall
+++ b/packaging/macos/preinstall
@@ -1,0 +1,3 @@
+#!/bin/sh
+launchctl bootout system/com.dpro.tel-agent.web 2>/dev/null || true
+launchctl bootout system/com.dpro.tel-agent.api 2>/dev/null || true

--- a/packaging/macos/tel-agent.env
+++ b/packaging/macos/tel-agent.env
@@ -1,0 +1,7 @@
+ENVIRONMENT=production
+DATABASE_URL=sqlite+aiosqlite:////Library/Application Support/Tel-Agent/tel-agent.db
+BIND_HOST=127.0.0.1
+BIND_PORT=38472
+CORS_ORIGINS=http://localhost:38471
+TRUSTED_HOSTS=localhost,127.0.0.1
+ENCRYPTION_KEY=


### PR DESCRIPTION
## Summary
- build unsigned macOS .pkg installers for Apple Silicon and Intel
- bundle Python, Node, API, and dashboard as local launch services
- preserve local configuration and data during installation
- validate package artifacts in the release workflow

## Verification
- bash syntax checks
- workflow run: https://github.com/Dpro-at/Tel-Agent/actions/runs/33972202623