### PR TITLE
fix(ci): use current macOS Intel runner

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: macos-13
+            runner: macos-15-intel
           - arch: arm64
             runner: macos-14
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
Agent: codex

## Summary
- replace the retired macos-13 Intel label with GitHub's current macos-15-intel label
- unblock the Intel macOS package verification

## Verification
- git diff --check
- package run: https://github.com/Dpro-at/Tel-Agent/actions/runs/33973992903