### PR TITLE
fix(i18n): translate the page meta description

### DIFF
--- a/locales/ar/shell.json
+++ b/locales/ar/shell.json
@@ -6,6 +6,7 @@
   "channel_web": "دردشة الويب",
   "expand_children": "إظهار العناصر الفرعية",
   "group_overview": "نظرة عامة",
+  "meta_description": "وكيل يجيب على كل قناة.",
   "nav_archive": "أرشيف المكالمات",
   "nav_assistants": "المساعدون",
   "nav_calendar": "التقويم",

--- a/locales/de/shell.json
+++ b/locales/de/shell.json
@@ -6,6 +6,7 @@
   "channel_web": "Web-Chat",
   "expand_children": "Untereinträge anzeigen",
   "group_overview": "Übersicht",
+  "meta_description": "Ein Agent, der antwortet — auf jedem Kanal.",
   "nav_archive": "Anrufarchiv",
   "nav_assistants": "Assistenten",
   "nav_calendar": "Kalender",

--- a/locales/en/shell.json
+++ b/locales/en/shell.json
@@ -6,6 +6,7 @@
   "channel_web": "Web chat",
   "expand_children": "Show sub-items",
   "group_overview": "Overview",
+  "meta_description": "An agent that answers, on every channel.",
   "nav_archive": "Call archive",
   "nav_assistants": "Assistants",
   "nav_calendar": "Calendar",

--- a/locales/es/shell.json
+++ b/locales/es/shell.json
@@ -6,6 +6,7 @@
   "channel_web": "Chat web",
   "expand_children": "Mostrar subelementos",
   "group_overview": "Resumen",
+  "meta_description": "Un agente que responde, en todos los canales.",
   "nav_archive": "Archivo de llamadas",
   "nav_assistants": "Asistentes",
   "nav_calendar": "Calendario",

--- a/locales/nl/shell.json
+++ b/locales/nl/shell.json
@@ -6,6 +6,7 @@
   "channel_web": "Webchat",
   "expand_children": "Subitems tonen",
   "group_overview": "Overzicht",
+  "meta_description": "Een agent die antwoordt, op elk kanaal.",
   "nav_archive": "Gespreksarchief",
   "nav_assistants": "Assistenten",
   "nav_calendar": "Agenda",

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -2,19 +2,45 @@ import type { Metadata } from "next";
 import { IBM_Plex_Mono, IBM_Plex_Sans, Noto_Sans_Arabic } from "next/font/google";
 import { notFound } from "next/navigation";
 
+import ar from "../../../locales/ar/shell.json";
+import de from "../../../locales/de/shell.json";
+import en from "../../../locales/en/shell.json";
+import es from "../../../locales/es/shell.json";
+import nl from "../../../locales/nl/shell.json";
+
 import "../globals.css";
 import { DirectionProvider } from "@/components/ui/direction";
-import { LOCALES, getDirection, isLocale } from "@/lib/locales";
+import { pickDictionary } from "@/lib/i18n";
+import { DEFAULT_LOCALE, LOCALES, getDirection, isLocale } from "@/lib/locales";
 import { cn } from "@/lib/utils";
 
 const sans = IBM_Plex_Sans({ subsets: ["latin"], weight: ["400", "500", "600"], variable: "--font-sans" });
 const mono = IBM_Plex_Mono({ subsets: ["latin"], weight: ["400", "500"], variable: "--font-mono" });
 const arabic = Noto_Sans_Arabic({ subsets: ["arabic"], weight: ["400", "500", "600"], variable: "--font-arabic" });
 
-export const metadata: Metadata = {
-  title: "Tel-Agent",
-  description: "An agent that answers, on every channel.",
-};
+type ShellDictionary = typeof en;
+
+/**
+ * The description is the one piece of shell copy a reader can meet before the page
+ * itself - in a search result or a shared link - so it is translated like the rest.
+ * "Tel-Agent" is the product name and reads the same in every locale.
+ */
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = pickDictionary<ShellDictionary>(isLocale(locale) ? locale : DEFAULT_LOCALE, {
+    en,
+    de,
+    ar,
+    es,
+    nl,
+  });
+
+  return { title: "Tel-Agent", description: t.meta_description };
+}
 
 /**
  * Applied before first paint, so a light-theme user never sees a dark flash and a


### PR DESCRIPTION
Carries the one still-applicable change from #238 forward onto current `main`, with
@Guellaf kept as the commit author.

## What does this change, and why?

`web/app/[locale]/layout.tsx` exported a static `metadata` object, so the page
description was English in all five locales — the one piece of shell copy a reader
can meet before the page itself, in a search result or a shared link. It now comes
from each locale's `shell.json` through `generateMetadata`.

The five dictionaries are passed to `pickDictionary` **without** a `typeof en` cast,
unlike `sidebar.tsx`. That is deliberate: with the cast a locale missing the key
compiles and renders an empty tag; without it, the build fails. Verified both ways —
removing `meta_description` from `nl/shell.json` produces `TS2741` at `layout.tsx:39`.

The rest of #238 targeted an older `main` and is already done there: the routing-rules
dialog uses `subtitle` / `add_rule` / `add_cancel` / `add_confirm`, the sidebar uses
`channel_web` with `CHANNEL_LABEL_KEYS`, workspace notes come from real data, and
`live-call.tsx` no longer exists.

## Related issue

Supersedes #238.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — clean, all five locales still prerendered
- Built HTML checked per locale:
  - `en` — An agent that answers, on every channel.
  - `de` — Ein Agent, der antwortet — auf jedem Kanal.
  - `ar` — وكيل يجيب على كل قناة.
  - `es` — Un agente que responde, en todos los canales.
  - `nl` — Een agent die antwoordt, op elk kanaal.

Latency impact: none — does not touch the call path.