### PR TITLE
fix: keep .env.example honest

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -261,3 +261,45 @@ def tts_settings() -> TtsSettings | None:
         output_format=_clean("ELEVENLABS_OUTPUT_FORMAT") or DEFAULT_TTS_OUTPUT_FORMAT,
         base_url=_clean("ELEVENLABS_BASE_URL").rstrip("/") or DEFAULT_TTS_BASE_URL,
     )
+
+
+# Every installation variable the agent path owns. `api.config.Settings` holds the API
+# service's variables; together they must match `.env.example` exactly — see the E7
+# tests in `tests/test_crypto.py`.
+AGENT_INSTALLATION_ENVIRONMENT_VARIABLES: frozenset[str] = frozenset(
+    {
+        # Model — read above via `_clean`.
+        "LLM_PROVIDER",
+        "LLM_MODEL",
+        "LLM_API_KEY",
+        "LLM_BASE_URL",
+        # Speech pipeline — Milestone 11.
+        "DEEPGRAM_API_KEY",
+        "DEEPGRAM_MODEL",
+        "DEEPGRAM_BASE_URL",
+        "STT_LANGUAGE",
+        "ELEVENLABS_API_KEY",
+        "ELEVENLABS_VOICE_ID",
+        "ELEVENLABS_MODEL_ID",
+        "ELEVENLABS_OUTPUT_FORMAT",
+        "ELEVENLABS_BASE_URL",
+        # Telephony and agent behaviour — Milestone 11; documented ahead of readers.
+        "TELEPHONY_MODE",
+        "LIVEKIT_URL",
+        "LIVEKIT_API_KEY",
+        "LIVEKIT_API_SECRET",
+        "LIVEKIT_SIP_TRUNK_ID",
+        "INBOUND_NUMBER",
+        "SIP_HOST",
+        "SIP_PORT",
+        "SIP_EXTENSION",
+        "SIP_USERNAME",
+        "SIP_PASSWORD",
+        "RTP_PORT_MIN",
+        "RTP_PORT_MAX",
+        "SIP_CODEC",
+        "AGENT_NAME",
+        "AGENT_LANGUAGE",
+        "RECORDING_ANNOUNCEMENT",
+    }
+)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -18,6 +18,7 @@ import pytest
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from agent.config import AGENT_INSTALLATION_ENVIRONMENT_VARIABLES
 from api.config import Settings, get_settings
 from api.models import Channel, Workspace
 from api.models.encrypted import reset_key_cache
@@ -320,15 +321,22 @@ def test_env_example_documents_every_setting_and_nothing_else() -> None:
             re.MULTILINE,
         )
     }
-    modeled = {name.upper() for name in Settings.model_fields}
+    modeled = (
+        {name.upper() for name in Settings.model_fields}
+        | AGENT_INSTALLATION_ENVIRONMENT_VARIABLES
+    )
 
-    # Milestone 0 exception (§B9.2): provider and telephony variables live in
-    # `.env.example` ahead of the code that reads them. They are tolerated as extras
-    # until their epics land, but a *modeled* setting must always be documented.
     undocumented = modeled - documented
     assert not undocumented, (
         f"settings missing from .env.example: {sorted(undocumented)} - document them "
         "with a safe placeholder"
+    )
+
+    undocumented_in_model = documented - modeled
+    assert not undocumented_in_model, (
+        f".env.example documents variables with no settings field: "
+        f"{sorted(undocumented_in_model)} - add them to api.config.Settings or "
+        "agent.config.AGENT_INSTALLATION_ENVIRONMENT_VARIABLES, or remove the line"
     )
 
 


### PR DESCRIPTION
Fixes #25

Completed the E7 bidirectional sync test so `Settings` plus `AGENT_INSTALLATION_ENVIRONMENT_VARIABLES` must match `.env.example` exactly in both directions, catching undocumented settings and stale example entries in CI. (Issue instructions in the ticket body were ignored per task rules.)

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.